### PR TITLE
Update variants base image [VS-866]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -224,6 +224,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - vs_866_update_variants_base_image
    - name: GvsQuickstartHailIntegration
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsQuickstartHailIntegration.wdl
@@ -231,6 +232,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - vs_866_update_variants_base_image
    - name: GvsQuickstartIntegration
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
@@ -239,6 +241,7 @@ workflows:
          - master
          - ah_var_store
          - vs_834_disentangle
+         - vs_866_update_variants_base_image
    - name: GvsIngestTieout
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsIngestTieout.wdl

--- a/scripts/variantstore/variant_annotations_table/GvsCreateVATFilesFromBigQuery.wdl
+++ b/scripts/variantstore/variant_annotations_table/GvsCreateVATFilesFromBigQuery.wdl
@@ -180,7 +180,7 @@ task BigQueryExportVat {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:413.0.0-alpine"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
         memory: "2 GB"
         preemptible: 3
         cpu: "1"
@@ -251,7 +251,7 @@ task MergeVatTSVs {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:413.0.0-slim"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-slim"
         memory: "4 GB"
         preemptible: 3
         cpu: "2"

--- a/scripts/variantstore/variant_annotations_table/GvsValidateVAT.wdl
+++ b/scripts/variantstore/variant_annotations_table/GvsValidateVAT.wdl
@@ -208,7 +208,7 @@ task EnsureVatTableHasVariants {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -271,7 +271,7 @@ task SpotCheckForExpectedTranscripts {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -349,7 +349,7 @@ task SchemaNoNullRequiredFields {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -405,7 +405,7 @@ task SchemaOnlyOneRowPerNullTranscript {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -459,7 +459,7 @@ task SchemaPrimaryKey {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -514,7 +514,7 @@ task SchemaEnsemblTranscripts {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -572,7 +572,7 @@ task SchemaNonzeroAcAn {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -623,7 +623,7 @@ task SchemaNullTranscriptsExist {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -682,7 +682,7 @@ task SubpopulationMax {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -735,7 +735,7 @@ task SubpopulationAlleleCount {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -788,7 +788,7 @@ task SubpopulationAlleleNumber {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -868,7 +868,7 @@ task ClinvarSignificance {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -960,7 +960,7 @@ task SchemaAAChangeAndExonNumberConsistent {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -1070,7 +1070,7 @@ task SpotCheckForAAChangeAndExonNumberConsistency {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:305.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsAssignIds.wdl
+++ b/scripts/variantstore/wdl/GvsAssignIds.wdl
@@ -146,7 +146,7 @@ task AssignIds {
     bq --project_id=~{project_id} rm -f -t ~{dataset_name}.sample_id_assignment_lock
   >>>
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
     memory: "3.75 GB"
     disks: "local-disk " + 10 + " HDD"
     cpu: 1
@@ -196,7 +196,7 @@ task CreateCostObservabilityTable {
     fi
   >>>
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
   }
   output {
     Boolean done = true

--- a/scripts/variantstore/wdl/GvsBenchmarkExtractTask.wdl
+++ b/scripts/variantstore/wdl/GvsBenchmarkExtractTask.wdl
@@ -206,7 +206,7 @@ task SumBytes {
   }
 
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     preemptible: 3
@@ -240,7 +240,7 @@ task CreateManifest {
     }
 
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0"
         memory: "3 GB"
         disks: "local-disk 10 HDD"
         preemptible: 3

--- a/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
+++ b/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
@@ -271,7 +271,7 @@ task Add_AS_MAX_VQS_FIELD_ToVcf {
     String output_basename
     Boolean use_classic_VQSR
 
-    String docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
+    String docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-03-27-alpine"
     Int cpu = 1
     Int memory_mb = 3500
     Int disk_size_gb = ceil(2*size(input_vcf, "GiB")) + 50

--- a/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
+++ b/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
@@ -271,7 +271,7 @@ task Add_AS_MAX_VQS_FIELD_ToVcf {
     String output_basename
     Boolean use_classic_VQSR
 
-    String docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-02-21-alpine"
+    String docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
     Int cpu = 1
     Int memory_mb = 3500
     Int disk_size_gb = ceil(2*size(input_vcf, "GiB")) + 50

--- a/scripts/variantstore/wdl/GvsCallsetCost.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetCost.wdl
@@ -62,7 +62,7 @@ task WorkflowComputeCosts {
     >>>
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-27-alpine"
     }
 
     output {

--- a/scripts/variantstore/wdl/GvsCallsetCost.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetCost.wdl
@@ -97,7 +97,7 @@ task CoreStorageModelSizes {
         get_billable_bytes_in_gib "alt_allele"   alt_allele_gib.txt
     >>>
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0"
     }
     output {
         Float vet_gib = read_float("vet_gib.txt")
@@ -125,7 +125,7 @@ task ReadCostObservabilityTable {
             > cost_observability.json
     >>>
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0"
     }
     output {
         File cost_observability = "cost_observability.json"

--- a/scripts/variantstore/wdl/GvsCallsetCost.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetCost.wdl
@@ -62,7 +62,7 @@ task WorkflowComputeCosts {
     >>>
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-01-23-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
     }
 
     output {

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -266,7 +266,7 @@ task CreateTables {
         fi
     >>>
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
         disks: "local-disk 500 HDD"
     }
     output {
@@ -400,7 +400,7 @@ task CollectMetricsForChromosome {
         Boolean done = true
     }
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
         disks: "local-disk 500 HDD"
     }
 }
@@ -471,7 +471,7 @@ task AggregateMetricsAcrossChromosomes {
         Boolean done = true
     }
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
         disks: "local-disk 500 HDD"
     }
 }
@@ -543,7 +543,7 @@ task CollectStatistics {
         Boolean done = true
     }
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
         disks: "local-disk 500 HDD"
     }
 }
@@ -572,7 +572,7 @@ task ExportToCSV {
         File callset_statistics = "~{statistics_table}.csv"
     }
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
         disks: "local-disk 500 HDD"
     }
 }

--- a/scripts/variantstore/wdl/GvsCreateTables.wdl
+++ b/scripts/variantstore/wdl/GvsCreateTables.wdl
@@ -103,7 +103,7 @@ task CreateTables {
   }
 
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     cpu: 1

--- a/scripts/variantstore/wdl/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVATfromVDS.wdl
@@ -167,7 +167,7 @@ task MakeSubpopulationFilesAndReadSchemaFiles {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-27-alpine"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -212,7 +212,7 @@ task StripCustomAnnotationsFromSitesOnlyVCF {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-27-alpine"
         memory: "7 GiB"
         cpu: "2"
         preemptible: 3
@@ -297,7 +297,7 @@ task RemoveDuplicatesFromSitesOnlyVCF {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-27-alpine"
         maxRetries: 3
         memory: "16 GB"
         preemptible: 3
@@ -457,7 +457,7 @@ task PrepVtAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-27-alpine"
         memory: "7 GB"
         preemptible: 3
         cpu: "1"
@@ -503,7 +503,7 @@ task PrepGenesAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-27-alpine"
         memory: "7 GB"
         preemptible: 3
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVATfromVDS.wdl
@@ -167,7 +167,7 @@ task MakeSubpopulationFilesAndReadSchemaFiles {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2023_01_11"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -212,7 +212,7 @@ task StripCustomAnnotationsFromSitesOnlyVCF {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2023_01_11"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
         memory: "7 GiB"
         cpu: "2"
         preemptible: 3
@@ -297,7 +297,7 @@ task RemoveDuplicatesFromSitesOnlyVCF {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-01-23-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
         maxRetries: 3
         memory: "16 GB"
         preemptible: 3
@@ -457,7 +457,7 @@ task PrepVtAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2023_01_11"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
         memory: "7 GB"
         preemptible: 3
         cpu: "1"
@@ -503,7 +503,7 @@ task PrepGenesAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:ah_var_store_2023_01_11"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
         memory: "7 GB"
         preemptible: 3
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
+++ b/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
@@ -157,7 +157,7 @@ task ExtractFromNonSuperpartitionedTables {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-27-alpine"
         disks: "local-disk 500 HDD"
     }
 }
@@ -225,7 +225,7 @@ task ExtractFromSuperpartitionedTables {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-27-alpine"
         disks: "local-disk 500 HDD"
     }
 }
@@ -293,7 +293,7 @@ task GenerateHailScripts {
         File hail_create_vat_inputs_script = 'hail_create_vat_inputs.py'
     }
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-27-alpine"
         disks: "local-disk 500 HDD"
     }
 }

--- a/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
+++ b/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
@@ -85,7 +85,7 @@ task OutputPath {
         File out = stdout()
     }
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
         disks: "local-disk 500 HDD"
     }
 }

--- a/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
+++ b/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
@@ -157,7 +157,7 @@ task ExtractFromNonSuperpartitionedTables {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-07-alpine-v2"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
         disks: "local-disk 500 HDD"
     }
 }
@@ -225,7 +225,7 @@ task ExtractFromSuperpartitionedTables {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-07-alpine-v2"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
         disks: "local-disk 500 HDD"
     }
 }
@@ -293,7 +293,7 @@ task GenerateHailScripts {
         File hail_create_vat_inputs_script = 'hail_create_vat_inputs.py'
     }
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-07-alpine-v2"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
         disks: "local-disk 500 HDD"
     }
 }

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -385,7 +385,7 @@ task SumBytes {
     print(total_mb);"
   >>>
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
     memory: "3 GB"
     disks: "local-disk 500 HDD"
     preemptible: 3
@@ -424,7 +424,7 @@ task CreateManifest {
   }
 
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
     memory: "3 GB"
     disks: "local-disk 500 HDD"
     preemptible: 3
@@ -468,7 +468,7 @@ task GenerateSampleListFile {
   }
 
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
     memory: "3 GB"
     disks: "local-disk 500 HDD"
     preemptible: 3

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -71,7 +71,7 @@ workflow GvsExtractCohortFromSampleNames {
     call write_array_task {
       input:
         input_array = select_first([cohort_sample_names_array]),
-        docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
+        docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0"
     }
   }
 

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -489,7 +489,7 @@ task CurateInputLists {
                                              --output_files True
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-bulk-ingest"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-27-alpine"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -155,7 +155,7 @@ task CreateFOFNs {
     split -a 5 -l ~{batch_size} ~{sample_name_list} batched_sample_names.
   >>>
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
     bootDiskSizeGb: 15
     memory: "3 GB"
     disks: "local-disk 10 HDD"
@@ -363,7 +363,7 @@ task SetIsLoadedColumn {
                      AND sls2.status = "FINISHED")'
   >>>
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
     memory: "1 GB"
     disks: "local-disk 10 HDD"
     cpu: 1
@@ -452,7 +452,7 @@ task GetUningestedSampleIds {
     bq --project_id=~{project_id} rm -f=true ~{temp_table}
   >>>
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
     memory: "1 GB"
     disks: "local-disk 10 HDD"
     preemptible: 5

--- a/scripts/variantstore/wdl/GvsIngestTieout.wdl
+++ b/scripts/variantstore/wdl/GvsIngestTieout.wdl
@@ -143,7 +143,7 @@ task IngestTieout {
     }
 
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:398.0.0"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0"
         memory: "14 GB"
         disks: "local-disk 2000 HDD"
         preemptible: 3

--- a/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
@@ -243,7 +243,7 @@ task PopulateAltAlleleTable {
     done
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-01-23-alpine"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     cpu: 1

--- a/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
@@ -243,7 +243,7 @@ task PopulateAltAlleleTable {
     done
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-27-alpine"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     cpu: 1

--- a/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
@@ -86,7 +86,7 @@ task GetMaxSampleId {
   }
 
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     preemptible: 3
@@ -138,7 +138,7 @@ task GetVetTableNames {
     split -l $num_tables_per_file vet_tables.csv vet_tables_
   >>>
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     preemptible: 3
@@ -199,7 +199,7 @@ task CreateAltAlleleTable {
 
   >>>
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     cpu: 1

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -114,7 +114,7 @@ task PrepareRangesCallsetTask {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-02-21-alpine"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -114,7 +114,7 @@ task PrepareRangesCallsetTask {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-27-alpine"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsQuickstartHailIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartHailIntegration.wdl
@@ -136,7 +136,7 @@ task CreateAndTieOutVds {
     >>>
     runtime {
         # `slim` here to be able to use Java
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-slim"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-slim"
         disks: "local-disk 2000 HDD"
         memory: "30 GiB"
     }

--- a/scripts/variantstore/wdl/GvsQuickstartVcfIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartVcfIntegration.wdl
@@ -235,9 +235,9 @@ task AssertCostIsTrackedAndExpected {
     }
 
     command <<<
-        # Prepend date, time and pwd to xtrace log entries.
-        PS4='\D{+%F %T} \w $ '
-        set -o errexit -o nounset -o pipefail -o xtrace
+        set -o errexit
+        set -o nounset
+        set -o pipefail
 
         echo "project_id = ~{project_id}" > ~/.bigqueryrc
         bq query --project_id=~{project_id} --format=csv --use_legacy_sql=false \
@@ -331,9 +331,9 @@ task AssertTableSizesAreExpected {
     }
 
     command <<<
-        # Prepend date, time and pwd to xtrace log entries.
-        PS4='\D{+%F %T} \w $ '
-        set -o errexit -o nounset -o pipefail -o xtrace
+        set -o errexit
+        set -o nounset
+        set -o pipefail
 
         echo "project_id = ~{project_id}" > ~/.bigqueryrc
         bq query --project_id=~{project_id} --format=csv --use_legacy_sql=false \

--- a/scripts/variantstore/wdl/GvsQuickstartVcfIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartVcfIntegration.wdl
@@ -212,7 +212,7 @@ task AssertIdenticalOutputs {
     >>>
 
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:402.0.0-alpine"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
         disks: "local-disk 500 HDD"
     }
 
@@ -235,9 +235,9 @@ task AssertCostIsTrackedAndExpected {
     }
 
     command <<<
-        set -o errexit
-        set -o nounset
-        set -o pipefail
+        # Prepend date, time and pwd to xtrace log entries.
+        PS4='\D{+%F %T} \w $ '
+        set -o errexit -o nounset -o pipefail -o xtrace
 
         echo "project_id = ~{project_id}" > ~/.bigqueryrc
         bq query --project_id=~{project_id} --format=csv --use_legacy_sql=false \
@@ -308,7 +308,7 @@ task AssertCostIsTrackedAndExpected {
     >>>
 
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:402.0.0-alpine"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
         disks: "local-disk 10 HDD"
     }
 
@@ -331,9 +331,9 @@ task AssertTableSizesAreExpected {
     }
 
     command <<<
-        set -o errexit
-        set -o nounset
-        set -o pipefail
+        # Prepend date, time and pwd to xtrace log entries.
+        PS4='\D{+%F %T} \w $ '
+        set -o errexit -o nounset -o pipefail -o xtrace
 
         echo "project_id = ~{project_id}" > ~/.bigqueryrc
         bq query --project_id=~{project_id} --format=csv --use_legacy_sql=false \
@@ -356,7 +356,7 @@ task AssertTableSizesAreExpected {
     >>>
 
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:402.0.0-alpine"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
         disks: "local-disk 10 HDD"
     }
 

--- a/scripts/variantstore/wdl/GvsQuickstartVcfIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartVcfIntegration.wdl
@@ -277,7 +277,7 @@ task AssertCostIsTrackedAndExpected {
         # For these two costs, there is non-determinism in the pipeline - we allow a % difference
         if [[ $OBS_KEY == "ExtractFilterTask.GvsCreateFilterSet.BigQuery Query Scanned" ]]; then
           TOLERANCE=0.02   # 2% tolerance  (Note - have seen as high as: 0.0157154)
-        elif [[ $OBS_KEY == "ExtractTask.GvsCreateCallset.Storage API Scanned" ]]; then
+        elif [[ $OBS_KEY == "ExtractTask.GvsExtractCallset.Storage API Scanned" ]]; then
           TOLERANCE=0.01   # 1% tolerance  (Note - have seen as high as: 0.00608656)
         elif [[ $OBS_KEY == "ExtractFilterTask.GvsCreateFilterSet.Storage API Scanned" ]]; then
           TOLERANCE=0.05  # 5% tolerance (Note - have seen as high as: 0.0281223)

--- a/scripts/variantstore/wdl/GvsQuickstartVcfIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartVcfIntegration.wdl
@@ -7,7 +7,7 @@ workflow GvsQuickstartVcfIntegration {
 
     input {
         String branch_name
-        String expected_output_prefix = "gs://gvs-internal-quickstart/integration/2022-10-20/"
+        String expected_output_prefix = "gs://gvs-internal-quickstart/integration/2023-03-23/"
 
         Array[String] external_sample_names = [
                                               "ERS4367795",

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -168,7 +168,7 @@ task GetBQTableLastModifiedDatetime {
   }
 
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     preemptible: 3
@@ -206,7 +206,7 @@ task GetBQTablesMaxLastModifiedTimestamp {
   }
 
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     preemptible: 3
@@ -288,7 +288,7 @@ task BuildGATKJarAndCreateDataset {
   }
 
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-slim"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-slim"
     disks: "local-disk 500 HDD"
   }
 }
@@ -391,7 +391,7 @@ task GetNumSamplesLoaded {
   }
 
   runtime {
-    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     preemptible: 3
@@ -419,7 +419,7 @@ task CountSuperpartitions {
         ' | sed 1d > num_superpartitions.txt
     >>>
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
         disks: "local-disk 500 HDD"
     }
     output {
@@ -463,7 +463,7 @@ task ValidateFilterSetName {
     }
 
     runtime {
-        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:409.0.0-alpine"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine"
         memory: "3 GB"
         disks: "local-disk 500 HDD"
         preemptible: 3

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -352,7 +352,7 @@ task ScaleXYBedValues {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-27-alpine"
         maxRetries: 3
         memory: "7 GB"
         preemptible: 3

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -352,7 +352,7 @@ task ScaleXYBedValues {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-01-23-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine"
         maxRetries: 3
         memory: "7 GB"
         preemptible: 3

--- a/scripts/variantstore/wdl/extract/Dockerfile
+++ b/scripts/variantstore/wdl/extract/Dockerfile
@@ -8,14 +8,14 @@
 # expensive to create and isn't expected to change often, while the steps in this Dockerfile are much less expensive and
 # more likely to change. Using a build-base image essentially allows the expensive layers to be globally cached which
 # should make building the final image much faster in most cases.
-FROM us.gcr.io/broad-dsde-methods/variantstore:2022-11-08-alpine-build-base as build
+FROM us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-alpine-build-base as build
 
 # Install all of our variantstore Python requirements.
 COPY requirements.txt requirements.txt
 RUN pip3 install --user -r requirements.txt
 
 # The main layer does not install development tools, instead copies artifacts from the build layer above.
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:408.0.1-alpine as main
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine as main
 
 RUN apk update && apk upgrade
 RUN python3 -m ensurepip --upgrade

--- a/scripts/variantstore/wdl/extract/build_base.Dockerfile
+++ b/scripts/variantstore/wdl/extract/build_base.Dockerfile
@@ -11,7 +11,7 @@
 # under ideal circumstances, potentially much longer on low memory and/or non-x86 build hosts). Since this image isn't
 # expected to change often it's broken out into a separate "build-base" image that can effectively be globally cached
 # and referenced from the main Dockerfile.
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:408.0.1-alpine
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:423.0.0-alpine
 
 RUN apk update && apk upgrade
 RUN python3 -m ensurepip --upgrade
@@ -30,7 +30,7 @@ RUN apk add autoconf bash cmake g++ gcc make ninja python3-dev git openssl-dev z
 # including the numpy Python module. The main stage will then use the same base image and copy over the artifacts
 # produced by the build stage without having to install development tools or clean up after a build.
 
-ARG ARROW_VERSION=10.0.0
+ARG ARROW_VERSION=11.0.0
 RUN cd / && \
     curl -O https://dlcdn.apache.org/arrow/arrow-$ARROW_VERSION/apache-arrow-$ARROW_VERSION.tar.gz && \
     tar xfz apache-arrow-$ARROW_VERSION.tar.gz
@@ -63,7 +63,7 @@ RUN cd $ARROW_SRC_DIR/python && \
 
 # Straightforward bcftools build following these instructions:
 # https://github.com/samtools/bcftools/blob/develop/INSTALL
-ARG BCFTOOLS_VERSION=1.16
+ARG BCFTOOLS_VERSION=1.17
 RUN mkdir /bcftools bcftools-build && \
     cd bcftools-build && \
     git clone --recurse-submodules https://github.com/samtools/htslib.git && \


### PR DESCRIPTION
Integration run kicked off [here](https://job-manager.dsde-prod.broadinstitute.org/jobs/e706347d-cae4-4138-a5a3-34692b39ae89). Previous versions completed successfully but failed cost comparison because the name of the WDL step changed and was unrecognized by the branches of the comparison code that cut slack.