### PR TITLE
Update the Intel GKL to the latest release, 0.8.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -337,7 +337,7 @@ dependencies {
     implementation('com.github.fommil.netlib:netlib-native_system-linux-x86_64:1.1:natives')
     implementation('com.github.fommil.netlib:netlib-native_system-osx-x86_64:1.1:natives')
 
-    implementation('com.intel.gkl:gkl:0.8.8') {
+    implementation('com.intel.gkl:gkl:0.8.11') {
         exclude module: 'htsjdk'
     }
 


### PR DESCRIPTION
This release contains important bugfixes, including a fix for https://github.com/broadinstitute/gatk/issues/8141 (intermittent failure to properly compress outputs)