### PR TITLE
All sample inputs as files instead of strings [VS-1019]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -126,6 +126,7 @@ workflows:
          - master
          - ah_var_store
          - bulk_ingest_staging
+         - rsa_vs_1019
    - name: GvsPrepareRangesCallset
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -65,6 +65,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - rsa_vs_1019
    - name: GvsBenchmarkExtractTask
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsBenchmarkExtractTask.wdl

--- a/scripts/variantstore/TERRA_QUICKSTART.md
+++ b/scripts/variantstore/TERRA_QUICKSTART.md
@@ -26,11 +26,11 @@ This workflow should be run on a **sample set** as the root entity, for this wor
 
 These are the required parameters which must be supplied to the workflow:
 
-| Parameter             | Description |
-| --------------------- | ----------- |
-| dataset_name          | the name of the dataset you created above       |
-| external_sample_names | GCS path of a text file that lists all the sample names (external sample ID) |
-| project_id            | the name of the google project containing the dataset |
+| Parameter             | Description                                                                   |
+| --------------------- |-------------------------------------------------------------------------------|
+| dataset_name          | the name of the dataset you created above                                     |
+| external_sample_names | GCS path of a text file that lists all the sample names (external sample IDs) |
+| project_id            | the name of the google project containing the dataset                         |
 
 ## 1.2 Load data
 Next, your re-blocked gVCF files will be copied into the `ref_ranges_*` and `vet_*` tables by running the `GvsImportGenomes` workflow.
@@ -39,13 +39,13 @@ This workflow should be run on a **sample set** as the root entity, for this wor
 
 These are the required parameters which must be supplied to the workflow:
 
-| Parameter             | Description |
-| --------------------- | ----------- |
-| dataset_name          | the name of the dataset you created above       |
-| external_sample_names | GCS path of a text file that lists all the sample names (external sample ID) |
+| Parameter             | Description                                                                            |
+| --------------------- |----------------------------------------------------------------------------------------|
+| dataset_name          | the name of the dataset you created above                                              |
+| external_sample_names | GCS path of a text file that lists all the sample names (external sample IDs)          |
 | input_vcf_indexes     | `this.samples.hg38_reblocked_v2_vcf_index` (reblocked gvcf index file for each sample) |
-| input_vcfs            | `this.samples.hg38_reblocked_v2_vcf` (reblocked gvcf file for each sample) |
-| project_id            | the name of the google project containing the dataset |
+| input_vcfs            | `this.samples.hg38_reblocked_v2_vcf` (reblocked gvcf file for each sample)             |
+| project_id            | the name of the google project containing the dataset                                  |
 
 ## 2. Create Alt Allele Table
 This step loads data into the ALT_ALLELE table from the `vet_*` tables.

--- a/scripts/variantstore/TERRA_QUICKSTART.md
+++ b/scripts/variantstore/TERRA_QUICKSTART.md
@@ -29,7 +29,7 @@ These are the required parameters which must be supplied to the workflow:
 | Parameter             | Description |
 | --------------------- | ----------- |
 | dataset_name          | the name of the dataset you created above       |
-| external_sample_names | `this.samples.sample_id` (the sample identifier column from the `gvs_demo_10` sample set) |
+| external_sample_names | GCS path of a text file that lists all the sample names (external sample ID) |
 | project_id            | the name of the google project containing the dataset |
 
 ## 1.2 Load data
@@ -42,7 +42,7 @@ These are the required parameters which must be supplied to the workflow:
 | Parameter             | Description |
 | --------------------- | ----------- |
 | dataset_name          | the name of the dataset you created above       |
-| external_sample_names | `this.samples.sample_id` (the sample identifier from the `gvs_demo_10` sample set) |
+| external_sample_names | GCS path of a text file that lists all the sample names (external sample ID) |
 | input_vcf_indexes     | `this.samples.hg38_reblocked_v2_vcf_index` (reblocked gvcf index file for each sample) |
 | input_vcfs            | `this.samples.hg38_reblocked_v2_vcf` (reblocked gvcf file for each sample) |
 | project_id            | the name of the google project containing the dataset |

