### PR TITLE
Move to using GenomicsDB 1.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ final barclayVersion = System.getProperty('barclay.version','5.0.0')
 final sparkVersion = System.getProperty('spark.version', '3.3.1')
 final hadoopVersion = System.getProperty('hadoop.version', '3.3.1')
 final disqVersion = System.getProperty('disq.version','0.3.6')
-final genomicsdbVersion = System.getProperty('genomicsdb.version','1.4.4')
+final genomicsdbVersion = System.getProperty('genomicsdb.version','1.5.0')
 final bigQueryVersion = System.getProperty('bigQuery.version', '2.9.0')
 final bigQueryStorageVersion = System.getProperty('bigQueryStorage.version', '2.9.1')
 final guavaVersion = System.getProperty('guava.version', '31.0.1-jre')
@@ -242,8 +242,6 @@ dependencies {
     implementation ('org.genomicsdb:genomicsdb:' + genomicsdbVersion)  {
         exclude module: 'log4j-api'
         exclude module: 'log4j-core'
-        exclude module: 'spark-core_2.12'
-        exclude module: 'spark-sql_2.12'
         exclude module: 'htsjdk'
         exclude module: 'protobuf-java'
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GATKGenomicsDBUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GATKGenomicsDBUtils.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.hellbender.tools.genomicsdb;
 
-import com.googlecode.protobuf.format.JsonFormat;
+import com.google.protobuf.util.JsonFormat;
 import htsjdk.samtools.util.FileExtensions;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.walkers.annotator.AnnotationUtils;
@@ -169,7 +169,7 @@ public class GATKGenomicsDBUtils {
     public static GenomicsDBVidMapProto.VidMappingPB getProtobufVidMappingFromJsonFile(final String vidmapJson)
             throws IOException {
         final GenomicsDBVidMapProto.VidMappingPB.Builder vidMapBuilder = GenomicsDBVidMapProto.VidMappingPB.newBuilder();
-        JsonFormat.merge(readEntireFile(vidmapJson), vidMapBuilder);
+        JsonFormat.parser().merge(readEntireFile(vidmapJson), vidMapBuilder);
         return vidMapBuilder.build();
     }
 


### PR DESCRIPTION
Move to using [GenomicsDB Release 1.5.0](https://github.com/GenomicsDB/GenomicsDB/releases/v1.5.0). 
Highlights in the release relevant to gatk are
-  [readthedocs](https://genomicsdb.readthedocs.io/en/latest/) for GenomicsDB design/usage/functionality - GenomicsDB/GenomicsDB#265.
- GenomicsDB/GenomicsDB#284
- GenomicsDB/GenomicsDB#271
- Exclude spark from genomicsdb core jar GenomicsDB/GenomicsDB#281
- General improved performance/logging.