### PR TITLE
Non-GVS bits required for GVS [VS-971]

### DIFF
--- a/scripts/vcf_site_level_filtering_cromwell_tests/run_vcf_site_level_filtering_wdl.sh
+++ b/scripts/vcf_site_level_filtering_cromwell_tests/run_vcf_site_level_filtering_wdl.sh
@@ -32,6 +32,13 @@ sed -r "s/__GATK_DOCKER__/broadinstitute\/gatk\:$HASH_TO_USE/g" $CROMWELL_TEST_D
 
 echo "Running Filtering WDL through cromwell"
 
+cat > ${WORKING_DIR}/src/test/resources/cromwell_monitoring_script.sh <<FIN
+while true
+do
+   echo 'dummy monitoring script running...'
+   sleep 10
+done
+FIN
 cat $WORKING_DIR/vcf_site_level_filtering_mod.json
 java -jar $CROMWELL_JAR run $WDL_DIR/JointVcfFiltering.wdl -i $WORKING_DIR/vcf_site_level_filtering_mod.json
 

--- a/scripts/vcf_site_level_filtering_cromwell_tests/vcf_site_level_filtering.json
+++ b/scripts/vcf_site_level_filtering_cromwell_tests/vcf_site_level_filtering.json
@@ -13,5 +13,6 @@
   "JointVcfFiltering.annotations": ["ReadPosRankSum", "FS", "SOR", "QD"],
   "JointVcfFiltering.output_prefix": "test_10_samples",
   "JointVcfFiltering.resource_args": "--resource:hapmap,training=true,calibration=true gs://gcp-public-data--broad-references/hg38/v0/hapmap_3.3.hg38.vcf.gz --resource:omni,training=true,calibration=true gs://gcp-public-data--broad-references/hg38/v0/1000G_omni2.5.hg38.vcf.gz --resource:1000G,training=true gs://gcp-public-data--broad-references/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz --resource:mills,training=true,calibration=true gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
-  "JointVcfFiltering.extract_extra_args": "-L chr21"
+  "JointVcfFiltering.extract_extra_args": "-L chr21",
+  "JointVcfFiltering.monitoring_script": "/home/runner/work/gatk/gatk/src/test/resources/cromwell_monitoring_script.sh"
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/gvs/bigquery/BigQueryResultAndStatistics.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gvs/bigquery/BigQueryResultAndStatistics.java
@@ -1,4 +1,4 @@
-package org.broadinstitute.hellbender.utils.bigquery;
+package org.broadinstitute.hellbender.utils.gvs.bigquery;
 
 import com.google.cloud.bigquery.JobStatistics;
 import com.google.cloud.bigquery.TableResult;

