### PR TITLE
Experimental tool that aligns sequencing reads to set of haplotypes / templates

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowPairHMMAlignReadsToHaplotypes.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowPairHMMAlignReadsToHaplotypes.java
@@ -1,4 +1,4 @@
-package org.broadinstitute.hellbender.tools.walkers.groundtruth;
+package org.broadinstitute.hellbender.tools.walkers.featuremapping;
 
 
 import htsjdk.samtools.SAMFileHeader;
@@ -117,7 +117,7 @@ public final class FlowPairHMMAlignReadsToHaplotypes extends ReadWalker {
         if (outputFormat.equals("expanded")) {
             outputWriter = new AlleleLikelihoodWriter(IOUtils.getPath(output), null);
         } else if (outputFormat.equals("concise")) {
-            outputWriter = new ConciseAlleleLikelihoodWriter(IOUtils.getPath(output), null);
+            outputWriter = new ConciseAlleleLikelihoodWriter(IOUtils.getPath(output));
         } else {
             throw new RuntimeException("Output format can be only expanded or concise");
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowPairHMMAlignReadsToHaplotypes.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowPairHMMAlignReadsToHaplotypes.java
@@ -27,7 +27,6 @@ import java.util.*;
  * that the reads were generated from one of the haplotypes and only sequencing errors. Thus, the alignment score
  * is exactly the likelihood of the read given haplotype that is calculated in HaplotypeCaller.
  *
- *
  * <h3> Input </h3>
  * <ul>
  *     <li> BAM/CRAM file</li>

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/groundtruth/FlowPairHMMAlignReadsToHaplotypes.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/groundtruth/FlowPairHMMAlignReadsToHaplotypes.java
@@ -13,13 +13,10 @@ import org.broadinstitute.barclay.argparser.ExperimentalFeature;
 import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.programgroups.FlowBasedProgramGroup;
 import org.broadinstitute.hellbender.engine.*;
-import org.broadinstitute.hellbender.tools.FlowBasedArgumentCollection;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.*;
-import org.broadinstitute.hellbender.utils.dragstr.DragstrParamUtils;
 import org.broadinstitute.hellbender.utils.genotyper.AlleleLikelihoods;
 import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
-import org.broadinstitute.hellbender.utils.read.FlowBasedReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.genotyper.SampleList;
 import org.broadinstitute.hellbender.utils.genotyper.IndexedSampleList;
@@ -102,6 +99,14 @@ public class FlowPairHMMAlignReadsToHaplotypes extends ReadWalker {
         }
     }
 
+    @Override
+    public Object onTraversalSuccess(){
+        AlleleLikelihoods<GATKRead, Haplotype> readByHaplotypeMatrix = calculateLikelihoods(readBuffer);
+        outputWriter.writeAlleleLikelihoodsConcise(readByHaplotypeMatrix, haplotypeToName, writeHeader, readCount - BUFFER_SIZE_LIMIT);
+        writeHeader=false;
+        readBuffer.clear();
+        return null;
+    }
     private AlleleLikelihoods<GATKRead,Haplotype> calculateLikelihoods(final List<GATKRead> reads){
         SampleList samples = new IndexedSampleList(Arrays.asList("sm1"));
         Map<String, List<GATKRead>> tmpMap = new HashMap<>();

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/groundtruth/FlowPairHMMAlignReadsToHaplotypes.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/groundtruth/FlowPairHMMAlignReadsToHaplotypes.java
@@ -1,0 +1,101 @@
+package org.broadinstitute.hellbender.tools.walkers.groundtruth;
+
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.reference.FastaSequenceFile;
+import htsjdk.samtools.reference.ReferenceSequence;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.ArgumentCollection;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.ExperimentalFeature;
+import org.broadinstitute.barclay.help.DocumentedFeature;
+import org.broadinstitute.hellbender.cmdline.programgroups.FlowBasedProgramGroup;
+import org.broadinstitute.hellbender.engine.*;
+import org.broadinstitute.hellbender.tools.FlowBasedArgumentCollection;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.AlleleLikelihoodWriter;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.FlowBasedHMMEngine;
+import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.LikelihoodEngineArgumentCollection;
+import org.broadinstitute.hellbender.utils.dragstr.DragstrParamUtils;
+import org.broadinstitute.hellbender.utils.genotyper.AlleleLikelihoods;
+import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.broadinstitute.hellbender.utils.read.FlowBasedReadUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.genotyper.SampleList;
+import org.broadinstitute.hellbender.utils.genotyper.IndexedSampleList;
+
+import java.util.*;
+
+@CommandLineProgramProperties(
+        summary = "Align Reads to Haplotypes using FlowBasedPairHMM",
+        oneLineSummary = "Produces readxhaplotype matrix with likelihoods of read / haplotype",
+        programGroup = FlowBasedProgramGroup.class
+)
+
+@DocumentedFeature
+@ExperimentalFeature
+public class FlowPairHMMAlignReadsToHaplotypes extends ReadWalker {
+
+    private static final Logger logger = LogManager.getLogger(FlowPairHMMAlignReadsToHaplotypes.class);
+
+    @Argument(fullName = "haplotypes", shortName = "R", doc="Fasta file with haplotypes")
+    public GATKPath haplotypes_fa;
+
+    @Argument(fullName = "input", shortName = "I", doc="Input BAM/CRAM file with reads")
+    public GATKPath reads;
+
+    @Argument(fullName = "output", shortName = "O", doc="Readxhaplotype log-likelihood matrix")
+    public String output;
+
+    @ArgumentCollection
+    public FlowBasedArgumentCollection fbargs = new FlowBasedArgumentCollection();
+    LikelihoodEngineArgumentCollection likelihoodArgs = new LikelihoodEngineArgumentCollection();
+    SAMFileHeader sequenceHeader;
+    final FlowBasedHMMEngine aligner = new FlowBasedHMMEngine(fbargs, (byte) likelihoodArgs.gcpHMM,
+            10000, likelihoodArgs.expectedErrorRatePerBase, likelihoodArgs.pcrErrorModel,
+            likelihoodArgs.dontUseDragstrPairHMMScores ? null : DragstrParamUtils.parse(likelihoodArgs.dragstrParams),
+            likelihoodArgs.enableDynamicReadDisqualification, likelihoodArgs.readDisqualificationThresholdConstant,
+            likelihoodArgs.minUsableIndelScoreToUse, (byte) likelihoodArgs.flatDeletionPenalty,
+            (byte) likelihoodArgs.flatInsertionPenatly);
+
+    AlleleLikelihoodWriter outputWriter;
+
+    List<Haplotype> haplotypeList;
+
+    List<GATKRead> readBuffer;
+    final int BUFFER_SIZE_LIMIT = 1000;
+    @Override
+    public void onTraversalStart() {
+        super.onTraversalStart();
+        sequenceHeader = getHeaderForReads();
+        outputWriter = new AlleleLikelihoodWriter(IOUtils.getPath(output), null);
+        haplotypeList = new ArrayList<>();
+        FastaSequenceFile haplotypeFile = new FastaSequenceFile(haplotypes_fa.toPath(), false);
+        ReferenceSequence seq = haplotypeFile.nextSequence();
+        byte[] flowOrder = FlowBasedReadUtils.getReadFlowOrder(sequenceHeader, null);
+        readBuffer = new ArrayList<>();
+        while (seq != null ){
+            Haplotype hap = new Haplotype(seq.getBases());
+            haplotypeList.add(hap);
+            seq = haplotypeFile.nextSequence();
+        }
+    }
+    @Override
+    public void apply(final GATKRead read, final ReferenceContext referenceContext, final FeatureContext featureContext){
+        readBuffer.add(read);
+        if (readBuffer.size() == BUFFER_SIZE_LIMIT){
+            AlleleLikelihoods<GATKRead, Haplotype> readByHaplotypeMatrix = calculateLikelihoods(readBuffer);
+            outputWriter.writeAlleleLikelihoods(readByHaplotypeMatrix);
+            readBuffer.clear();
+        }
+    }
+
+    private AlleleLikelihoods<GATKRead,Haplotype> calculateLikelihoods(final List<GATKRead> reads){
+        SampleList samples = new IndexedSampleList(Arrays.asList("sm1"));
+        Map<String, List<GATKRead>> tmpMap = new HashMap<>();
+        tmpMap.put("sm1", reads);
+        return aligner.computeReadLikelihoods(haplotypeList, sequenceHeader, samples, tmpMap, false);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AlleleLikelihoodWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AlleleLikelihoodWriter.java
@@ -94,10 +94,10 @@ public class AlleleLikelihoodWriter implements AutoCloseable {
     }
 
     /**
-     * Add a likelihood matrix to the output. Only haplotypes falling within the output interval will be output
+     * Write read x haplotype likelihood matrix as a matrix
      * @param likelihoods - matrix to add
      */
-    public void writeAlleleLikelihoodsConcise(final AlleleLikelihoods<GATKRead, Haplotype> likelihoods, Map<String, String> haplotypeToNameMap, boolean writeHeader, int readCount){
+    public void writeAlleleLikelihoodsAsMatrix(final AlleleLikelihoods<GATKRead, Haplotype> likelihoods, Map<String, String> haplotypeToNameMap, boolean writeHeader, int readCount){
         final List<String> samples = likelihoods.samples();
         final List<Haplotype> haplotypes = likelihoods.alleles();
         try {
@@ -110,7 +110,7 @@ public class AlleleLikelihoodWriter implements AutoCloseable {
                     output.write("\n");
                 }
 
-                List<GATKRead> reads = likelihoods.sampleEvidence(0);
+                List<GATKRead> reads = likelihoods.sampleEvidence(s);
                 for (int read = 0; read < likelihoods.sampleMatrix(s).evidenceCount(); read++) {
                     output.write(String.format("%s", reads.get(read).getName()));
                     for (int allele = 0; allele < likelihoods.sampleMatrix(s).numberOfAlleles(); allele++) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AlleleLikelihoodWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AlleleLikelihoodWriter.java
@@ -103,17 +103,18 @@ public class AlleleLikelihoodWriter implements AutoCloseable {
         try {
             for (int s = 0 ; s < samples.size(); s++) {
                 if (writeHeader){
+                    output.write("Read");
                     for (int allele = 0; allele < likelihoods.sampleMatrix(s).numberOfAlleles(); allele++) {
-                        output.write(String.format("#Haplotype\t%08d\t%s\n", allele, haplotypeToNameMap.get(haplotypes.get(allele).toString())));
+                        output.write(String.format("\t%s", haplotypeToNameMap.get(haplotypes.get(allele).toString())));
                     }
+                    output.write("\n");
                 }
 
                 List<GATKRead> reads = likelihoods.sampleEvidence(0);
                 for (int read = 0; read < likelihoods.sampleMatrix(s).evidenceCount(); read++) {
-                    output.write(String.format("#Read\t%08d\t%s\n", readCount+read, reads.get(read).getName()));
+                    output.write(String.format("%s", reads.get(read).getName()));
                     for (int allele = 0; allele < likelihoods.sampleMatrix(s).numberOfAlleles(); allele++) {
-                        output.write(String.format("%08d\t%.3f\n",
-                                allele, likelihoods.sampleMatrix(s).get(allele, read)));
+                        output.write(String.format("\t%.3f",likelihoods.sampleMatrix(s).get(allele, read)));
                     }
                     output.write("\n");
                 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ConciseAlleleLikelihoodWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ConciseAlleleLikelihoodWriter.java
@@ -10,9 +10,14 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+/*
+A class for logging likelihood matrices, in a more consise way - we just show
+for read the best haplotype and the differences in the scores from the second best and the reference haplotype
+ */
+
 public class ConciseAlleleLikelihoodWriter extends AlleleLikelihoodWriter{
-    public ConciseAlleleLikelihoodWriter(final Path _outputPath, final SimpleInterval _interval) {
-        super(_outputPath, _interval);
+    public ConciseAlleleLikelihoodWriter(final Path _outputPath) {
+        super(_outputPath, null);
     }
     /**
      * Write read x haplotype likelihood matrix as a matrix of
@@ -64,5 +69,4 @@ public class ConciseAlleleLikelihoodWriter extends AlleleLikelihoodWriter{
             throw new RuntimeException(String.format("Unable to write matrix to file"));
         }
     }
-
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ConciseAlleleLikelihoodWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ConciseAlleleLikelihoodWriter.java
@@ -59,9 +59,9 @@ public class ConciseAlleleLikelihoodWriter extends AlleleLikelihoodWriter{
                         }
                     }
                     output.write(bestHap + "\t");
-                    output.write(bestScore + "\t");
-                    output.write(bestScore-secondBestScore + "\t");
-                    output.write(bestScore-refScore + "\n");
+                    output.write(String.format("%.03f", bestScore) + "\t");
+                    output.write(String.format("%.03f", bestScore-secondBestScore) + "\t");
+                    output.write(String.format("%.03f", bestScore-refScore) + "\n");
                 }
             }
             output.flush();

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ConciseAlleleLikelihoodWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ConciseAlleleLikelihoodWriter.java
@@ -1,11 +1,9 @@
 package org.broadinstitute.hellbender.tools.walkers.haplotypecaller;
 import java.nio.file.Path;
-import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.genotyper.AlleleLikelihoods;
 import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
-import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +64,7 @@ public class ConciseAlleleLikelihoodWriter extends AlleleLikelihoodWriter{
             }
             output.flush();
         } catch (IOException err) {
-            throw new RuntimeException(String.format("Unable to write matrix to file"));
+            throw new RuntimeException("Unable to write matrix to file");
         }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ConciseAlleleLikelihoodWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ConciseAlleleLikelihoodWriter.java
@@ -1,0 +1,68 @@
+package org.broadinstitute.hellbender.tools.walkers.haplotypecaller;
+import java.nio.file.Path;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.genotyper.AlleleLikelihoods;
+import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class ConciseAlleleLikelihoodWriter extends AlleleLikelihoodWriter{
+    public ConciseAlleleLikelihoodWriter(final Path _outputPath, final SimpleInterval _interval) {
+        super(_outputPath, _interval);
+    }
+    /**
+     * Write read x haplotype likelihood matrix as a matrix of
+     * @param likelihoods - matrix to add
+     */
+    public void writeAlleleLikelihoodsAsMatrix(final AlleleLikelihoods<GATKRead, Haplotype> likelihoods,
+                                               Map<String, String> haplotypeToNameMap,
+                                               boolean writeHeader, int readCount){
+        final List<String> samples = likelihoods.samples();
+        final List<Haplotype> haplotypes = likelihoods.alleles();
+        try {
+            for (int s = 0 ; s < samples.size(); s++) {
+                if (writeHeader){
+                    output.write("Read\t");
+                    output.write("Best_hap\t");
+                    output.write("Best_score\t");
+                    output.write("Diff_from_second\t");
+                    output.write("Diff_from_ref\n");
+                }
+
+                List<GATKRead> reads = likelihoods.sampleEvidence(s);
+                for (int read = 0; read < likelihoods.sampleMatrix(s).evidenceCount(); read++) {
+                    output.write(String.format("%s\t", reads.get(read).getName()));
+                    String bestHap = "";
+                    double bestScore = Double.NEGATIVE_INFINITY;
+                    double secondBestScore = Double.NEGATIVE_INFINITY;
+                    double refScore = Double.NEGATIVE_INFINITY;
+                    for (int allele = 0; allele < likelihoods.sampleMatrix(s).numberOfAlleles(); allele++) {
+                        double newScore = likelihoods.sampleMatrix(s).get(allele, read);
+                        if (newScore > bestScore){
+                            secondBestScore = bestScore;
+                            bestScore = newScore;
+                            bestHap = haplotypeToNameMap.get(haplotypes.get(allele).toString());
+                            if (haplotypes.get(allele).isReference()){
+                                refScore = newScore;
+                            }
+                        } else if (newScore > secondBestScore){
+                            secondBestScore = newScore;
+                        }
+                    }
+                    output.write(bestHap + "\t");
+                    output.write(bestScore + "\t");
+                    output.write(bestScore-secondBestScore + "\t");
+                    output.write(bestScore-refScore + "\n");
+                }
+            }
+            output.flush();
+        } catch (IOException err) {
+            throw new RuntimeException(String.format("Unable to write matrix to file"));
+        }
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/FlowBasedAlignmentArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/FlowBasedAlignmentArgumentCollection.java
@@ -12,6 +12,8 @@ public class FlowBasedAlignmentArgumentCollection extends FlowBasedArgumentColle
     public static final String FLOW_LIKELIHOOD_PARALLEL_THREADS_LONG_NAME = "flow-likelihood-parallel-threads";
     public static final String FLOW_LIKELIHOOD_OPTIMIZED_COMP_LONG_NAME = "flow-likelihood-optimized-comp";
 
+    public static final String TRIM_TO_HAPLOTYPE_LONG_NAME = "trim-to-haplotype";
+    public static final String EXACT_MATCHING_LONG_NAME = "exact-matching";
     @Advanced
     @Hidden
     @Argument(fullName = FLOW_LIKELIHOOD_PARALLEL_THREADS_LONG_NAME, doc = "Number of threads to parallelize likelihood computation inner (read) loop with", optional=true)
@@ -23,5 +25,14 @@ public class FlowBasedAlignmentArgumentCollection extends FlowBasedArgumentColle
             "for common probability values", optional=true)
     public boolean flowLikelihoodOptimizedComp = false;
 
+    @Advanced
+    @Hidden
+    @Argument(fullName = TRIM_TO_HAPLOTYPE_LONG_NAME, doc = "Should the read be trimmed to the haplotype", optional=true)
+    public boolean trimToHaplotype = true;
+
+    @Advanced
+    @Hidden
+    @Argument(fullName = EXACT_MATCHING_LONG_NAME, doc = "Should exact match of haplotype to read be assumed", optional=true)
+    public boolean exactMatching = false;
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/FlowBasedHMMEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/FlowBasedHMMEngine.java
@@ -85,7 +85,18 @@ public class FlowBasedHMMEngine implements ReadLikelihoodCalculationEngine {
     public AlleleLikelihoods<GATKRead, Haplotype> computeReadLikelihoods(final List<Haplotype> haplotypeList,
                                                                          final SAMFileHeader hdr,
                                                                          final SampleList samples,
-                                                                         final Map<String, List<GATKRead>> perSampleReadList, final boolean filterPoorly) {
+                                                                         final Map<String, List<GATKRead>> perSampleReadList,
+                                                                         final boolean filterPoorly){
+        return computeReadLikelihoods(haplotypeList, hdr, samples, perSampleReadList, filterPoorly, true);
+    }
+
+
+    public AlleleLikelihoods<GATKRead, Haplotype> computeReadLikelihoods(final List<Haplotype> haplotypeList,
+                                                                         final SAMFileHeader hdr,
+                                                                         final SampleList samples,
+                                                                         final Map<String, List<GATKRead>> perSampleReadList,
+                                                                         final boolean filterPoorly,
+                                                                         final boolean normalizeLikelihoods) {
         Utils.nonNull(samples, "samples is null");
         Utils.nonNull(perSampleReadList, "perSampleReadList is null");
         Utils.nonNull(haplotypeList, "haplotypeList is null");
@@ -98,8 +109,9 @@ public class FlowBasedHMMEngine implements ReadLikelihoodCalculationEngine {
         for (int i = 0; i < sampleCount; i++) {
             computeReadLikelihoods(result.sampleMatrix(i), hdr);
         }
-
-        result.normalizeLikelihoods(log10globalReadMismappingRate, true);
+        if (normalizeLikelihoods) {
+            result.normalizeLikelihoods(log10globalReadMismappingRate, true);
+        }
         if ( filterPoorly ) {
             filterPoorlyModeledEvidence(result, dynamicReadDisqualification, expectedErrorRatePerBase, readDisqualificationScale);
         }
@@ -246,18 +258,18 @@ public class FlowBasedHMMEngine implements ReadLikelihoodCalculationEngine {
         }
 
         //NOTE: we assume all haplotypes start and end on the same place!
-        final int haplotypeStart = processedHaplotypes.get(0).getStart();
-        final int haplotypeEnd = processedHaplotypes.get(0).getEnd();
-        for (int i = 0 ; i < processedReads.size(); i++) {
-            final FlowBasedRead fbr=processedReads.get(i);
-            final int readStart = fbr.getStart();
-            final int readEnd = fbr.getEnd();
-            final int diffLeft = haplotypeStart - readStart;
-            final int diffRight = readEnd - haplotypeEnd;
-            //It is rare that this function is applied, maybe just some boundary cases
-            //in general reads are already trimmed to the haplotype starts and ends so diff_left <= 0 and diff_right <= 0
-            fbr.applyBaseClipping(Math.max(0, diffLeft), Math.max(diffRight, 0), false);
-        }
+//        final int haplotypeStart = processedHaplotypes.get(0).getStart();
+//        final int haplotypeEnd = processedHaplotypes.get(0).getEnd();
+//        for (int i = 0 ; i < processedReads.size(); i++) {
+//            final FlowBasedRead fbr=processedReads.get(i);
+//            final int readStart = fbr.getStart();
+//            final int readEnd = fbr.getEnd();
+//            final int diffLeft = haplotypeStart - readStart;
+//            final int diffRight = readEnd - haplotypeEnd;
+//            //It is rare that this function is applied, maybe just some boundary cases
+//            //in general reads are already trimmed to the haplotype starts and ends so diff_left <= 0 and diff_right <= 0
+//            fbr.applyBaseClipping(Math.max(0, diffLeft), Math.max(diffRight, 0), false);
+//        }
         initializeFlowPairHMM(processedHaplotypes, processedReads);
 
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowPairHMMAlignReadsToHaplotypesIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowPairHMMAlignReadsToHaplotypesIntegrationTest.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 
 public class FlowPairHMMAlignReadsToHaplotypesIntegrationTest extends CommandLineProgramTest{
-    public static final boolean UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS = true;
+    public static final boolean UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS = false;
 
     private static String testDir = publicTestDir + FlowTestConstants.FEATURE_MAPPING_DATA_DIR;
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowPairHMMAlignReadsToHaplotypesIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowPairHMMAlignReadsToHaplotypesIntegrationTest.java
@@ -12,7 +12,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 public class FlowPairHMMAlignReadsToHaplotypesIntegrationTest extends CommandLineProgramTest{
     public static final boolean UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS = false;
 
-    private static String testDir = publicTestDir + FlowTestConstants.FEATURE_MAPPING_DATA_DIR;
+    private static final String testDir = publicTestDir + FlowTestConstants.FEATURE_MAPPING_DATA_DIR;
 
     @Test
     public void assertThatExpectedOutputUpdateToggleIsDisabled() {

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowPairHMMAlignReadsToHaplotypesIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowPairHMMAlignReadsToHaplotypesIntegrationTest.java
@@ -1,0 +1,82 @@
+package org.broadinstitute.hellbender.tools.walkers.featuremapping;
+
+import org.broadinstitute.hellbender.testutils.IntegrationTestSpec;
+import org.broadinstitute.hellbender.tools.walkers.variantrecalling.FlowTestConstants;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import org.broadinstitute.hellbender.CommandLineProgramTest;
+
+public class FlowPairHMMAlignReadsToHaplotypesIntegrationTest extends CommandLineProgramTest{
+    public static final boolean UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS = false;
+
+    private static String testDir = publicTestDir + FlowTestConstants.FEATURE_MAPPING_DATA_DIR;
+
+    @Test
+    public void assertThatExpectedOutputUpdateToggleIsDisabled() {
+        Assert.assertFalse(UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS, "The toggle to update expected outputs should not be left enabled");
+    }
+
+    @Test
+    public void testExpanded() throws IOException {
+
+        final File outputDir = createTempDir("testFlowAlignReads");
+        final File expectedFile = new File(testDir + "/read_to_hap_expanded.txt");
+        final File outputFile = UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ? expectedFile : new File(outputDir + "/read_to_hap_expanded.txt");
+
+        final String[] args = new String[] {
+                "-O", outputFile.getAbsolutePath(),
+                "-I", testDir + "/alignReadsToHaplotypesTest.bam",
+                "-H", testDir + "/alignReadsToHaplotypesTest.fa",
+                "--flow-use-t0-tag",
+                "-E", "FBA",
+                "--flow-fill-empty-bins-value", "0.00001",
+                "--flow-probability-threshold", "0.00001",
+                "--flow-likelihood-optimized-comp"
+        };
+
+        // run the tool
+        runCommandLine(args);  // no assert, just make sure we don't throw
+
+        // make sure we've generated the otuput file
+        Assert.assertTrue(outputFile.exists());
+
+        // walk the output and expected files, compare non-comment lines
+        if ( !UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ) {
+            IntegrationTestSpec.assertEqualTextFiles(outputFile, expectedFile, "#");
+        }
+    }
+
+    public void testConcise() throws IOException {
+
+        final File outputDir = createTempDir("testFlowAlignReads");
+        final File expectedFile = new File(testDir + "/read_to_hap_concise.txt");
+        final File outputFile = UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ? expectedFile : new File(outputDir + "/read_to_hap_concise.txt");
+
+        final String[] args = new String[] {
+                "-O", outputFile.getAbsolutePath(),
+                "-I", testDir + "/alignReadsToHaplotypesTest.bam",
+                "-H", testDir + "/alignReadsToHaplotypesTest.fa",
+                "--ref-haplotype", "Hap2",
+                "--output-format", "concise",
+                "--flow-use-t0-tag",
+                "-E", "FBA",
+                "--flow-fill-empty-bins-value", "0.00001",
+                "--flow-probability-threshold", "0.00001",
+                "--flow-likelihood-optimized-comp"
+        };
+
+        // run the tool
+        runCommandLine(args);  // no assert, just make sure we don't throw
+
+        // make sure we've generated the otuput file
+        Assert.assertTrue(outputFile.exists());
+
+        // walk the output and expected files, compare non-comment lines
+        if ( !UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ) {
+            IntegrationTestSpec.assertEqualTextFiles(outputFile, expectedFile, "#");
+        }
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowPairHMMAlignReadsToHaplotypesIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowPairHMMAlignReadsToHaplotypesIntegrationTest.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 
 public class FlowPairHMMAlignReadsToHaplotypesIntegrationTest extends CommandLineProgramTest{
-    public static final boolean UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS = false;
+    public static final boolean UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS = true;
 
     private static String testDir = publicTestDir + FlowTestConstants.FEATURE_MAPPING_DATA_DIR;
 
@@ -49,6 +49,7 @@ public class FlowPairHMMAlignReadsToHaplotypesIntegrationTest extends CommandLin
         }
     }
 
+    @Test
     public void testConcise() throws IOException {
 
         final File outputDir = createTempDir("testFlowAlignReads");
@@ -59,7 +60,7 @@ public class FlowPairHMMAlignReadsToHaplotypesIntegrationTest extends CommandLin
                 "-O", outputFile.getAbsolutePath(),
                 "-I", testDir + "/alignReadsToHaplotypesTest.bam",
                 "-H", testDir + "/alignReadsToHaplotypesTest.fa",
-                "--ref-haplotype", "Hap2",
+                "--ref-haplotype", "Hap_2",
                 "--output-format", "concise",
                 "--flow-use-t0-tag",
                 "-E", "FBA",

--- a/src/test/resources/large/featureMapping/alignReadsToHaplotypesTest.bam
+++ b/src/test/resources/large/featureMapping/alignReadsToHaplotypesTest.bam
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cc7c5e25bd63fe149b36e4cfd4208a75ef237759b6e463cef8708e986e6139b
+size 27990

--- a/src/test/resources/large/featureMapping/alignReadsToHaplotypesTest.fa
+++ b/src/test/resources/large/featureMapping/alignReadsToHaplotypesTest.fa
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4c282131b44132675b85c9653ae5bb1ded1935c3addc5f8c6c6ea509866cafd
+size 353955

--- a/src/test/resources/large/featureMapping/read_to_hap_concise.txt
+++ b/src/test/resources/large/featureMapping/read_to_hap_concise.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec18069e6f9f4f2ce38a4e7b6d84e782cebd9d65e4d7cf61fb025981f714a3e7
+size 5729

--- a/src/test/resources/large/featureMapping/read_to_hap_expanded.txt
+++ b/src/test/resources/large/featureMapping/read_to_hap_expanded.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b883ea34f0f741cf4046535f4644545a63eaf66699cd94cc7792d0ae05fe62cb
+size 1165603


### PR DESCRIPTION
This tool is useful for alignment of the reads to a large set of templates that are very close in sequence. In this case the alignment is close to the problem that the HaplotypeCaller is solving - of calculating the likelihood of the read compared to a set of close haplotypes. 
The tool outputs read x haplotype matrix for a set of reads and haplotypes using either FlowPairHMM or FlowBasedAlignmentEngine