### PR TITLE
ReblockGVCFs cleanup

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/ReblockGVCF.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantutils/ReblockGVCF.java
@@ -326,9 +326,9 @@ public final class ReblockGVCF extends MultiVariantWalker {
     @Override
     public void apply(VariantContext variant, ReadsContext reads, ReferenceContext ref, FeatureContext features) {
         if (!variant.hasAllele(Allele.NON_REF_ALLELE)) {
-            throw new GATKException("Variant Context at " + variant.getContig() + ":" + variant.getStart() + " does not contain a <NON-REF> allele. This tool is only intended for use with GVCFs.");
+            throw new UserException("Variant Context at " + variant.getContig() + ":" + variant.getStart() + " does not contain a <NON-REF> allele. This tool is only intended for use with GVCFs.");
         }
-        VariantContext newVC = annotationsToRemove.size() > 0 ? vcFormatAnnotationsRemoved(variant) : variant;
+        VariantContext newVC = annotationsToRemove.size() > 0 ? removeVCFFormatAnnotations(variant) : variant;
         regenotypeVC(newVC);
     }
 
@@ -338,7 +338,7 @@ public final class ReblockGVCF extends MultiVariantWalker {
      * @param vc variant context to remove format annotations from
      * @return variant context with format annotations removed from genotype
      */
-    private VariantContext vcFormatAnnotationsRemoved(final VariantContext vc) {
+    private VariantContext removeVCFFormatAnnotations(final VariantContext vc) {
         final Genotype genotype = vc.getGenotype(0);
         Map<String, Object> extendedAttributes = genotype.getExtendedAttributes();
         for (String annotation : annotationsToRemove) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/ReblockGVCFIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/ReblockGVCFIntegrationTest.java
@@ -9,6 +9,7 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.engine.FeatureDataSource;
+import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
 import org.broadinstitute.hellbender.testutils.CommandLineProgramTester;
@@ -574,5 +575,36 @@ public class ReblockGVCFIntegrationTest extends CommandLineProgramTest {
         final VariantContext filteredRefBlockVC = VariantContextTestUtils.readEntireVCFIntoMemory(output.getAbsolutePath()).getRight().get(0);
         Assert.assertFalse(filteredRefBlockVC.isFiltered()); // Ref block is unfiltered even though the input RefBlock and low qual variant were both filtered
         Assert.assertEquals(filteredRefBlockVC.getGenotype(0).getDP(), 12); // Ref block is combination of filtered variant with depth 22 and filtered ref block with depth 1
+    }
+
+    @Test
+    public void testRemovingFormatAnnotations() {
+        final File input = getTestFile("dragen.g.vcf");
+        final File output = createTempFile("reblockedgvcf", ".vcf");
+        final String priKey = "PRI";
+
+        final ArgumentsBuilder args = new ArgumentsBuilder();
+        args.addReference(new File(hg38Reference))
+                .add("V", input)
+                .add(ReblockGVCF.ANNOTATIONS_TO_REMOVE_LONG_NAME, priKey)
+                .addOutput(output);
+        runCommandLine(args);
+
+        final List<VariantContext> outVCs = VariantContextTestUtils.readEntireVCFIntoMemory(output.getAbsolutePath()).getRight();
+        for(VariantContext vc : outVCs){
+            Assert.assertNull(vc.getGenotype(0).getExtendedAttribute(priKey));
+        }
+    }
+
+    @Test
+    public void testNonGVCFInput() {
+        final File output = createTempFile("reblockedgvcf", ".vcf");
+
+        final ArgumentsBuilder args = new ArgumentsBuilder();
+        args.addReference(new File(b37_reference_20_21))
+                .add("V", "src/test/resources/large/NA12878.HiSeq.WGS.b37_decoy.indel.recalibrated.chr20.vcf")
+                .addOutput(output);
+
+        Assert.assertThrows(GATKException.class, () -> runCommandLine(args));
     }
 }


### PR DESCRIPTION
Adds argument to remove FORMAT level annotations from every genotype in the GVCF (for example, for removing the G-length PRI annotation in dragen GVCFs).

Also adds check to make sure the input VCF is a GVCF rather than a single sample VCF.