--- a/scripts/variantstore/beta_docs/gvs-overview.md
+++ b/scripts/variantstore/beta_docs/gvs-overview.md
@@ -64,15 +64,11 @@ The [GVS beta workspace](https://app.terra.bio/#workspaces/gvs-prod/Genomic_Vari
 
 The table below describes the GVS workflow input variables:
 
-| Input variable name | Description | Type |
-| --- | --- | --- |
-| dataset_name | Name of the BigQuery dataset used to hold input samples, filtering model data, and other tables created during the workflow. | String |
-| project_id | Name of the Google project that contains the BigQuery dataset. | String |
-| external_sample_names | Unique sample IDs used in creation of output VCF file; `sample_id` in the sample data table in Terra. | Array of strings |
-| input_vcfs | Cloud paths to the sample GVCF files. | Array of files |
-| input_vcf_indexes | Cloud paths to the sample GVCF index files. | Array of files |
-| call_set_identifier | Used to name the filter model, BigQuery extract tables, and final joint VCF shards; should begin with a letter; valid characters include A-z, 0-9, “.”, “,”, “-“, and “_”. | String |
-| extract_output_gcs_dir | Optional; desired cloud path for output files. | String |
+| Input variable name | Description | Type            |
+| --- | --- |-----------------|
+| call_set_identifier | Used to name the filter model, BigQuery extract tables, and final joint VCF shards; should begin with a letter; valid characters include A-z, 0-9, “.”, “,”, “-“, and “_”. | String          |
+| dataset_name | Name of the BigQuery dataset used to hold input samples, filtering model data, and other tables created during the workflow. | String          |
+| project_id | Name of the Google project that contains the BigQuery dataset. | String          |
 
 ## Tasks and tools
 

--- a/scripts/variantstore/docs/DELIVERING_GVS_VCF.md
+++ b/scripts/variantstore/docs/DELIVERING_GVS_VCF.md
@@ -31,14 +31,13 @@
 ## The Pipeline
 1. `GvsAssignIds` workflow
    - To optimize the GVS internal queries, each sample must have a unique and consecutive integer ID assigned. Running the `GvsAssignIds` workflow will create a unique GVS ID for each sample (`sample_id`) and update the BQ `sample_info` table (creating it if it doesn't exist). This workflow takes care of creating the BQ `vet_*`, `ref_ranges_*` and `cost_observability` tables needed for the sample IDs generated.
-   - Run at the `sample set` level ("Step 1" in workflow submission) with a sample set of all the new samples to be included in the callset (created by the "Fetch WGS metadata for samples from list" notebook mentioned above).
-   - You will want to set the `external_sample_names` input based on the column in the workspace Data table, e.g. "this.samples.research_id".
+   - This workflow does not use the Terra Data Entity Model to run, so be sure to select the `Run workflow with inputs defined by file paths` workflow submission option.
+   -  The `external_sample_names` input should be the GCS path of a text file that lists all the sample names (external sample ID).
    - If new controls are being added, they need to be done in a separate run, with the `samples_are_controls` input set to "true" (the referenced Data columns may also be different, e.g. "this.control_samples.control_sample_id" instead of "this.samples.research_id").
 2. `GvsImportGenomes` workflow
    - This will import the re-blocked gVCF files into GVS. The workflow will check whether data for that sample has already been loaded into GVS. It is designed to be re-run (with the same inputs) if there is a failure during one of the workflow tasks (e.g. BigQuery write API interrupts).
    - Run at the `sample set` level ("Step 1" in workflow submission).  You can either run this on a sample_set of all the samples and rely on the workflow logic to break it up into batches (or manually set the `load_data_batch_size` input) or run it on smaller sample_sets created by the "Fetch WGS metadata for samples from list" notebook mentioned above.  
-   - You will want to set the `external_sample_names`, `input_vcfs` and `input_vcf_indexes` inputs based on the columns in the workspace Data table, e.g. "this.samples.research_id", "this.samples.reblocked_gvcf_v2" and "this.samples.reblocked_gvcf_index_v2".
-   - **NOTE** It appears that there is a rawls limit on the size of the input (list of gvcf files and indexes) per workflow run. 25K samples in a list worked for the Intermediate call set, 50K did not.
+   - The `external_sample_names` input should be the GCS path of a text file that lists all the sample names (external sample ID).
 3. `GvsWithdrawSamples` workflow
    - Run if there are any samples to withdraw from the last callset.
 4. `GvsPopulateAltAllele` workflow

--- a/scripts/variantstore/docs/DELIVERING_GVS_VCF.md
+++ b/scripts/variantstore/docs/DELIVERING_GVS_VCF.md
@@ -32,12 +32,12 @@
 1. `GvsAssignIds` workflow
    - To optimize the GVS internal queries, each sample must have a unique and consecutive integer ID assigned. Running the `GvsAssignIds` workflow will create a unique GVS ID for each sample (`sample_id`) and update the BQ `sample_info` table (creating it if it doesn't exist). This workflow takes care of creating the BQ `vet_*`, `ref_ranges_*` and `cost_observability` tables needed for the sample IDs generated.
    - This workflow does not use the Terra Data Entity Model to run, so be sure to select the `Run workflow with inputs defined by file paths` workflow submission option.
-   -  The `external_sample_names` input should be the GCS path of a text file that lists all the sample names (external sample ID).
+   -  The `external_sample_names` input should be the GCS path of a text file that lists all the sample names (external sample IDs).
    - If new controls are being added, they need to be done in a separate run, with the `samples_are_controls` input set to "true" (the referenced Data columns may also be different, e.g. "this.control_samples.control_sample_id" instead of "this.samples.research_id").
 2. `GvsImportGenomes` workflow
    - This will import the re-blocked gVCF files into GVS. The workflow will check whether data for that sample has already been loaded into GVS. It is designed to be re-run (with the same inputs) if there is a failure during one of the workflow tasks (e.g. BigQuery write API interrupts).
    - Run at the `sample set` level ("Step 1" in workflow submission).  You can either run this on a sample_set of all the samples and rely on the workflow logic to break it up into batches (or manually set the `load_data_batch_size` input) or run it on smaller sample_sets created by the "Fetch WGS metadata for samples from list" notebook mentioned above.  
-   - The `external_sample_names` input should be the GCS path of a text file that lists all the sample names (external sample ID).
+   - The `external_sample_names` input should be the GCS path of a text file that lists all the sample names (external sample IDs).
 3. `GvsWithdrawSamples` workflow
    - Run if there are any samples to withdraw from the last callset.
 4. `GvsPopulateAltAllele` workflow

--- a/scripts/variantstore/docs/RUNNING_EXOMES_ON_GVS.md
+++ b/scripts/variantstore/docs/RUNNING_EXOMES_ON_GVS.md
@@ -27,7 +27,7 @@ gs://gcp-public-data--broad-references/hg38/v0/bge_exome_calling_regions.v1.1.in
 1. `GvsAssignIds` workflow
     - To optimize the GVS internal queries, each sample must have a unique and consecutive integer ID assigned. Running the `GvsAssignIds` will create a unique GVS ID for each sample (`sample_id`) and update the BQ `sample_info` table (creating it if it doesn't exist). This workflow takes care of creating the BQ `vet_*`, `ref_ranges_*` and `cost_observability` tables needed for the sample IDs generated.
     - This workflow does not use the Terra Data Entity Model to run, so be sure to select the `Run workflow with inputs defined by file paths` workflow submission option.
-    -  The `external_sample_names` input should be the GCS path of a text file that lists all the sample names (external sample ID).
+    -  The `external_sample_names` input should be the GCS path of a text file that lists all the sample names (external sample IDs).
     - If new controls are being added, they need to be done in a separate run, with the `samples_are_controls` input set to "true" (the referenced Data columns may also be different, e.g. "this.control_samples.control_sample_id" instead of "this.samples.research_id").
 2. `GvsImportGenomes` workflow
     - This will import the re-blocked gVCF files into GVS. The workflow will check whether data for that sample has already been loaded into GVS. It is designed to be re-run (with the same inputs) if there is a failure during one of the workflow tasks (e.g. BigQuery write API interrupts).

--- a/scripts/variantstore/docs/RUNNING_EXOMES_ON_GVS.md
+++ b/scripts/variantstore/docs/RUNNING_EXOMES_ON_GVS.md
@@ -26,8 +26,8 @@ gs://gcp-public-data--broad-references/hg38/v0/bge_exome_calling_regions.v1.1.in
 - OR you can run the two workflows that `GvsBulkIngestGenomes` calls (for instance if you also need to load control samples) 
 1. `GvsAssignIds` workflow
     - To optimize the GVS internal queries, each sample must have a unique and consecutive integer ID assigned. Running the `GvsAssignIds` will create a unique GVS ID for each sample (`sample_id`) and update the BQ `sample_info` table (creating it if it doesn't exist). This workflow takes care of creating the BQ `vet_*`, `ref_ranges_*` and `cost_observability` tables needed for the sample IDs generated.
-    - Run at the `sample set` level ("Step 1" in workflow submission) with a sample set of all the new samples to be included in the callset.
-    - You will want to set the `external_sample_names` input based on the column in the workspace Data table, e.g. "this.samples.research_id".
+    - This workflow does not use the Terra Data Entity Model to run, so be sure to select the `Run workflow with inputs defined by file paths` workflow submission option.
+    -  The `external_sample_names` input should be the GCS path of a text file that lists all the sample names (external sample ID).
     - If new controls are being added, they need to be done in a separate run, with the `samples_are_controls` input set to "true" (the referenced Data columns may also be different, e.g. "this.control_samples.control_sample_id" instead of "this.samples.research_id").
 2. `GvsImportGenomes` workflow
     - This will import the re-blocked gVCF files into GVS. The workflow will check whether data for that sample has already been loaded into GVS. It is designed to be re-run (with the same inputs) if there is a failure during one of the workflow tasks (e.g. BigQuery write API interrupts).

--- a/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
+++ b/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
@@ -29,7 +29,7 @@
 1. `GvsAssignIds` workflow
    - To optimize the GVS internal queries, each sample must have a unique and consecutive integer ID assigned. Running the `GvsAssignIds` will create a unique GVS ID for each sample (`sample_id`) and update the BQ `sample_info` table (creating it if it doesn't exist). This workflow takes care of creating the BQ `vet_*`, `ref_ranges_*` and `cost_observability` tables needed for the sample IDs generated.
    - This workflow does not use the Terra Data Entity Model to run, so be sure to select the `Run workflow with inputs defined by file paths` workflow submission option.
-   - You will want to set the `external_sample_names` input based on the GCS path of a text file that lists all the sample names (external sample ID).
+   - You will want to set the `external_sample_names` input based on the GCS path of a text file that lists all the sample names (external sample IDs).
    - If new controls are being added, they need to be done in a separate run, with the `samples_are_controls` input set to "true" (the referenced Data columns may also be different, e.g. "this.control_samples.control_sample_id" instead of "this.samples.research_id").
 2. `GvsImportGenomes` workflow
    - This will import the re-blocked gVCF files into GVS. The workflow will check whether data for that sample has already been loaded into GVS. It is designed to be re-run (with the same inputs) if there is a failure during one of the workflow tasks (e.g. BigQuery write API interrupts).

--- a/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
+++ b/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
@@ -28,8 +28,8 @@
 ## The Pipeline
 1. `GvsAssignIds` workflow
    - To optimize the GVS internal queries, each sample must have a unique and consecutive integer ID assigned. Running the `GvsAssignIds` will create a unique GVS ID for each sample (`sample_id`) and update the BQ `sample_info` table (creating it if it doesn't exist). This workflow takes care of creating the BQ `vet_*`, `ref_ranges_*` and `cost_observability` tables needed for the sample IDs generated.
-   - Run at the `sample set` level ("Step 1" in workflow submission) with a sample set of all the new samples to be included in the callset (created by the "Fetch WGS metadata for samples from list" notebook mentioned above).
-   - You will want to set the `external_sample_names` input based on the column in the workspace Data table, e.g. "this.samples.research_id".
+   - This workflow does not use the Terra Data Entity Model to run, so be sure to select the `Run workflow with inputs defined by file paths` workflow submission option.
+   - You will want to set the `external_sample_names` input based on the GCS path of a text file that lists all the sample names (external sample ID).
    - If new controls are being added, they need to be done in a separate run, with the `samples_are_controls` input set to "true" (the referenced Data columns may also be different, e.g. "this.control_samples.control_sample_id" instead of "this.samples.research_id").
 2. `GvsImportGenomes` workflow
    - This will import the re-blocked gVCF files into GVS. The workflow will check whether data for that sample has already been loaded into GVS. It is designed to be re-run (with the same inputs) if there is a failure during one of the workflow tasks (e.g. BigQuery write API interrupts).

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -89,8 +89,9 @@ workflow GvsBulkIngestGenomes {
         input:
             dataset_name = dataset_name,
             project_id = project_id,
-            external_sample_names = read_lines(SplitBulkImportFofn.sample_name_fofn),
+            external_sample_names = SplitBulkImportFofn.sample_name_fofn,
             samples_are_controls = false,
+            num_samples = SplitBulkImportFofn.sample_num
     }
 
     call ImportGenomes.GvsImportGenomes as ImportGenomes {
@@ -98,9 +99,10 @@ workflow GvsBulkIngestGenomes {
             go = AssignIds.done,
             dataset_name = dataset_name,
             project_id = project_id,
-            external_sample_names = read_lines(SplitBulkImportFofn.sample_name_fofn),
-            input_vcfs = read_lines(SplitBulkImportFofn.vcf_file_name_fofn),
-            input_vcf_indexes = read_lines(SplitBulkImportFofn.vcf_index_file_name_fofn),
+            external_sample_names = SplitBulkImportFofn.sample_name_fofn,
+            num_samples = SplitBulkImportFofn.sample_num,
+            input_vcfs = SplitBulkImportFofn.vcf_file_name_fofn,
+            input_vcf_indexes = SplitBulkImportFofn.vcf_index_file_name_fofn,
             interval_list = interval_list,
 
             # The larger the `load_data_batch_size` the greater the probability of preemptions and non-retryable
@@ -239,6 +241,7 @@ task SplitBulkImportFofn {
         cut -f 1 ~{import_fofn} > sample_names.txt
         cut -f 2 ~{import_fofn} > vcf_file_names.txt
         cut -f 3 ~{import_fofn} > vcf_index_file_names.txt
+        wc -l  ~{import_fofn} > sample_num.txt
     >>>
 
     runtime {
@@ -252,6 +255,7 @@ task SplitBulkImportFofn {
         File sample_name_fofn = "sample_names.txt"
         File vcf_file_name_fofn = "vcf_file_names.txt"
         File vcf_index_file_name_fofn = "vcf_index_file_names.txt"
+        Int sample_num = read_int("sample_num.txt")
     }
 }
 

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -90,8 +90,7 @@ workflow GvsBulkIngestGenomes {
             dataset_name = dataset_name,
             project_id = project_id,
             external_sample_names = SplitBulkImportFofn.sample_name_fofn,
-            samples_are_controls = false,
-            num_samples = SplitBulkImportFofn.sample_num
+            samples_are_controls = false
     }
 
     call ImportGenomes.GvsImportGenomes as ImportGenomes {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -241,7 +241,7 @@ task SplitBulkImportFofn {
         cut -f 1 ~{import_fofn} > sample_names.txt
         cut -f 2 ~{import_fofn} > vcf_file_names.txt
         cut -f 3 ~{import_fofn} > vcf_index_file_names.txt
-        wc -l  ~{import_fofn} > sample_num.txt
+        wc -l  ~{import_fofn} | cut -w -f2 > sample_num.txt
     >>>
 
     runtime {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -241,11 +241,11 @@ task SplitBulkImportFofn {
         cut -f 1 ~{import_fofn} > sample_names.txt
         cut -f 2 ~{import_fofn} > vcf_file_names.txt
         cut -f 3 ~{import_fofn} > vcf_index_file_names.txt
-        wc -l  ~{import_fofn} | cut -w -f2 > sample_num.txt
+        wc -l < ~{import_fofn} > sample_num.txt
     >>>
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/variantstore:2023-07-24-alpine-bd6b9d62e"
+        docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:426.0.0-alpine"
         memory: "3 GB"
         disks: "local-disk 200 HDD"
         cpu: 1

--- a/scripts/variantstore/wdl/GvsIngestTieout.wdl
+++ b/scripts/variantstore/wdl/GvsIngestTieout.wdl
@@ -9,9 +9,9 @@ workflow GvsIngestTieout {
         String project
         String reference_dataset_name
         String branch_name
-        Array[String] sample_names
-        Array[File] input_vcfs
-        Array[File] input_vcf_indexes
+        File sample_names
+        File input_vcfs
+        File input_vcf_indexes
     }
 
     call Utils.BuildGATKJarAndCreateDataset {


### PR DESCRIPTION
Ran into what looks like a limit of the WDL `read_string()` function, so converted all the sample-based inputs to be files (instead of strings).

Run that worked (until quotas kicked in): https://app.terra.bio/#workspaces/gvs-dev/GVS_190k_Exomes/job_history/49b92660-e5d6-4305-9857-1dcd19dde1e7