### PR TITLE
VS-838. Remove the unneeded SCORE field from the filter_set_info_vqsr table

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -95,8 +95,7 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - gg_VS-695_RunPandSForVQSR_Lite
-         - gg_VS-849_Add_AS_MQ_IndelAnnot_To_VQSR_Lite
+         - gg_VS-838_RemoveVQSRLiteScore
    - name: GvsPopulateAltAllele
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
@@ -120,7 +119,7 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - gg_VS-695_RunPandSForVQSR_Lite
+         - gg_VS-838_RemoveVQSRLiteScore
    - name: GvsImportGenomes
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -217,7 +216,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - gg_VS-695_RunPandSForVQSR_Lite
    - name: GvsQuickstartVcfIntegration
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsQuickstartVcfIntegration.wdl

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -425,7 +425,7 @@ task ExtractFilterTask {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_03_01_b01183576153cf000e17dea32144d332cb7b79a9"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_04_04_2a148d7c7de8c6e15b6b705342261ce85d5db5d5"
     memory: "7 GB"
     disks: "local-disk 10 HDD"
     bootDiskSizeGb: 15
@@ -506,7 +506,7 @@ task PopulateFilterSetInfo {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_03_01_b01183576153cf000e17dea32144d332cb7b79a9"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_04_04_2a148d7c7de8c6e15b6b705342261ce85d5db5d5"
     memory: "3500 MB"
     disks: "local-disk 250 HDD"
     bootDiskSizeGb: 15
@@ -562,7 +562,7 @@ task PopulateFilterSetSites {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_03_01_b01183576153cf000e17dea32144d332cb7b79a9"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_04_04_2a148d7c7de8c6e15b6b705342261ce85d5db5d5"
     memory: "3500 MB"
     disks: "local-disk 200 HDD"
     bootDiskSizeGb: 15
@@ -609,7 +609,7 @@ task PopulateFilterSetTranches {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_03_01_b01183576153cf000e17dea32144d332cb7b79a9"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_04_04_2a148d7c7de8c6e15b6b705342261ce85d5db5d5"
     memory: "3500 MB"
     disks: "local-disk 200 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -61,7 +61,7 @@ workflow GvsCreateFilterSet {
   String fq_filter_sites_destination_table = "~{project_id}.~{dataset_name}.filter_set_sites"
 
   String fq_info_destination_table_schema =           "filter_set_name:string,type:string,location:integer,ref:string,alt:string,vqslod:float,culprit:string,training_label:string,yng_status:string"
-  String fq_info_destination_table_vqsr_lite_schema = "filter_set_name:string,type:string,location:integer,ref:string,alt:string,calibration_sensitivity:float,score:float,training_label:string,yng_status:string"
+  String fq_info_destination_table_vqsr_lite_schema = "filter_set_name:string,type:string,location:integer,ref:string,alt:string,calibration_sensitivity:float,training_label:string,yng_status:string"
 
   call Utils.GetBQTableLastModifiedDatetime as SamplesTableDatetimeCheck {
     input:

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -348,7 +348,7 @@ task ExtractTask {
     echo ~{interval_index},${OUTPUT_FILE_DEST},${OUTPUT_FILE_BYTES},${OUTPUT_FILE_INDEX_DEST},${OUTPUT_FILE_INDEX_BYTES} >> manifest.txt
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_03_01_b01183576153cf000e17dea32144d332cb7b79a9"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_04_04_2a148d7c7de8c6e15b6b705342261ce85d5db5d5"
     memory: "12 GB"
     disks: "local-disk 150 HDD"
     bootDiskSizeGb: 15

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/SchemaUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/SchemaUtils.java
@@ -48,7 +48,6 @@ public class SchemaUtils {
     public static final String FILTER_SET_NAME = "filter_set_name";
     public static final String VQSLOD = "vqslod";
     public static final String CALIBRATION_SENSITIVITY = "calibration_sensitivity";
-    public static final String SCORE = "score";
     public static final String YNG_STATUS = "yng_status";
 
     //Tranches table
@@ -66,7 +65,7 @@ public class SchemaUtils {
 
     public static final List<String> SAMPLE_FIELDS = Arrays.asList(SchemaUtils.SAMPLE_NAME_FIELD_NAME, SchemaUtils.SAMPLE_ID_FIELD_NAME);
     public static final List<String> YNG_FIELDS = Arrays.asList(FILTER_SET_NAME, LOCATION_FIELD_NAME, REF_ALLELE_FIELD_NAME, ALT_ALLELE_FIELD_NAME, VQSLOD, YNG_STATUS);
-    public static final List<String> VQSLITE_YNG_FIELDS = Arrays.asList(FILTER_SET_NAME, LOCATION_FIELD_NAME, REF_ALLELE_FIELD_NAME, ALT_ALLELE_FIELD_NAME, CALIBRATION_SENSITIVITY, SCORE, YNG_STATUS);
+    public static final List<String> VQSLITE_YNG_FIELDS = Arrays.asList(FILTER_SET_NAME, LOCATION_FIELD_NAME, REF_ALLELE_FIELD_NAME, ALT_ALLELE_FIELD_NAME, CALIBRATION_SENSITIVITY, YNG_STATUS);
     public static final List<String> TRANCHE_FIELDS = Arrays.asList(TARGET_TRUTH_SENSITIVITY, MIN_VQSLOD, TRANCHE_FILTER_NAME, TRANCHE_MODEL);
 
     public static final List<String> ALT_ALLELE_FIELDS = Arrays.asList(LOCATION_FIELD_NAME, SAMPLE_ID_FIELD_NAME, REF_ALLELE_FIELD_NAME, "allele", ALT_ALLELE_FIELD_NAME, "allele_pos", CALL_GT, AS_RAW_MQ, RAW_MQ, AS_RAW_MQRankSum, "raw_mqranksum_x_10", AS_QUALapprox, "qual", AS_RAW_ReadPosRankSum, "raw_readposranksum_x_10", AS_SB_TABLE, "SB_REF_PLUS","SB_REF_MINUS","SB_ALT_PLUS","SB_ALT_MINUS", CALL_AD, "ref_ad", "ad");

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortLite.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortLite.java
@@ -224,7 +224,6 @@ public class ExtractCohortLite extends ExtractTool {
         );
         headerLines.add(GATKVCFHeaderLines.getFormatLine(GATKVCFConstants.REFERENCE_GENOTYPE_QUALITY));
         headerLines.add(GATKVCFHeaderLines.getInfoLine(GATKVCFConstants.AS_VQS_SENS_KEY));
-        headerLines.add(GATKVCFHeaderLines.getInfoLine(GATKVCFConstants.AS_VQS_SCORE_KEY));
         headerLines.add(GATKVCFHeaderLines.getInfoLine(GATKVCFConstants.AS_YNG_STATUS_KEY));
 
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortLiteFilterRecord.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortLiteFilterRecord.java
@@ -13,7 +13,6 @@ public class ExtractCohortLiteFilterRecord implements Locatable {
     private final Integer end;
 
     private final Double sensitivity;
-    private final Double score;
     private final String yng;
     private final String refAllele;
     private final String altAllele;
@@ -25,7 +24,6 @@ public class ExtractCohortLiteFilterRecord implements Locatable {
         this.end = start;
 
         this.sensitivity = Double.parseDouble(genericRecord.get(SchemaUtils.CALIBRATION_SENSITIVITY).toString());
-        this.score   = Double.parseDouble(genericRecord.get(SchemaUtils.SCORE).toString());
         this.yng = genericRecord.get(SchemaUtils.YNG_STATUS).toString();
 
         this.refAllele = genericRecord.get(SchemaUtils.REF_ALLELE_FIELD_NAME).toString();
@@ -44,8 +42,6 @@ public class ExtractCohortLiteFilterRecord implements Locatable {
     public long getLocation() { return this.location; }
 
     public double getSensitivity() { return this.sensitivity; }
-
-    public double getScore() { return this.score; }
 
     public String getYng() { return this.yng; }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/CreateFilteringFiles.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/filtering/CreateFilteringFiles.java
@@ -40,7 +40,7 @@ public final class CreateFilteringFiles extends VariantWalker {
         Arrays.asList("filter_set_name", "mode", "location", "ref", "alt", "vqslod", "culprit", "training_label", "yng");
     // TODO - not sure about culprit and training label.
     private List<String> HEADER_VQSR_LITE =
-        Arrays.asList("filter_set_name", "mode", "location", "ref", "alt", "calibration_sensitivity", "score", "training_label", "yng");
+        Arrays.asList("filter_set_name", "mode", "location", "ref", "alt", "calibration_sensitivity", "training_label", "yng");
 
     
     @Argument(fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, 
@@ -132,7 +132,6 @@ public final class CreateFilteringFiles extends VariantWalker {
         } else {
             // New VQSR-Lite has CALIBRATION_SENSITIVITY instead of vqslod
             String calibration_sensitivity = variant.getAttributeAsString("CALIBRATION_SENSITIVITY","");
-            String score = variant.getAttributeAsString("SCORE","");
             String trainingLabel = variant.hasAttribute("training") ? "POSITIVE" : "";
             String yng = variant.hasAttribute("training") ? "Y" : "G";
             row = Arrays.asList(
@@ -142,7 +141,6 @@ public final class CreateFilteringFiles extends VariantWalker {
                     ref,
                     alt,
                     calibration_sensitivity,
-                    score,
                     trainingLabel,
                     yng
             );

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFConstants.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFConstants.java
@@ -28,7 +28,6 @@ public final class GATKVCFConstants {
     public static final String AS_CULPRIT_KEY =                     "AS_culprit";
     public static final String AS_VQS_LOD_KEY =                     "AS_VQSLOD";
     public static final String AS_VQS_SENS_KEY =                    "AS_VQS_SENS";
-    public static final String AS_VQS_SCORE_KEY =                   "AS_VQS_SCORE";
     public static final String AS_YNG_STATUS_KEY =                  "AS_YNG";
     public static final String ORIGINAL_AC_KEY =                    "AC_Orig"; //SelectVariants
     public static final String ORIGINAL_AF_KEY =                    "AF_Orig"; //SelectVariants

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFHeaderLines.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFHeaderLines.java
@@ -159,7 +159,6 @@ public class GATKVCFHeaderLines {
         addInfoLine(new VCFInfoHeaderLine(AS_CULPRIT_KEY, VCFHeaderLineCount.A, VCFHeaderLineType.String, "For each alt allele, the annotation which was the worst performing in the Gaussian mixture model, likely the reason why the variant was filtered out"));
         addInfoLine(new VCFInfoHeaderLine(AS_VQS_LOD_KEY, VCFHeaderLineCount.A, VCFHeaderLineType.String, "For each alt allele, the log odds of being a true variant versus being false under the trained gaussian mixture model"));
         addInfoLine(new VCFInfoHeaderLine(AS_VQS_SENS_KEY, VCFHeaderLineCount.A, VCFHeaderLineType.String, "For each alt allele, the calibration sensitivity threshold of being a true variant versus being false under the trained gaussian mixture model"));
-        addInfoLine(new VCFInfoHeaderLine(AS_VQS_SCORE_KEY, VCFHeaderLineCount.A, VCFHeaderLineType.String, "For each alt allele, the score of being a true variant versus being false under the trained gaussian mixture model"));
         addInfoLine(new VCFInfoHeaderLine(AS_YNG_STATUS_KEY, VCFHeaderLineCount.A, VCFHeaderLineType.String, "For each alt allele, the yay/nay/grey status (yay are known good alleles, nay are known false positives, grey are unknown)"));
 
         addInfoLine(new VCFInfoHeaderLine(HI_CONF_DENOVO_KEY, 1, VCFHeaderLineType.String, "High confidence possible de novo mutation (GQ >= 20 for all trio members)=[comma-delimited list of child samples]"));


### PR DESCRIPTION
Remove the unneeded SCORE field from the filter_set_info_vqsr table.

The SCORE field was added to the filter_set_info_vqsr_lite table during debugging at Sam’s behest. It is the value that is used internally to determine the CALIBRATION_SENSITIVITY which is the primary ‘score’ of vqsr_lite. It can be removed now that we are done with debugging an issue we had earlier in development.