### PR TITLE
VS-942.  Fix an error where NO variants were found

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -111,7 +111,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - gg_FixExomes
    - name: GvsImportGenomes
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsImportGenomes.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -111,7 +111,7 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - gg_VS-987_OutOfDateDocker
+         - gg_FixExomes
    - name: GvsImportGenomes
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsImportGenomes.wdl

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -315,7 +315,7 @@ task ExtractFilterTask {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_21"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22_1d6ddf63e1431bff8005f2f2373f0d25ee586dad"
     memory: "7 GB"
     disks: "local-disk 10 HDD"
     bootDiskSizeGb: 15
@@ -397,7 +397,7 @@ task PopulateFilterSetInfo {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_21"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22_1d6ddf63e1431bff8005f2f2373f0d25ee586dad"
     memory: "3500 MB"
     disks: "local-disk 250 HDD"
     bootDiskSizeGb: 15
@@ -457,7 +457,7 @@ task PopulateFilterSetSites {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_21"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22_1d6ddf63e1431bff8005f2f2373f0d25ee586dad"
     memory: "3500 MB"
     disks: "local-disk 200 HDD"
     bootDiskSizeGb: 15
@@ -509,7 +509,7 @@ task PopulateFilterSetTranches {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_21"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22_1d6ddf63e1431bff8005f2f2373f0d25ee586dad"
     memory: "3500 MB"
     disks: "local-disk 200 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -315,7 +315,7 @@ task ExtractFilterTask {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22_1d6ddf63e1431bff8005f2f2373f0d25ee586dad"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22"
     memory: "7 GB"
     disks: "local-disk 10 HDD"
     bootDiskSizeGb: 15
@@ -397,7 +397,7 @@ task PopulateFilterSetInfo {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22_1d6ddf63e1431bff8005f2f2373f0d25ee586dad"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22"
     memory: "3500 MB"
     disks: "local-disk 250 HDD"
     bootDiskSizeGb: 15
@@ -457,7 +457,7 @@ task PopulateFilterSetSites {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22_1d6ddf63e1431bff8005f2f2373f0d25ee586dad"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22"
     memory: "3500 MB"
     disks: "local-disk 200 HDD"
     bootDiskSizeGb: 15
@@ -509,7 +509,7 @@ task PopulateFilterSetTranches {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22_1d6ddf63e1431bff8005f2f2373f0d25ee586dad"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22"
     memory: "3500 MB"
     disks: "local-disk 200 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -354,7 +354,7 @@ task ExtractTask {
     echo ~{interval_index},${OUTPUT_FILE_DEST},${OUTPUT_FILE_BYTES},${OUTPUT_FILE_INDEX_DEST},${OUTPUT_FILE_INDEX_BYTES} >> manifest.txt
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_21"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22_1d6ddf63e1431bff8005f2f2373f0d25ee586dad"
     memory: "12 GB"
     disks: "local-disk 150 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -354,7 +354,7 @@ task ExtractTask {
     echo ~{interval_index},${OUTPUT_FILE_DEST},${OUTPUT_FILE_BYTES},${OUTPUT_FILE_INDEX_DEST},${OUTPUT_FILE_INDEX_BYTES} >> manifest.txt
   >>>
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22_1d6ddf63e1431bff8005f2f2373f0d25ee586dad"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22"
     memory: "12 GB"
     disks: "local-disk 150 HDD"
     bootDiskSizeGb: 15

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -323,7 +323,7 @@ task LoadData {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22_1d6ddf63e1431bff8005f2f2373f0d25ee586dad"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22"
     maxRetries: load_data_maxretries
     memory: "3.75 GB"
     disks: "local-disk 50 HDD"

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -323,7 +323,7 @@ task LoadData {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_21"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22_1d6ddf63e1431bff8005f2f2373f0d25ee586dad"
     maxRetries: load_data_maxretries
     memory: "3.75 GB"
     disks: "local-disk 50 HDD"

--- a/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
+++ b/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
@@ -39,7 +39,7 @@ workflow GvsJointVariantCalling {
       Int SNP_VQSR_CLASSIC_mem_gb_override = ""
     }
     # This is the most updated snapshot of the code as of June 22, 2023
-    File gatk_override = "gs://gvs_quickstart_storage/jars/gatk-package-4.2.0.0-726-g63a0bea-SNAPSHOT-local.jar"
+    File gatk_override = "gs://gvs_quickstart_storage/jars/gatk-package-4.2.0.0-721-ga778e4c-SNAPSHOT-local.jar"
     File interval_list = "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.noCentromeres.noTelomeres.interval_list"
 
     File interval_weights_bed = "gs://broad-public-datasets/gvs/weights/gvs_vet_weights_1kb.bed"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -41,7 +41,7 @@ task MergeVCFs {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22_1d6ddf63e1431bff8005f2f2373f0d25ee586dad"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22"
     preemptible: select_first([preemptible_tries, 3])
     memory: "3 GiB"
     disks: "local-disk ~{disk_size} HDD"
@@ -127,7 +127,7 @@ task SplitIntervals {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22_1d6ddf63e1431bff8005f2f2373f0d25ee586dad"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22"
     bootDiskSizeGb: 15
     memory: "~{disk_memory} GB"
     disks: "local-disk ~{disk_size} HDD"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -41,7 +41,7 @@ task MergeVCFs {
   }
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_21"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22_1d6ddf63e1431bff8005f2f2373f0d25ee586dad"
     preemptible: select_first([preemptible_tries, 3])
     memory: "3 GiB"
     disks: "local-disk ~{disk_size} HDD"
@@ -127,7 +127,7 @@ task SplitIntervals {
   >>>
 
   runtime {
-    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_21"
+    docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22_1d6ddf63e1431bff8005f2f2373f0d25ee586dad"
     bootDiskSizeGb: 15
     memory: "~{disk_memory} GB"
     disks: "local-disk ~{disk_size} HDD"

--- a/scripts/variantstore/wdl/GvsWarpTasks.wdl
+++ b/scripts/variantstore/wdl/GvsWarpTasks.wdl
@@ -138,7 +138,7 @@ task GatherTranches {
         bootDiskSizeGb: 15
         disks: "local-disk " + disk_size + " HDD"
         preemptible: 1
-        docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22_1d6ddf63e1431bff8005f2f2373f0d25ee586dad"
+        docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22"
     }
 
     output {

--- a/scripts/variantstore/wdl/GvsWarpTasks.wdl
+++ b/scripts/variantstore/wdl/GvsWarpTasks.wdl
@@ -138,7 +138,7 @@ task GatherTranches {
         bootDiskSizeGb: 15
         disks: "local-disk " + disk_size + " HDD"
         preemptible: 1
-        docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_21"
+        docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_06_22_1d6ddf63e1431bff8005f2f2373f0d25ee586dad"
     }
 
     output {

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
@@ -1150,7 +1150,7 @@ public class ExtractCohortEngine {
         }
 
         // finish writing out reference rows
-        if (lastSample != maxSampleId) {
+        if ((lastSample != null) && (lastSample != maxSampleId)) {
             processReferenceData(currentPositionRecords, sortedReferenceRangeIterator, referenceCache, lastPosition, lastSample + 1, maxSampleId, sampleIdsToExtract);
         }
 


### PR DESCRIPTION
This PR fixes a bug I found in testing. I was extracting all the samples for an Exome run and it was widely scattered. So there occurred a situation where there no VET entries in one of the shards and a NPE happened.
This PR fixes that and makes it tool generate an empty (well, has a header) VCF, which the GVS workflow can handle.

Failing workflow showing the problem [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Exome%20Data%2049k/job_history/9f821329-f2bd-487c-a9af-4a81d0716072).

Passing workflow (after the fix) [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Exome%20Data%2049k/job_history/52ecbbaa-199d-413b-95fe-2a3285462b43)
Passing Integration Test [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/job_history/a2f67baa-9613-4c4e-be3b-85a1b25a3b3b)
