### PR TITLE
Sanity check variantstore images before publishing [VS-889]

### DIFF
--- a/scripts/variantstore/wdl/extract/build_build_base_docker.sh
+++ b/scripts/variantstore/wdl/extract/build_build_base_docker.sh
@@ -2,7 +2,7 @@
 
 if [ $# -lt 1 ]; then
     echo "USAGE: ./build_build_base_docker.sh [DOCKER_TAG_STRING] [OPTIONAL:LATEST]"
-    echo " e.g.: ./build_build_base_docker.sh \$(date -I)-alpine-build-base"
+    echo " e.g.: ./build_build_base_docker.sh \$(date -Idate)-alpine-build-base"
     exit 1
 fi
 
@@ -15,10 +15,34 @@ fi
 set -o errexit -o nounset -o pipefail -o xtrace
 
 BASE_REPO="broad-dsde-methods/variantstore"
-REPO_WITH_TAG="${BASE_REPO}:${1}"
+TAG="${1}"
+REPO_WITH_TAG="${BASE_REPO}:${TAG}"
 GCR_TAG="us.gcr.io/${REPO_WITH_TAG}"
 
+set +o errexit
+grep "${TAG}" <(docker images | grep "^${BASE_REPO}" | awk '{print $2}') > /dev/null
+RC="$?"
+set -o errexit
+
+if [[ $RC -eq 0 ]]
+then
+  echo "Error: Tag '${TAG}' already exists for image '${BASE_REPO}', refusing to tag again."
+  exit 1
+fi
+
 docker build --file build_base.Dockerfile . -t "${REPO_WITH_TAG}"
+
+# Smoke test: make sure the gsutil command does not crash with a no-args invocation.
+set +o errexit
+docker run --rm -it "${REPO_WITH_TAG}" gsutil > /dev/null
+RC="$?"
+set -o errexit
+
+if [[ $RC -ne 0 ]]
+then
+  echo "Error: image '${REPO_WITH_TAG}' did not pass smoke test, will need to be deleted before attempting to tag again."
+  exit 1
+fi
 
 docker tag "${REPO_WITH_TAG}" "${GCR_TAG}"
 docker push "${GCR_TAG}"

--- a/scripts/variantstore/wdl/extract/build_docker.sh
+++ b/scripts/variantstore/wdl/extract/build_docker.sh
@@ -1,6 +1,6 @@
 if [ $# -lt 1 ]; then
     echo "USAGE: ./build_docker.sh [DOCKER_TAG_STRING] [OPTIONAL:LATEST]"
-    echo " e.g.: ./build_docker.sh \$(date -I)-alpine"
+    echo " e.g.: ./build_docker.sh \$(date -Idate)-alpine"
     exit 1
 fi
 


### PR DESCRIPTION
tl;dr Added sanity checks, a smoke test, and fixed sample invocations in Docker build scripts.

Last month I built a bad base image when I was unsuccessfully trying to combine GCP and Azure CLIs in one image. What's worse is I seem to have tagged this broken image with a tag previously used for a good version of the image. These changes harden the Docker image build script to refuse to write over an existing tag and execute a smoke test against the image before pushing to GCR. While I was in there I also fixed the sample invocations that we saw during mobbing did not work on all versions of `date`.