### PR TITLE
No empty alts if you please [VS-918]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -216,7 +216,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_866_update_variants_base_image
    - name: GvsQuickstartHailIntegration
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsQuickstartHailIntegration.wdl
@@ -224,7 +223,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - rc-vs-853-adopt-hail-python-code
    - name: GvsQuickstartIntegration
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
@@ -232,7 +230,7 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - vs_908_monitoring_script_public
+         - vs_918_vat_alt_allele_feud
    - name: GvsIngestTieout
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsIngestTieout.wdl

--- a/scripts/variantstore/docs/Build Docker from VM/building_gatk_docker_on_a_vm.md
+++ b/scripts/variantstore/docs/Build Docker from VM/building_gatk_docker_on_a_vm.md
@@ -9,7 +9,7 @@ Azure virtual machine, though much of this would likely apply to Google Cloud (o
 Through the [Azure portal](https://portal.azure.com/) allocate a VM in the Variants subscription. I used a Standard
 E4-2ads v5 (2 vcpus, 32 GiB memory) for this purpose:
 
-![Azure VM for building Docker image](Azure VM for building Docker image.png)
+![Azure VM for building Docker image](./Azure VM for building Docker image.png)
 
 Generate a new SSH key when prompted and save this to a safe location as you will need it soon. 
 

--- a/scripts/variantstore/variant_annotations_table/README.md
+++ b/scripts/variantstore/variant_annotations_table/README.md
@@ -25,7 +25,7 @@ When the script is done running it will print out the path to where it has writt
 
 ### Run GvsCreateVATfromVDS
 
-Note: in order for this workflow to run successfully the 'Use reference disks' option must be selected in Terra workflow
+**Note:** in order for this workflow to run successfully the 'Use reference disks' option must be selected in Terra workflow
 configuration. If this option is not selected the `AnnotateVCF` tasks will refuse to run.
 
 Most of the inputs are specific to where the VAT will live or will be the same for the VDS creation, like the `project_id`, `dataset_name`, `filter_set_name`, and `output_path`. This workflow does not use the Terra Data Entity Model to run, so be sure to select the `Run workflow with inputs defined by file paths` workflow submission option. For the specific data being put in the VAT, two inputs need to be copied into a GCP bucket that this pipeline will have access to and passed to the WDL:

--- a/scripts/variantstore/variant_annotations_table/README.md
+++ b/scripts/variantstore/variant_annotations_table/README.md
@@ -2,8 +2,8 @@
 
 ### The VAT pipeline is a python script and a set of WDLs
 
-- hail_create_vat_inputs.py is a script to be run in a notebook terminal to generate a sites-only VCF.
-- [GvsCreateVATfromVDS.wdl](/scripts/variantstore/wdl/GvsCreateVATfromVDS.wdl) creates the variant annotations table from a sites only VCF and an acestry file TSV.
+- [hail_create_vat_inputs.py](https://raw.githubusercontent.com/broadinstitute/gatk/ah_var_store/scripts/variantstore/wdl/extract/hail_create_vat_inputs.py) is a script to be run in a notebook terminal to generate a sites-only VCF.
+- [GvsCreateVATfromVDS.wdl](/scripts/variantstore/wdl/GvsCreateVATfromVDS.wdl) creates the variant annotations table from a sites only VCF and an ancestry file TSV.
 - [GvsValidateVAT.wdl](/scripts/variantstore/variant_annotations_table/GvsValidateVAT.wdl) checks and validates the created VAT and prints a report of any failing validation.
 
 The pipeline takes in a Hail Variant Dataset (VDS), creates a queryable table in BigQuery, and outputs a bgzipped TSV file containing the contents of that table. That TSV file is the sole AoU deliverable.
@@ -12,18 +12,21 @@ The pipeline takes in a Hail Variant Dataset (VDS), creates a queryable table in
 
 You will want to set up a [notebook in a similar configuration](../docs/aou/vds/cluster/AoU%20Delta%20VDS%20Cluster%20Configuration.md) as you did for creating the VAT (minus the custom wheel) and then copy two python scripts for running locally in the notebook. The two scripts are:
 
-* create_vat_inputs.py which you can get via `curl https://raw.githubusercontent.com/broadinstitute/gatk/ah_var_store/scripts/variantstore/wdl/extract/create_vat_inputs.py -o create_vat_inputs.py`
-* the `hail_create_vat_inputs_script` output from the task `GenerateHailScripts`from the run of`GvsExtractAvroFilesForHail` workflow that was used to generate the VDS.
+* `create_vat_inputs.py` which you can get via `curl -O https://raw.githubusercontent.com/broadinstitute/gatk/ah_var_store/scripts/variantstore/wdl/extract/create_vat_inputs.py`
+* The `hail_create_vat_inputs.py` output from the task `GenerateHailScripts` from the run of `GvsExtractAvroFilesForHail` workflow that was used to generate the VDS.
 
-Once you have copied them, run `python3 hail_create_vat_inputs.py` with the following input(s)
+Once you have copied them, run `python3 hail_create_vat_inputs.py` with the following input(s):
 
-* `--ancestry_file` GCS pointer to the TSV file that maps `sample_name`s to sub-populations
-* `--vds_path` GCS pointer to the top-level directory of the VDS
-* `--sites_only_vcf` (optional, should be pre-populated by the `GvsExtractAvroFilesForHail` workflow) the location to write the sites-only VCF to; save this for the `GvsCreateVATfromVDS` workflow
+* `--ancestry_input_path` Required, GCS path of the TSV file that maps `sample_name`s to subpopulations.
+* `--vds_input_path` Optional, should be pre-populated by the `GvsExtractAvroFilesForHail` workflow. GCS path of the top-level directory of the VDS.
+* `--sites_only_output_path` Optional, should be pre-populated by the `GvsExtractAvroFilesForHail` workflow. GCS path to write the sites-only VCF to; save this for the `GvsCreateVATfromVDS` workflow.
 
-When the script is done running, it will spit out the path to where it has written the sites-only VCF.
+When the script is done running it will print out the path to where it has written the sites-only VCF.
 
 ### Run GvsCreateVATfromVDS
+
+Note: in order for this workflow to run successfully the 'Use reference disks' option must be selected in Terra workflow
+configuration. If this option is not selected the `AnnotateVCF` tasks will refuse to run.
 
 Most of the inputs are specific to where the VAT will live or will be the same for the VDS creation, like the `project_id`, `dataset_name`, `filter_set_name`, and `output_path`. This workflow does not use the Terra Data Entity Model to run, so be sure to select the `Run workflow with inputs defined by file paths` workflow submission option. For the specific data being put in the VAT, two inputs need to be copied into a GCP bucket that this pipeline will have access to and passed to the WDL:
 

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -128,7 +128,7 @@ workflow GvsBulkIngestGenomes {
         >>>
 
         runtime {
-            docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-08-alpine"
+            docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-17-alpine"
             memory: "3 GB"
             disks: "local-disk 10 HDD"
             cpu: 1
@@ -162,7 +162,7 @@ workflow GvsBulkIngestGenomes {
 
         >>>
         runtime {
-            docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-08-alpine"
+            docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-17-alpine"
             memory: "3 GB"
             disks: "local-disk 10 HDD"
             cpu: 1

--- a/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
+++ b/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
@@ -271,7 +271,7 @@ task Add_AS_MAX_VQS_FIELD_ToVcf {
     String output_basename
     Boolean use_classic_VQSR
 
-    String docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
+    String docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
     Int cpu = 1
     Int memory_mb = 3500
     Int disk_size_gb = ceil(2*size(input_vcf, "GiB")) + 50

--- a/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
+++ b/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
@@ -271,7 +271,7 @@ task Add_AS_MAX_VQS_FIELD_ToVcf {
     String output_basename
     Boolean use_classic_VQSR
 
-    String docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-04-13-alpine"
+    String docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
     Int cpu = 1
     Int memory_mb = 3500
     Int disk_size_gb = ceil(2*size(input_vcf, "GiB")) + 50

--- a/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
+++ b/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
@@ -271,7 +271,7 @@ task Add_AS_MAX_VQS_FIELD_ToVcf {
     String output_basename
     Boolean use_classic_VQSR
 
-    String docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
+    String docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
     Int cpu = 1
     Int memory_mb = 3500
     Int disk_size_gb = ceil(2*size(input_vcf, "GiB")) + 50

--- a/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
+++ b/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
@@ -271,7 +271,7 @@ task Add_AS_MAX_VQS_FIELD_ToVcf {
     String output_basename
     Boolean use_classic_VQSR
 
-    String docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
+    String docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-05-17-alpine"
     Int cpu = 1
     Int memory_mb = 3500
     Int disk_size_gb = ceil(2*size(input_vcf, "GiB")) + 50

--- a/scripts/variantstore/wdl/GvsCallsetCost.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetCost.wdl
@@ -62,7 +62,7 @@ task WorkflowComputeCosts {
     >>>
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
     }
 
     output {

--- a/scripts/variantstore/wdl/GvsCallsetCost.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetCost.wdl
@@ -62,7 +62,7 @@ task WorkflowComputeCosts {
     >>>
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-04-13-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
     }
 
     output {

--- a/scripts/variantstore/wdl/GvsCallsetCost.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetCost.wdl
@@ -62,7 +62,7 @@ task WorkflowComputeCosts {
     >>>
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
     }
 
     output {

--- a/scripts/variantstore/wdl/GvsCallsetCost.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetCost.wdl
@@ -62,7 +62,7 @@ task WorkflowComputeCosts {
     >>>
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-17-alpine"
     }
 
     output {

--- a/scripts/variantstore/wdl/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVATfromVDS.wdl
@@ -167,7 +167,7 @@ task MakeSubpopulationFilesAndReadSchemaFiles {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-04-13-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -212,7 +212,7 @@ task StripCustomAnnotationsFromSitesOnlyVCF {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-04-13-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
         memory: "7 GiB"
         cpu: "2"
         preemptible: 3
@@ -297,7 +297,7 @@ task RemoveDuplicatesFromSitesOnlyVCF {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-04-13-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
         maxRetries: 3
         memory: "16 GB"
         preemptible: 3
@@ -457,7 +457,7 @@ task PrepVtAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-04-13-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
         memory: "7 GB"
         preemptible: 3
         cpu: "1"
@@ -503,7 +503,7 @@ task PrepGenesAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-04-13-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
         memory: "7 GB"
         preemptible: 3
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVATfromVDS.wdl
@@ -167,7 +167,7 @@ task MakeSubpopulationFilesAndReadSchemaFiles {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -212,7 +212,7 @@ task StripCustomAnnotationsFromSitesOnlyVCF {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
         memory: "7 GiB"
         cpu: "2"
         preemptible: 3
@@ -297,7 +297,7 @@ task RemoveDuplicatesFromSitesOnlyVCF {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
         maxRetries: 3
         memory: "16 GB"
         preemptible: 3
@@ -457,7 +457,7 @@ task PrepVtAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
         memory: "7 GB"
         preemptible: 3
         cpu: "1"
@@ -503,7 +503,7 @@ task PrepGenesAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
         memory: "7 GB"
         preemptible: 3
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVATfromVDS.wdl
@@ -167,7 +167,7 @@ task MakeSubpopulationFilesAndReadSchemaFiles {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-17-alpine"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -212,7 +212,7 @@ task StripCustomAnnotationsFromSitesOnlyVCF {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-17-alpine"
         memory: "7 GiB"
         cpu: "2"
         preemptible: 3
@@ -297,7 +297,7 @@ task RemoveDuplicatesFromSitesOnlyVCF {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-17-alpine"
         maxRetries: 3
         memory: "16 GB"
         preemptible: 3
@@ -457,7 +457,7 @@ task PrepVtAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-17-alpine"
         memory: "7 GB"
         preemptible: 3
         cpu: "1"
@@ -503,7 +503,7 @@ task PrepGenesAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-17-alpine"
         memory: "7 GB"
         preemptible: 3
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVATfromVDS.wdl
@@ -167,7 +167,7 @@ task MakeSubpopulationFilesAndReadSchemaFiles {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
         memory: "1 GB"
         preemptible: 3
         cpu: "1"
@@ -212,7 +212,7 @@ task StripCustomAnnotationsFromSitesOnlyVCF {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
         memory: "7 GiB"
         cpu: "2"
         preemptible: 3
@@ -297,7 +297,7 @@ task RemoveDuplicatesFromSitesOnlyVCF {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
         maxRetries: 3
         memory: "16 GB"
         preemptible: 3
@@ -457,7 +457,7 @@ task PrepVtAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
         memory: "7 GB"
         preemptible: 3
         cpu: "1"
@@ -503,7 +503,7 @@ task PrepGenesAnnotationJson {
     # ------------------------------------------------
     # Runtime settings:
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
         memory: "7 GB"
         preemptible: 3
         cpu: "1"

--- a/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
+++ b/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
@@ -157,7 +157,7 @@ task ExtractFromNonSuperpartitionedTables {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-04-13-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
         disks: "local-disk 500 HDD"
     }
 }
@@ -225,7 +225,7 @@ task ExtractFromSuperpartitionedTables {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-04-13-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
         disks: "local-disk 500 HDD"
     }
 }

--- a/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
+++ b/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
@@ -157,7 +157,7 @@ task ExtractFromNonSuperpartitionedTables {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
         disks: "local-disk 500 HDD"
     }
 }
@@ -225,7 +225,7 @@ task ExtractFromSuperpartitionedTables {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
         disks: "local-disk 500 HDD"
     }
 }

--- a/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
+++ b/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
@@ -157,7 +157,7 @@ task ExtractFromNonSuperpartitionedTables {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
         disks: "local-disk 500 HDD"
     }
 }
@@ -225,7 +225,7 @@ task ExtractFromSuperpartitionedTables {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
         disks: "local-disk 500 HDD"
     }
 }
@@ -293,7 +293,7 @@ task GenerateHailScripts {
         File hail_create_vat_inputs_script = 'hail_create_vat_inputs.py'
     }
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-05-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
         disks: "local-disk 500 HDD"
     }
 }

--- a/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
+++ b/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
@@ -157,7 +157,7 @@ task ExtractFromNonSuperpartitionedTables {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-17-alpine"
         disks: "local-disk 500 HDD"
     }
 }
@@ -225,7 +225,7 @@ task ExtractFromSuperpartitionedTables {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-17-alpine"
         disks: "local-disk 500 HDD"
     }
 }
@@ -293,7 +293,7 @@ task GenerateHailScripts {
         File hail_create_vat_inputs_script = 'hail_create_vat_inputs.py'
     }
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-17-alpine"
         disks: "local-disk 500 HDD"
     }
 }

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -489,7 +489,7 @@ task CurateInputLists {
                                              --output_files True
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -489,7 +489,7 @@ task CurateInputLists {
                                              --output_files True
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-17-alpine"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -489,7 +489,7 @@ task CurateInputLists {
                                              --output_files True
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -489,7 +489,7 @@ task CurateInputLists {
                                              --output_files True
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-04-13-alpine"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
@@ -243,7 +243,7 @@ task PopulateAltAlleleTable {
     done
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-17-alpine"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     cpu: 1

--- a/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
@@ -243,7 +243,7 @@ task PopulateAltAlleleTable {
     done
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-04-13-alpine"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     cpu: 1

--- a/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
@@ -243,7 +243,7 @@ task PopulateAltAlleleTable {
     done
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     cpu: 1

--- a/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
@@ -243,7 +243,7 @@ task PopulateAltAlleleTable {
     done
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     cpu: 1

--- a/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
@@ -69,7 +69,7 @@ task GenerateFOFNsFromDataTables {
 
     >>>
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-03-23-bulk-ingest"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
         memory: "3 GB"
         disks: "local-disk 200 HDD"
         cpu: 1

--- a/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareBulkImport.wdl
@@ -69,7 +69,7 @@ task GenerateFOFNsFromDataTables {
 
     >>>
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-17-alpine"
         memory: "3 GB"
         disks: "local-disk 200 HDD"
         cpu: 1

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -114,7 +114,7 @@ task PrepareRangesCallsetTask {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -114,7 +114,7 @@ task PrepareRangesCallsetTask {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-04-13-alpine"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -114,7 +114,7 @@ task PrepareRangesCallsetTask {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -114,7 +114,7 @@ task PrepareRangesCallsetTask {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-17-alpine"
     memory: "3 GB"
     disks: "local-disk 100 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -381,7 +381,7 @@ task ScaleXYBedValues {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
         maxRetries: 3
         memory: "7 GB"
         preemptible: 3
@@ -666,7 +666,7 @@ task SummarizeTaskMonitorLogs {
   # ------------------------------------------------
   # Runtime settings:
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-04-10-alpine"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
     memory: "1 GB"
     preemptible: 3
     cpu: "1"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -381,7 +381,7 @@ task ScaleXYBedValues {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-04-13-alpine"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
         maxRetries: 3
         memory: "7 GB"
         preemptible: 3

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -381,7 +381,7 @@ task ScaleXYBedValues {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-17-alpine"
         maxRetries: 3
         memory: "7 GB"
         preemptible: 3
@@ -666,7 +666,7 @@ task SummarizeTaskMonitorLogs {
   # ------------------------------------------------
   # Runtime settings:
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-12-alpine-vs-918"
+    docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-17-alpine"
     memory: "1 GB"
     preemptible: 3
     cpu: "1"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -381,7 +381,7 @@ task ScaleXYBedValues {
     }
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918"
+        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-05-11-alpine-vs-918_01"
         maxRetries: 3
         memory: "7 GB"
         preemptible: 3

--- a/scripts/variantstore/wdl/extract/alt_allele_temp_function.sql
+++ b/scripts/variantstore/wdl/extract/alt_allele_temp_function.sql
@@ -12,4 +12,4 @@ RETURNS STRING
       }
   }
   return ref + ',' + allele
-    """;
+  """;

--- a/scripts/variantstore/wdl/extract/alt_allele_temp_function.sql
+++ b/scripts/variantstore/wdl/extract/alt_allele_temp_function.sql
@@ -1,14 +1,15 @@
 CREATE TEMPORARY FUNCTION minimize(ref STRING, allele STRING)
 RETURNS STRING
   LANGUAGE js AS """
+
   let done = false
-    while (!done && ref.length !== 1) {
-        if (ref.slice(-1) === allele.slice(-1)) {
-            ref = ref.slice(0, -1)
-	    allele = allele.slice(0,-1)
-        } else {
-            done = true
-        }
-    }
-    return ref+','+allele
+  while (!done && ref.length !== 1 && alt.length !== 1) {
+      if (ref.slice(-1) === allele.slice(-1)) {
+          ref = ref.slice(0, -1)
+	      allele = allele.slice(0,-1)
+      } else {
+        done = true
+      }
+  }
+  return ref + ',' + allele
     """;

--- a/scripts/variantstore/wdl/extract/alt_allele_temp_function.sql
+++ b/scripts/variantstore/wdl/extract/alt_allele_temp_function.sql
@@ -3,7 +3,7 @@ RETURNS STRING
   LANGUAGE js AS """
 
   let done = false
-  while (!done && ref.length !== 1 && alt.length !== 1) {
+  while (!done && ref.length !== 1 && allele.length !== 1) {
       if (ref.slice(-1) === allele.slice(-1)) {
           ref = ref.slice(0, -1)
 	      allele = allele.slice(0,-1)

--- a/scripts/variantstore/wdl/extract/hail_create_vat_inputs.py
+++ b/scripts/variantstore/wdl/extract/hail_create_vat_inputs.py
@@ -181,15 +181,14 @@ def write_tie_out_vcf(vds, vcf_output_path):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(allow_abbrev=False, description='Create VAT inputs TSV')
-    parser.add_argument('--ancestry_file', type=str, help='Input ancestry file', required=True)
-    parser.add_argument('--vds_path', type=str, help='Input VDS Path', default="@VDS_INPUT_PATH@") #TODO: names feel confusing to me that this is an input and the next two are outputs?
-    parser.add_argument('--sites_only_vcf', type=str, help='Output sites-only VCF file',
+    parser.add_argument('--ancestry_input_path', type=str, help='Input ancestry file path', required=True)
+    parser.add_argument('--vds_input_path', type=str, help='Input VDS path', default="@VDS_INPUT_PATH@")
+    parser.add_argument('--sites_only_output_path', type=str, help='Output sites-only VCF path',
                         default="@SITES_ONLY_VCF_OUTPUT_PATH@")
 
     args = parser.parse_args()
 
     vds = hl.vds.read_vds(args.vds_path)
-    # write_sites_only_vcf(vds, args.sites_only_vcf)
     local_ancestry_file = create_vat_inputs.download_ancestry_file(args.ancestry_file)
 
     main(vds, local_ancestry_file, args.sites_only_vcf)


### PR DESCRIPTION
The empty alts that results from overtrimming in an alt allele UDF correlate strongly with VAT / alt allele mismatches, but from trial runs with and without this patch they don't seem to actually be causing the mismatches. Nonetheless I think this is a desirable change as it keeps VAT VIDs from getting weird. VIDs have the format `<contig>-<position>-<ref>-<alt>`; if the alt is empty the VID just ends in a dash which just seems like an edge case waiting to break something.