### PR TITLE
Prep for modern womtool [VS-860]

### DIFF
--- a/scripts/variantstore/tieout/legacy_wdl/JointGenotyping.wdl
+++ b/scripts/variantstore/tieout/legacy_wdl/JointGenotyping.wdl
@@ -261,7 +261,7 @@ workflow JointGenotyping {
 
     call Tasks.GatherTranches as SNPGatherTranches {
       input:
-        tranches = SNPsVariantRecalibratorScattered.tranches,
+        input_tranches = SNPsVariantRecalibratorScattered.tranches,
         output_filename = callset_name + ".snps.gathered.tranches",
         mode = "SNP",
         disk_size = small_disk

--- a/scripts/variantstore/tieout/legacy_wdl/JointGenotypingTasks.wdl
+++ b/scripts/variantstore/tieout/legacy_wdl/JointGenotypingTasks.wdl
@@ -506,7 +506,7 @@ task SNPsVariantRecalibrator {
 task GatherTranches {
 
   input {
-    Array[File] tranches
+    Array[File] input_tranches
     String output_filename
     String mode
     Int disk_size
@@ -522,7 +522,7 @@ task GatherTranches {
   command <<<
     set -euo pipefail
 
-    tranches_fofn=~{write_lines(tranches)}
+    tranches_fofn=~{write_lines(input_tranches)}
 
     # Jose says:
     # Cromwell will fall over if we have it try to localize tens of thousands of files,


### PR DESCRIPTION
Modern versions of womtool don't tolerate task inputs with the same name as task outputs and produce baffling error messages like [this](https://broadinstitute.slack.com/archives/C4GSMFXS9/p1654807836682679). 