### PR TITLE
fix for https://github.com/broadinstitute/gatk/issues/7304 ( haploid genotype and mendelian violations )

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/samples/MendelianViolation.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/samples/MendelianViolation.java
@@ -161,24 +161,42 @@ public class MendelianViolation {
      * @return true if the three genotypes represent a Mendelian violation; false otherwise
      */
     public static boolean isViolation(final Genotype gMom, final Genotype gDad, final Genotype gChild) {
-        if (gChild.isNoCall()){ //cannot possibly be a violation is child is no call
-            return false;
-        }
-        if(gMom.isHomRef() && gDad.isHomRef() && gChild.isHomRef()) {
-            return false;
-        }
+        switch (gChild.getPloidy()) {
+            case 1 : {
+                final Allele child_allele = gChild.getAlleles().get(0);
+                if (child_allele.isNoCall()){ //cannot possibly be a violation if allele child is no call
+                    return false;
+                    }
+                //one parents is no "call
+                if(!gMom.isCalled() || !gDad.isCalled()){
+                    return false;
+                    }
+                return  !gMom.getAlleles().contains(child_allele) && !gDad.getAlleles().contains(child_allele);
+                }
+            case 2 : {
+                if (gChild.isNoCall()){ //cannot possibly be a violation if child is no call
+                    return false;
+                }
+                if(gMom.isHomRef() && gDad.isHomRef() && gChild.isHomRef()) {
+                    return false;
+                }
 
-        //1 parent is no "call
-        if(!gMom.isCalled()){
-            return (gDad.isHomRef() && gChild.isHomVar()) || (gDad.isHomVar() && gChild.isHomRef());
+                //1 parent is no "call
+                if(!gMom.isCalled()){
+                    return (gDad.isHomRef() && gChild.isHomVar()) || (gDad.isHomVar() && gChild.isHomRef());
+                }
+                else if(!gDad.isCalled()){
+                    return (gMom.isHomRef() && gChild.isHomVar()) || (gMom.isHomVar() && gChild.isHomRef());
+                }
+                //Both parents have genotype information
+                final Allele childRef = gChild.getAlleles().get(0);
+                return !(gMom.getAlleles().contains(childRef) && gDad.getAlleles().contains(gChild.getAlleles().get(1)) ||
+                    gMom.getAlleles().contains(gChild.getAlleles().get(1)) && gDad.getAlleles().contains(childRef));
+                }
+            default: {
+                return false;
+                }
         }
-        else if(!gDad.isCalled()){
-            return (gMom.isHomRef() && gChild.isHomVar()) || (gMom.isHomVar() && gChild.isHomRef());
-        }
-        //Both parents have genotype information
-        final Allele childRef = gChild.getAlleles().get(0);
-        return !(gMom.getAlleles().contains(childRef) && gDad.getAlleles().contains(gChild.getAlleles().get(1)) ||
-            gMom.getAlleles().contains(gChild.getAlleles().get(1)) && gDad.getAlleles().contains(childRef));
     }
 
     private void createInheritanceMap(){

--- a/src/test/java/org/broadinstitute/hellbender/utils/samples/MendelianViolationUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/samples/MendelianViolationUnitTest.java
@@ -21,10 +21,20 @@ public final class MendelianViolationUnitTest extends GATKBaseTest {
     private static final List<Allele> het = Arrays.asList(refAllele, altAllele);
     private static final List<Allele> notCall = Arrays.asList(noCallAllele, noCallAllele);
 
+    // haploid alleles
+    private static final List<Allele> hapRef = Collections.singletonList(refAllele);
+    private static final List<Allele> hapVar = Collections.singletonList(altAllele);
+    private static final List<Allele> hapNotCall = Collections.singletonList(noCallAllele);
+
     private static final Genotype g00 = new GenotypeBuilder("2", homRef).DP(10).AD(new int[]{10,0}).GQ(GQ30).make();
     private static final Genotype g01 = new GenotypeBuilder("1", het).DP(10).AD(new int[]{5, 5}).GQ(GQ25).make();
     private static final Genotype g11 = new GenotypeBuilder("3", homVar).DP(10).AD(new int[]{0, 10}).GQ(GQ30).make();
     private static final Genotype gNo = new GenotypeBuilder("4", notCall).make();
+
+    //haploid genotypes
+    private static final Genotype ghap0  = new GenotypeBuilder("5", hapRef).DP(10).AD(new int[]{10}).GQ(GQ30).make();
+    private static final Genotype ghap1  = new GenotypeBuilder("6", hapVar).DP(10).AD(new int[]{5}).GQ(GQ30).make();
+    private static final Genotype ghapNo = new GenotypeBuilder("7", hapNotCall).make();
 
     private static final Sample sMom = new Sample("mom", "fam", null, null, Sex.FEMALE);
     private static final Sample sDad = new Sample("dad",     sMom.getFamilyID(), null, null, Sex.MALE);
@@ -116,6 +126,13 @@ public final class MendelianViolationUnitTest extends GATKBaseTest {
         tests.add(new Object[]{gNo, gNo, g01, false});
         tests.add(new Object[]{gNo, gNo, g11, false});
         tests.add(new Object[]{gNo, gNo, gNo, false});
+      
+        tests.add(new Object[]{ghap0, ghap0, ghap0, false});
+        tests.add(new Object[]{ghap0, ghap0, ghap1, true});
+        tests.add(new Object[]{g00, g00, ghap1, true});
+        tests.add(new Object[]{g01, g00, ghap1, false});
+        tests.add(new Object[]{g00, g00, ghap0, false});
+        tests.add(new Object[]{ghap0, ghap0, ghapNo, false});
 
         return tests.toArray(new Object[][]{});
     }


### PR DESCRIPTION
Hi GATK team,

this is a fix for the following issue :  https://github.com/broadinstitute/gatk/issues/7304 where and IndexOutOfBoundsException is raised when there is a non-diploid genotype in `MendelianViolation.isViolation`

I added a switch case to test the child ploidy as well as a few tests in MendelianViolationUnitTest

