### PR TITLE
Add support for breakend replacement alleles in SVCluster

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/cluster/CanonicalSVCollapser.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/cluster/CanonicalSVCollapser.java
@@ -181,7 +181,7 @@ public class CanonicalSVCollapser {
         final Allele refAllele = collapseRefAlleles(representative.getContigA(), start);
         final List<Allele> altAlleles;
         if (type == GATKSVVCFConstants.StructuralVariantAnnotationType.BND) {
-            altAlleles = Collections.singletonList(constructBndAllele(strandA, representative.getStrandB(), representative.getContigB(), end, refAllele));
+            altAlleles = Collections.singletonList(constructBndAllele(strandA, strandB, representative.getContigB(), end, refAllele));
         } else {
             altAlleles = collapseAltAlleles(items);
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVCluster.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVCluster.java
@@ -411,13 +411,8 @@ public final class SVCluster extends MultiVariantWalker {
     }
 
     private VCFHeader createHeader() {
-        final VCFHeader header = new VCFHeader(getDefaultToolVCFHeaderLines(), samples);
-        header.setVCFHeaderVersion(VCFHeaderVersion.VCF4_2);
+        final VCFHeader header = new VCFHeader(getHeaderForVariants().getMetaDataInInputOrder(), samples);
         header.setSequenceDictionary(dictionary);
-
-        // Copy from inputs
-        getHeaderForVariants().getFormatHeaderLines().forEach(header::addMetaDataLine);
-        getHeaderForVariants().getInfoHeaderLines().forEach(header::addMetaDataLine);
 
         // Required info lines
         header.addMetaDataLine(VCFStandardHeaderLines.getInfoLine(VCFConstants.END_KEY));


### PR DESCRIPTION
Implements allele collapsing for "breakend replacement" BND alleles, as described in section 5.4 of the [VCFv4.2 spec](https://samtools.github.io/hts-specs/VCFv4.2.pdf).

Also:
- Validates symbolic alt allele for non-BND SV classes when attempting to collapse multiple alt alleles.
- Greatly improves unit test coverage for `CanonicalSVCollapser`.