### PR TITLE
Update SV split-read strand validation and clustering

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/SVCallRecord.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/SVCallRecord.java
@@ -163,8 +163,8 @@ public class SVCallRecord implements SVLocatable {
                                        final int positionA,
                                        final int positionB,
                                        final Integer inputLength) {
-        if (type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.CNV) || type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL)
-                || type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP) || type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.INV)) {
+        if (type == GATKSVVCFConstants.StructuralVariantAnnotationType.CNV || type == GATKSVVCFConstants.StructuralVariantAnnotationType.DEL
+                || type == GATKSVVCFConstants.StructuralVariantAnnotationType.DUP || type == GATKSVVCFConstants.StructuralVariantAnnotationType.INV) {
             // Intrachromosomal classes
             final int length = CoordMath.getLength(positionA, positionB);
             if (inputLength != null) {
@@ -183,7 +183,7 @@ public class SVCallRecord implements SVLocatable {
     /**
      * Determines strands for the variant. For SV classes with implicit strand orientations (e.g. DEL, DUP) or that have
      * multiple strand types on each end (i.e. CNVs which are either DEL/DUP which are +/- and -/+), inferred strands
-     * are null. For INV and BND both input strands must be non-null. Additionally, INV types must have equal strands.
+     * are null.
      * @param type SV type
      * @param inputStrandA assumed first strand, may be null
      * @param inputStrandB assumed second strand, may be null
@@ -192,10 +192,10 @@ public class SVCallRecord implements SVLocatable {
     private static Pair<Boolean, Boolean> inferStrands(final GATKSVVCFConstants.StructuralVariantAnnotationType type,
                                                        final Boolean inputStrandA,
                                                        final Boolean inputStrandB) {
-        if (type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.CNV)) {
+        if (type == GATKSVVCFConstants.StructuralVariantAnnotationType.CNV) {
             Utils.validateArg(inputStrandA == null && inputStrandB == null, "Attempted to create CNV with non-null strands");
             return Pair.of(null, null);
-        } else if (type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL)) {
+        } else if (type == GATKSVVCFConstants.StructuralVariantAnnotationType.DEL) {
             if (inputStrandA != null) {
                 Utils.validateArg(inputStrandA.booleanValue() == true, "Attempted to create DEL with negative first strand");
             }
@@ -203,7 +203,7 @@ public class SVCallRecord implements SVLocatable {
                 Utils.validateArg(inputStrandB.booleanValue() == false, "Attempted to create DEL with positive second strand");
             }
             return Pair.of(Boolean.TRUE, Boolean.FALSE);
-        } else if (type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP)) {
+        } else if (type == GATKSVVCFConstants.StructuralVariantAnnotationType.DUP) {
             if (inputStrandA != null) {
                 Utils.validateArg(inputStrandA.booleanValue() == false, "Attempted to create DUP with positive first strand");
             }

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/SVCallRecord.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/SVCallRecord.java
@@ -195,12 +195,12 @@ public class SVCallRecord implements SVLocatable {
         if (type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.CNV)) {
             Utils.validateArg(inputStrandA == null && inputStrandB == null, "Attempted to create CNV with non-null strands");
             return Pair.of(null, null);
-        } else if (type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL) || type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.INS)) {
+        } else if (type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL)) {
             if (inputStrandA != null) {
-                Utils.validateArg(inputStrandA.booleanValue() == true, "Attempted to create DEL/INS with negative first strand");
+                Utils.validateArg(inputStrandA.booleanValue() == true, "Attempted to create DEL with negative first strand");
             }
             if (inputStrandB != null) {
-                Utils.validateArg(inputStrandB.booleanValue() == false, "Attempted to create DEL/INS with positive second strand");
+                Utils.validateArg(inputStrandB.booleanValue() == false, "Attempted to create DEL with positive second strand");
             }
             return Pair.of(Boolean.TRUE, Boolean.FALSE);
         } else if (type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP)) {
@@ -212,10 +212,6 @@ public class SVCallRecord implements SVLocatable {
             }
             return Pair.of(Boolean.FALSE, Boolean.TRUE);
         } else {
-            if (type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.INV)) {
-                Utils.validateArg(Objects.equals(inputStrandA, inputStrandB), "Inversions must have matching strands but found " +
-                        inputStrandA + " / " + inputStrandB);
-            }
             return Pair.of(inputStrandA, inputStrandB);
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/SVCallRecordUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/SVCallRecordUtils.java
@@ -96,7 +96,8 @@ public final class SVCallRecordUtils {
 
         builder.attribute(GATKSVVCFConstants.SVLEN, record.getLength());
         if ((svtype.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.BND)
-                || svtype.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.INV))
+                || svtype.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.INV)
+                || svtype.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.INS))
                 && record.getStrandA() != null && record.getStrandB() != null) {
             builder.attribute(GATKSVVCFConstants.STRANDS_ATTRIBUTE, getStrandString(record));
         }
@@ -334,7 +335,6 @@ public final class SVCallRecordUtils {
 
         final String strands;
         if (type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL)
-                || type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.INS)
                 || type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.CNV)
                 || type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP)) {
             // SVCallRecord class can resolve these
@@ -386,8 +386,8 @@ public final class SVCallRecordUtils {
         } else {
             contigB = contigA;
             // Force reset of END coordinate
-            if (type.equals(StructuralVariantType.INS)) {
-                positionB = positionA + 1;
+            if (type == GATKSVVCFConstants.StructuralVariantAnnotationType.INS) {
+                positionB = positionA;
             } else {
                 positionB = variant.getEnd();
             }

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/SVCallRecordUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/SVCallRecordUtils.java
@@ -95,9 +95,9 @@ public final class SVCallRecordUtils {
         }
 
         builder.attribute(GATKSVVCFConstants.SVLEN, record.getLength());
-        if ((svtype.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.BND)
-                || svtype.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.INV)
-                || svtype.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.INS))
+        if ((svtype == GATKSVVCFConstants.StructuralVariantAnnotationType.BND
+                || svtype == GATKSVVCFConstants.StructuralVariantAnnotationType.INV
+                || svtype == GATKSVVCFConstants.StructuralVariantAnnotationType.INS)
                 && record.getStrandA() != null && record.getStrandB() != null) {
             builder.attribute(GATKSVVCFConstants.STRANDS_ATTRIBUTE, getStrandString(record));
         }
@@ -295,7 +295,7 @@ public final class SVCallRecordUtils {
      * @return stream of BND records pair, or the original record if not an INV
      */
     public static Stream<SVCallRecord> convertInversionsToBreakends(final SVCallRecord record, final SAMSequenceDictionary dictionary) {
-        if (!record.getType().equals(GATKSVVCFConstants.StructuralVariantAnnotationType.INV)) {
+        if (record.getType() != GATKSVVCFConstants.StructuralVariantAnnotationType.INV) {
             return Stream.of(record);
         }
         Utils.validateArg(record.isIntrachromosomal(), "Inversion " + record.getId() + " is not intrachromosomal");
@@ -334,9 +334,9 @@ public final class SVCallRecordUtils {
         final List<String> algorithms = getAlgorithms(variant);
 
         final String strands;
-        if (type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL)
-                || type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.CNV)
-                || type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP)) {
+        if (type == GATKSVVCFConstants.StructuralVariantAnnotationType.DEL
+                || type == GATKSVVCFConstants.StructuralVariantAnnotationType.CNV
+                || type == GATKSVVCFConstants.StructuralVariantAnnotationType.DUP) {
             // SVCallRecord class can resolve these
             strands = null;
         } else {
@@ -346,12 +346,12 @@ public final class SVCallRecordUtils {
         final Boolean strand2 = strands == null ? null : strands.endsWith(SVCallRecord.STRAND_PLUS);
 
         final Integer length;
-        if (type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.BND)
-                || type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL)
-                || type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP)
-                || type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.CNV)
-                || type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.INV)
-                || type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.CTX)) {
+        if (type == GATKSVVCFConstants.StructuralVariantAnnotationType.BND
+                || type == GATKSVVCFConstants.StructuralVariantAnnotationType.DEL
+                || type == GATKSVVCFConstants.StructuralVariantAnnotationType.DUP
+                || type == GATKSVVCFConstants.StructuralVariantAnnotationType.CNV
+                || type == GATKSVVCFConstants.StructuralVariantAnnotationType.INV
+                || type == GATKSVVCFConstants.StructuralVariantAnnotationType.CTX) {
             // SVCallRecord class can resolve these
             length = null;
         } else {
@@ -364,8 +364,8 @@ public final class SVCallRecordUtils {
         final int positionB;
         final boolean hasContig2 = variant.hasAttribute(GATKSVVCFConstants.CONTIG2_ATTRIBUTE);
         final boolean hasEnd2 = variant.hasAttribute(GATKSVVCFConstants.END2_ATTRIBUTE);
-        if (type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.BND)
-                || type.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.CTX)) {
+        if (type == GATKSVVCFConstants.StructuralVariantAnnotationType.BND
+                || type == GATKSVVCFConstants.StructuralVariantAnnotationType.CTX) {
             if (!(hasContig2 && hasEnd2)) {
                 throw new UserException.BadInput("Attributes " + GATKSVVCFConstants.END2_ATTRIBUTE +
                         " and " + GATKSVVCFConstants.CONTIG2_ATTRIBUTE + " are required for BND records (variant " +

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/cluster/CanonicalSVLinkage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/cluster/CanonicalSVLinkage.java
@@ -97,8 +97,8 @@ public class CanonicalSVLinkage<T extends SVCallRecord> extends SVClusterLinkage
             return false;
         }
         // Only require matching strands if BND or INV type
-        if ((a.getType().equals(GATKSVVCFConstants.StructuralVariantAnnotationType.BND)
-                || a.getType().equals(GATKSVVCFConstants.StructuralVariantAnnotationType.INV))
+        if ((a.getType() == GATKSVVCFConstants.StructuralVariantAnnotationType.BND
+                || a.getType() == GATKSVVCFConstants.StructuralVariantAnnotationType.INV)
                 && !strandsMatch(a, b)) {
             return false;
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/cluster/CanonicalSVLinkage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/cluster/CanonicalSVLinkage.java
@@ -96,7 +96,10 @@ public class CanonicalSVLinkage<T extends SVCallRecord> extends SVClusterLinkage
         if (!typesMatch(a, b)) {
             return false;
         }
-        if (!strandsMatch(a, b)) {
+        // Only require matching strands if BND or INV type
+        if ((a.getType().equals(GATKSVVCFConstants.StructuralVariantAnnotationType.BND)
+                || a.getType().equals(GATKSVVCFConstants.StructuralVariantAnnotationType.INV))
+                && !strandsMatch(a, b)) {
             return false;
         }
         // Checks appropriate parameter set

--- a/src/test/java/org/broadinstitute/hellbender/tools/sv/SVCallRecordUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/sv/SVCallRecordUtilsUnitTest.java
@@ -474,10 +474,10 @@ public class SVCallRecordUtilsUnitTest {
                             ALLELES_DEL, Lists.newArrayList(GENOTYPE_DEL_1, GENOTYPE_DEL_2), 1000, "+-",
                             GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM),
                             null, null,
-                            TEST_ATTRIBUTES, -10.),
+                            TEST_ATTRIBUTES, -90.),
                         new SVCallRecord("var1", "chr1", 1000, true, "chr1", 1999, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, 1000,
                             Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM), ALLELES_DEL, Lists.newArrayList(GENOTYPE_DEL_1, GENOTYPE_DEL_2),
-                                TEST_ATTRIBUTES, Collections.emptySet(), -10.)
+                                TEST_ATTRIBUTES, Collections.emptySet(), -90.)
                 },
                 {
                         SVTestUtils.newVariantContext("var2", "chr1", 1000, 1999,

--- a/src/test/java/org/broadinstitute/hellbender/tools/sv/SVCallRecordUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/sv/SVCallRecordUtilsUnitTest.java
@@ -27,8 +27,6 @@ public class SVCallRecordUtilsUnitTest {
     private static final Map<String, Object> TEST_ATTRIBUTES = Collections.singletonMap("TEST_KEY", "TEST_VAL");
     private static final Map<String, Object> TEST_ATTRIBUTES_CPX = Lists.newArrayList(
             new AbstractMap.SimpleImmutableEntry<String, Object>("TEST_KEY", "TEST_VAL"),
-                    new AbstractMap.SimpleImmutableEntry<String, Object>(GATKSVVCFConstants.END2_ATTRIBUTE, 2000),
-            new AbstractMap.SimpleImmutableEntry<String, Object>(GATKSVVCFConstants.CONTIG2_ATTRIBUTE, "chrX"),
             new AbstractMap.SimpleImmutableEntry<String, Object>(GATKSVVCFConstants.CPX_TYPE, GATKSVVCFConstants.ComplexVariantSubtype.dDUP.toString())
             ).stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
@@ -106,6 +104,24 @@ public class SVCallRecordUtilsUnitTest {
                                 .id("var2")
                                 .genotypes(GENOTYPE_INS_1)
                                 .attribute(VCFConstants.END_KEY, 1000)
+                                .attribute(GATKSVVCFConstants.STRANDS_ATTRIBUTE, "+-")
+                                .attribute(GATKSVVCFConstants.ALGORITHMS_ATTRIBUTE, SVTestUtils.PESR_ONLY_ALGORITHM_LIST)
+                                .attribute(GATKSVVCFConstants.SVTYPE, GATKSVVCFConstants.StructuralVariantAnnotationType.INS)
+                                .make(),
+                        Collections.emptyList()
+                },
+                // INS, flipped strands
+                {
+                        new SVCallRecord("var2", "chr1", 1000, false, "chr1", 1000, true, GATKSVVCFConstants.StructuralVariantAnnotationType.INS, null, 500,
+                                SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
+                                ALLELES_INS,
+                                Lists.newArrayList(GENOTYPE_INS_1),
+                                Collections.emptyMap(), Collections.emptySet(), null),
+                        new VariantContextBuilder("", "chr1", 1000, 1000, ALLELES_INS)
+                                .id("var2")
+                                .genotypes(GENOTYPE_INS_1)
+                                .attribute(VCFConstants.END_KEY, 1000)
+                                .attribute(GATKSVVCFConstants.STRANDS_ATTRIBUTE, "-+")
                                 .attribute(GATKSVVCFConstants.ALGORITHMS_ATTRIBUTE, SVTestUtils.PESR_ONLY_ALGORITHM_LIST)
                                 .attribute(GATKSVVCFConstants.SVTYPE, GATKSVVCFConstants.StructuralVariantAnnotationType.INS)
                                 .make(),
@@ -122,6 +138,7 @@ public class SVCallRecordUtilsUnitTest {
                                 .id("var2")
                                 .genotypes(GENOTYPE_INS_1)
                                 .attribute(VCFConstants.END_KEY, 1000)
+                                .attribute(GATKSVVCFConstants.STRANDS_ATTRIBUTE, "+-")
                                 .attribute(GATKSVVCFConstants.ALGORITHMS_ATTRIBUTE, SVTestUtils.PESR_ONLY_ALGORITHM_LIST)
                                 .attribute(GATKSVVCFConstants.SVTYPE, GATKSVVCFConstants.StructuralVariantAnnotationType.INS)
                                 .make(),
@@ -457,54 +474,99 @@ public class SVCallRecordUtilsUnitTest {
                             ALLELES_DEL, Lists.newArrayList(GENOTYPE_DEL_1, GENOTYPE_DEL_2), 1000, "+-",
                             GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM),
                             null, null,
-                            TEST_ATTRIBUTES),
+                            TEST_ATTRIBUTES, -10.),
                         new SVCallRecord("var1", "chr1", 1000, true, "chr1", 1999, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, 1000,
                             Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM), ALLELES_DEL, Lists.newArrayList(GENOTYPE_DEL_1, GENOTYPE_DEL_2),
-                                TEST_ATTRIBUTES, Collections.emptySet(), null)
+                                TEST_ATTRIBUTES, Collections.emptySet(), -10.)
                 },
                 {
-                        SVTestUtils.newVariantContext("var1", "chr1", 1000, 1999,
+                        SVTestUtils.newVariantContext("var2", "chr1", 1000, 1999,
                                 ALLELES_DEL, Lists.newArrayList(GENOTYPE_DEL_1, GENOTYPE_DEL_2), 1000, "+-",
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM),
                                 null, null,
-                                TEST_ATTRIBUTES),
-                        new SVCallRecord("var1", "chr1", 1000, true, "chr1", 1999, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, 1000,
+                                TEST_ATTRIBUTES, null),
+                        new SVCallRecord("var2", "chr1", 1000, true, "chr1", 1999, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, 1000,
                                 Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM), ALLELES_DEL, Lists.newArrayList(GENOTYPE_DEL_1, GENOTYPE_DEL_2),
                                 TEST_ATTRIBUTES, Collections.emptySet(), null)
                 },
                 {
-                        SVTestUtils.newVariantContext("var2", "chr1", 1000, 1000,
+                        SVTestUtils.newVariantContext("var3", "chr1", 1000, 1000,
                                 ALLELES_INS, Lists.newArrayList(GENOTYPE_INS_1, GENOTYPE_INS_2), 500, "+-",
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.INS, SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
-                                null, null, TEST_ATTRIBUTES),
-                        new SVCallRecord("var2", "chr1", 1000, true, "chr1", 1000, false, GATKSVVCFConstants.StructuralVariantAnnotationType.INS, null, 500,
+                                null, null, TEST_ATTRIBUTES, null),
+                        new SVCallRecord("var3", "chr1", 1000, true, "chr1", 1000, false, GATKSVVCFConstants.StructuralVariantAnnotationType.INS, null, 500,
                                 SVTestUtils.PESR_ONLY_ALGORITHM_LIST, ALLELES_INS, Lists.newArrayList(GENOTYPE_INS_1, GENOTYPE_INS_2),
                                 TEST_ATTRIBUTES, Collections.emptySet(), null)
                 },
                 {
-                        SVTestUtils.newVariantContext("var3", "chr1", 1000, 1000,
+                        SVTestUtils.newVariantContext("var4", "chr1", 1000, 1000,
+                                ALLELES_INS, Lists.newArrayList(GENOTYPE_INS_1, GENOTYPE_INS_2), 500, "-+",
+                                GATKSVVCFConstants.StructuralVariantAnnotationType.INS, SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
+                                null, null, TEST_ATTRIBUTES, null),
+                        new SVCallRecord("var4", "chr1", 1000, false, "chr1", 1000, true, GATKSVVCFConstants.StructuralVariantAnnotationType.INS, null, 500,
+                                SVTestUtils.PESR_ONLY_ALGORITHM_LIST, ALLELES_INS, Lists.newArrayList(GENOTYPE_INS_1, GENOTYPE_INS_2),
+                                TEST_ATTRIBUTES, Collections.emptySet(), null)
+                },
+                {
+                        SVTestUtils.newVariantContext("var4b", "chr1", 1000, 1000,
+                                ALLELES_INS, Lists.newArrayList(GENOTYPE_INS_1, GENOTYPE_INS_2), -1, "-+",
+                                GATKSVVCFConstants.StructuralVariantAnnotationType.INS, SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
+                                null, null, TEST_ATTRIBUTES, null),
+                        new SVCallRecord("var4b", "chr1", 1000, false, "chr1", 1000, true, GATKSVVCFConstants.StructuralVariantAnnotationType.INS, null, null,
+                                SVTestUtils.PESR_ONLY_ALGORITHM_LIST, ALLELES_INS, Lists.newArrayList(GENOTYPE_INS_1, GENOTYPE_INS_2),
+                                TEST_ATTRIBUTES, Collections.emptySet(), null)
+                },
+                {
+                        SVTestUtils.newVariantContext("var5", "chr1", 1000, 1000,
                                 ALLELES_BND, Collections.singletonList(GENOTYPE_BND_1), null, "++",
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.BND, SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
-                                "chrX", 2000, TEST_ATTRIBUTES),
-                        new SVCallRecord("var3", "chr1", 1000, true, "chrX", 2000, true, GATKSVVCFConstants.StructuralVariantAnnotationType.BND, null, null,
+                                "chrX", 2000, TEST_ATTRIBUTES, null),
+                        new SVCallRecord("var5", "chr1", 1000, true, "chrX", 2000, true, GATKSVVCFConstants.StructuralVariantAnnotationType.BND, null, null,
                                 SVTestUtils.PESR_ONLY_ALGORITHM_LIST, ALLELES_BND, Collections.singletonList(GENOTYPE_BND_1),
                                 TEST_ATTRIBUTES, Collections.emptySet(), null)
                 },
                 {
-                        SVTestUtils.newVariantContext("var4", "chr1", 1000, 1000,
+                        SVTestUtils.newVariantContext("var6", "chr1", 1000, 1000,
                                 ALLELES_BND, Collections.singletonList(GENOTYPE_BND_1), null, "++",
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.BND, SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
-                                "chrX", 2000, TEST_ATTRIBUTES),
-                        new SVCallRecord("var4", "chr1", 1000, true, "chrX", 2000, true, GATKSVVCFConstants.StructuralVariantAnnotationType.BND, null, null,
+                                "chrX", 2000, TEST_ATTRIBUTES, null),
+                        new SVCallRecord("var6", "chr1", 1000, true, "chrX", 2000, true, GATKSVVCFConstants.StructuralVariantAnnotationType.BND, null, null,
                                 SVTestUtils.PESR_ONLY_ALGORITHM_LIST, ALLELES_BND, Collections.singletonList(GENOTYPE_BND_1),
                                 TEST_ATTRIBUTES, Collections.emptySet(), null)
                 },
                 {
-                        SVTestUtils.newVariantContext("var4", "chr1", 1000, 1000,
+                        SVTestUtils.newVariantContext("var7", "chr1", 1000, 1000,
                                 ALLELES_CPX, Collections.singletonList(GENOTYPE_CPX_1), 250, null,
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.CPX, SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
-                                "chrX", 2000, TEST_ATTRIBUTES_CPX),
-                        new SVCallRecord("var4", "chr1", 1000, null, "chrX", 2000, null, GATKSVVCFConstants.StructuralVariantAnnotationType.CPX, GATKSVVCFConstants.ComplexVariantSubtype.dDUP, 250,
+                                "chrX", 2000, TEST_ATTRIBUTES_CPX, null),
+                        new SVCallRecord("var7", "chr1", 1000, null, "chrX", 2000, null, GATKSVVCFConstants.StructuralVariantAnnotationType.CPX, GATKSVVCFConstants.ComplexVariantSubtype.dDUP, 250,
+                                SVTestUtils.PESR_ONLY_ALGORITHM_LIST, ALLELES_CPX, Collections.singletonList(GENOTYPE_CPX_1),
+                                TEST_ATTRIBUTES, Collections.emptySet(), null)
+                },
+                {
+                        SVTestUtils.newVariantContext("var8", "chr1", 1000, 2000,
+                                ALLELES_CPX, Collections.singletonList(GENOTYPE_CPX_1), 250, null,
+                                GATKSVVCFConstants.StructuralVariantAnnotationType.CPX, SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
+                                "chr1", null, TEST_ATTRIBUTES_CPX, null),
+                        new SVCallRecord("var8", "chr1", 1000, null, "chr1", 2000, null, GATKSVVCFConstants.StructuralVariantAnnotationType.CPX, GATKSVVCFConstants.ComplexVariantSubtype.dDUP, 250,
+                                SVTestUtils.PESR_ONLY_ALGORITHM_LIST, ALLELES_CPX, Collections.singletonList(GENOTYPE_CPX_1),
+                                TEST_ATTRIBUTES, Collections.emptySet(), null)
+                },
+                {
+                        SVTestUtils.newVariantContext("var9", "chr1", 1000, 2000,
+                                ALLELES_CPX, Collections.singletonList(GENOTYPE_CPX_1), 250, null,
+                                GATKSVVCFConstants.StructuralVariantAnnotationType.CPX, SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
+                                null, null, TEST_ATTRIBUTES_CPX, null),
+                        new SVCallRecord("var9", "chr1", 1000, null, "chr1", 2000, null, GATKSVVCFConstants.StructuralVariantAnnotationType.CPX, GATKSVVCFConstants.ComplexVariantSubtype.dDUP, 250,
+                                SVTestUtils.PESR_ONLY_ALGORITHM_LIST, ALLELES_CPX, Collections.singletonList(GENOTYPE_CPX_1),
+                                TEST_ATTRIBUTES, Collections.emptySet(), null)
+                },
+                {
+                        SVTestUtils.newVariantContext("var10", "chr1", 1000, 1000,
+                                ALLELES_CPX, Collections.singletonList(GENOTYPE_CPX_1), 250, null,
+                                GATKSVVCFConstants.StructuralVariantAnnotationType.CPX, SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
+                                "chrX", 2000, TEST_ATTRIBUTES, null),
+                        new SVCallRecord("var10", "chr1", 1000, null, "chrX", 2000, null, GATKSVVCFConstants.StructuralVariantAnnotationType.CPX, null, 250,
                                 SVTestUtils.PESR_ONLY_ALGORITHM_LIST, ALLELES_CPX, Collections.singletonList(GENOTYPE_CPX_1),
                                 TEST_ATTRIBUTES, Collections.emptySet(), null)
                 },

--- a/src/test/java/org/broadinstitute/hellbender/tools/sv/SVTestUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/sv/SVTestUtils.java
@@ -525,26 +525,31 @@ public class SVTestUtils {
                                                    final List<Genotype> genotypes, final Integer svlen,
                                                    final String strands, final GATKSVVCFConstants.StructuralVariantAnnotationType svtype,
                                                    final List<String> algorithms, final String chr2, final Integer end2,
-                                                   final Map<String, Object> extendedAttributes) {
+                                                   final Map<String, Object> extendedAttributes, final Double log10PError) {
         final Map<String, Object> attributes = new HashMap<>();
         attributes.put(GATKSVVCFConstants.SVLEN, svlen);
         attributes.put(GATKSVVCFConstants.SVTYPE, svtype);
         attributes.put(GATKSVVCFConstants.STRANDS_ATTRIBUTE, strands);
         attributes.put(GATKSVVCFConstants.ALGORITHMS_ATTRIBUTE, algorithms);
-        if (chr2 != null && end2 != null) {
+        if (chr2 != null) {
             attributes.put(GATKSVVCFConstants.CONTIG2_ATTRIBUTE, chr2);
+        }
+        if (end2 != null) {
             attributes.put(GATKSVVCFConstants.END2_ATTRIBUTE, end2);
         }
         attributes.putAll(extendedAttributes);
-        return new VariantContextBuilder()
+        VariantContextBuilder builder = new VariantContextBuilder()
                 .id(id)
                 .start(posA)
                 .chr(chrA)
                 .stop(end)
                 .alleles(alleles)
                 .genotypes(genotypes)
-                .attributes(attributes)
-                .make();
+                .attributes(attributes);
+        if (log10PError != null) {
+            builder = builder.log10PError(log10PError);
+        }
+        return builder.make();
     }
 
     public static Boolean getValidTestStrandA(final GATKSVVCFConstants.StructuralVariantAnnotationType type) {


### PR DESCRIPTION
Adds some flexibility to the allowed split-read strand annotations on SV records:

- Allow INS -+ strands
- Allow INV null strands
- When clustering, only require that strands match for INV/BND records

The changes affecting INS variants are commensurate with changing going into gatk-sv (see https://github.com/broadinstitute/gatk-sv/pull/553).

Added tests for the new functionality and improved some unit test coverage for a few related cases.
