### PR TITLE
Fix AssignIds pipefail with `head` [VS-1011]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -216,7 +216,7 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - bulk_ingest_fixup
+         - vs_1011_assignids_pipefail
    - name: GvsIngestTieout
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsIngestTieout.wdl


### PR DESCRIPTION
Integration run here: https://app.terra.bio/#workspaces/gvs-dev/mlc%20GVS%20Quickstart%203%20samples/job_history/acb5b878-af45-443d-8139-0f0044cbcb38

The basic problem: https://news.ycombinator.com/item?id=9255830

Repro:

```
% # make a file shaped like what was failing in ingest
% for i in $(seq 50000)
do   
  echo foo,${i} >> file.csv
done
% # repro the pipeline that was failing
% set -o pipefail
% cat file.csv | cut -d, -f2 | sort -r -n | head -1
50000
% echo $?
141
% # repeat with temp file construct
% head -1 <(cat file.csv | cut -d, -f2 | sort -r -n)                              
50000
% echo $?
0
%
```
```