### PR TITLE
VS-1004 Changes to make benchmarking VQSR Classic possible.

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -206,6 +206,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - gg_VS-1004_PassClassicMemArguments
    - name: GvsQuickstartHailIntegration
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsQuickstartHailIntegration.wdl
@@ -213,6 +214,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - gg_VS-1004_PassClassicMemArguments
    - name: GvsQuickstartIntegration
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
@@ -221,6 +223,7 @@ workflows:
          - master
          - ah_var_store
          - vs_1011_assignids_pipefail
+         - gg_VS-1004_PassClassicMemArguments
    - name: GvsIngestTieout
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsIngestTieout.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -182,6 +182,7 @@ workflows:
          - master
          - ah_var_store
          - bulk_ingest_staging
+         - gg_VS-1004_PassClassicMemArguments
    - name: GvsJointVariantCallsetCost
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsJointVariantCallsetCost.wdl

--- a/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
+++ b/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
@@ -30,6 +30,12 @@ workflow GvsJointVariantCalling {
         String? extract_output_file_base_name
         String? extract_table_prefix
         String? filter_set_name
+
+        # Overrides to be passed to GvsCreateFilterSet
+        Int? INDEL_VQSR_CLASSIC_max_gaussians_override = 4
+        Int? INDEL_VQSR_CLASSIC_mem_gb_override
+        Int? SNP_VQSR_CLASSIC_max_gaussians_override = 6
+        Int? SNP_VQSR_CLASSIC_mem_gb_override
     }
 
     # the call_set_identifier string is used to name many different things throughout this workflow (BQ tables, vcfs etc),
@@ -54,10 +60,6 @@ workflow GvsJointVariantCalling {
       File sample_names_to_extract = ""
       Int split_intervals_disk_size_override = ""
       Int split_intervals_mem_override = ""
-      Int INDEL_VQSR_CLASSIC_max_gaussians_override = 4
-      Int INDEL_VQSR_CLASSIC_mem_gb_override = ""
-      Int SNP_VQSR_CLASSIC_max_gaussians_override = 6
-      Int SNP_VQSR_CLASSIC_mem_gb_override = ""
     }
 
 

--- a/scripts/variantstore/wdl/GvsVQSRClassic.wdl
+++ b/scripts/variantstore/wdl/GvsVQSRClassic.wdl
@@ -255,8 +255,8 @@ task SNPsVariantRecalibratorCreateModel {
     Int disk_size
   }
 
-  Int machine_mem = select_first([machine_mem_gb, 100])
-  Int java_mem = machine_mem - 5
+  Int machine_mem = select_first([machine_mem_gb, 110])
+  Int java_mem = machine_mem - 10
 
   File monitoring_script = "gs://gvs_quickstart_storage/cromwell_monitoring_script.sh"
 
@@ -397,8 +397,8 @@ task IndelsVariantRecalibrator {
     Int? machine_mem_gb
   }
 
-  Int machine_mem = select_first([machine_mem_gb, 30])
-  Int java_mem = machine_mem - 5
+  Int machine_mem = select_first([machine_mem_gb, 35])
+  Int java_mem = machine_mem - 10
 
   File monitoring_script = "gs://gvs_quickstart_storage/cromwell_monitoring_script.sh"
 

--- a/scripts/variantstore/wdl/GvsVQSRClassic.wdl
+++ b/scripts/variantstore/wdl/GvsVQSRClassic.wdl
@@ -92,6 +92,7 @@ workflow JointVcfFiltering {
   if (num_samples_loaded > snps_variant_recalibration_threshold) {
     call SNPsVariantRecalibratorCreateModel {
       input:
+        num_samples = num_samples_loaded,
         sites_only_variant_filtered_vcf = sites_only_variant_filtered_vcf,
         sites_only_variant_filtered_vcf_index = sites_only_variant_filtered_vcf_idx,
         recalibration_filename = base_name + ".snps.recal",
@@ -250,12 +251,21 @@ task SNPsVariantRecalibratorCreateModel {
     Int max_gaussians = 6
     Int sample_every_nth_variant = 1
     Int maximum_training_variants = 2500000
+
+    Int num_samples
     Int? machine_mem_gb
 
     Int disk_size
   }
 
-  Int machine_mem = select_first([machine_mem_gb, 110])
+  # Based on https://docs.google.com/spreadsheets/d/1jOsudfO1-RadJXPGuHOIrjZW3Rg2SzvlL8Wg-lxZVUU/edit#gid=1056496058
+  Int default_mem_gb = if (num_samples <= 10000) then 110
+      else if (num_samples <= 15000) then 150
+      else if (num_samples <= 40000) then 256
+      else if (num_samples <= 99000) then 512
+      else 624
+
+  Int machine_mem = select_first([machine_mem_gb, default_mem_gb])
   Int java_mem = machine_mem - 10
 
   File monitoring_script = "gs://gvs_quickstart_storage/cromwell_monitoring_script.sh"


### PR DESCRIPTION
Allow VQSR Classic Memory overrides to be passed from GvsJointVariantCalling.wdl to GvsCreateFilterSet.wdl.
Increase memory overhead on a couple of tasks in GvsVQSRClassic.wdl

@RoriCremer is running the integration test [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration/job_history/8a8b5553-d9d4-47f5-80fb-ec5992172143).