--- a/src/main/java/org/broadinstitute/hellbender/utils/gvs/bigquery/BigQueryUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gvs/bigquery/BigQueryUtils.java
@@ -451,6 +451,19 @@ public final class BigQueryUtils {
     }
 
     public static boolean doRowsExistFor(String projectID, String datasetName, String tableName, String columnName, String value) {
+        String template = "SELECT COUNT(*) FROM `%s.%s.%s` WHERE %s = '%s'";
+        String query = String.format(template, projectID, datasetName, tableName, columnName, value);
+
+        BigQueryResultAndStatistics resultAndStatistics = BigQueryUtils.executeQuery(projectID, query, true, null);
+        for (final FieldValueList row : resultAndStatistics.result.iterateAll()) {
+            final long count = row.get(0).getLongValue();
+            return count != 0;
+        }
+        throw new GATKException(String.format("No rows returned from count of `%s.%s.%s` for %s = '%s'",
+                projectID, datasetName, tableName, columnName, value));
+    }
+
+    public static boolean doRowsExistFor(String projectID, String datasetName, String tableName, String columnName, Long value) {
         String template = "SELECT COUNT(*) FROM `%s.%s.%s` WHERE %s = %s";
         String query = String.format(template, projectID, datasetName, tableName, columnName, value);
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/gvs/bigquery/BigQueryUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gvs/bigquery/BigQueryUtils.java
@@ -1,4 +1,4 @@
-package org.broadinstitute.hellbender.utils.bigquery;
+package org.broadinstitute.hellbender.utils.gvs.bigquery;
 
 import com.google.cloud.bigquery.*;
 import io.grpc.StatusRuntimeException;

--- a/src/main/java/org/broadinstitute/hellbender/utils/gvs/bigquery/GATKAvroReader.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gvs/bigquery/GATKAvroReader.java
@@ -1,4 +1,4 @@
-package org.broadinstitute.hellbender.utils.bigquery;
+package org.broadinstitute.hellbender.utils.gvs.bigquery;
 
 import htsjdk.samtools.util.CloseableIterator;
 import org.apache.avro.generic.GenericRecord;

--- a/src/main/java/org/broadinstitute/hellbender/utils/gvs/bigquery/StorageAPIAvroReader.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gvs/bigquery/StorageAPIAvroReader.java
@@ -1,4 +1,4 @@
-package org.broadinstitute.hellbender.utils.bigquery;
+package org.broadinstitute.hellbender.utils.gvs.bigquery;
 
 import com.google.cloud.bigquery.storage.v1.AvroRows;
 import com.google.cloud.bigquery.storage.v1.BigQueryReadClient;

--- a/src/main/java/org/broadinstitute/hellbender/utils/gvs/bigquery/StorageAPIAvroReaderAndBigQueryStatistics.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gvs/bigquery/StorageAPIAvroReaderAndBigQueryStatistics.java
@@ -1,4 +1,4 @@
-package org.broadinstitute.hellbender.utils.bigquery;
+package org.broadinstitute.hellbender.utils.gvs.bigquery;
 
 import com.google.cloud.bigquery.JobStatistics;
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/gvs/bigquery/TableReference.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gvs/bigquery/TableReference.java
@@ -1,4 +1,4 @@
-package org.broadinstitute.hellbender.utils.bigquery;
+package org.broadinstitute.hellbender.utils.gvs.bigquery;
 
 import com.google.common.collect.ImmutableList;
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFConstants.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFConstants.java
@@ -208,7 +208,9 @@ public final class GATKVCFConstants {
     public static final String VQSR_FAILURE_PREFIX = "low_VQSLOD_";
     public static final String VQSR_FAILURE_SNP = VQSR_FAILURE_PREFIX + SNP;
     public static final String VQSR_FAILURE_INDEL = VQSR_FAILURE_PREFIX + INDEL;
-    public static final String VQS_SENS_FAILURE_PREFIX = "low_VQS_SENS_";
+    // Prefix for a site (SNP/INDEL) that failed calibration sensitivity cutoff. In this case, the site would be a
+    // failure if the sensitivity is greater than the threshold.
+    public static final String VQS_SENS_FAILURE_PREFIX = "high_VQS_SENS_";
     public static final String VQS_SENS_FAILURE_SNP = VQS_SENS_FAILURE_PREFIX + SNP;
     public static final String VQS_SENS_FAILURE_INDEL = VQS_SENS_FAILURE_PREFIX + INDEL;
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/gvs/bigquery/BigQueryUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/gvs/bigquery/BigQueryUtilsUnitTest.java
@@ -1,4 +1,4 @@
-package org.broadinstitute.hellbender.utils.bigquery;
+package org.broadinstitute.hellbender.utils.gvs.bigquery;
 
 import com.google.cloud.bigquery.FieldValueList;
 import org.apache.avro.generic.GenericRecord;


### PR DESCRIPTION
A collection of changes in non-GVS packages required to build a working version of GVS against master:

1. Support for an optional monitoring script for VQSR Lite `JointVcfFiltering.wdl`.
2. `VQS_SENS_FAILURE_PREFIX ` VCF header value updated for correctness.
3. Moved all BigQuery classes under a `gvs` package to make clear these are currently considered to be GVS specific.
4. Added method to BigQueryUtils.
5. ~ExcessHet calculation fixes for the case of no PLs.~ Removed, no longer required with Annotation changes in `ExtractTool`.