### PR TITLE
Make extract backwards compatible with the new schema

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -111,7 +111,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - rc-vs-1033-extract-back-comp
    - name: GvsImportGenomes
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsImportGenomes.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -111,6 +111,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - rc-vs-1033-extract-back-comp
    - name: GvsImportGenomes
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/GvsImportGenomes.wdl

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -661,8 +661,13 @@ task IsVQSRLite {
     echo "project_id = ~{project_id}" > ~/.bigqueryrc
 
     bq --apilog=false query --project_id='~{project_id}' --format=csv --use_legacy_sql=false ~{bq_labels} \
-      "SELECT COUNT(1) FROM \`~{fq_filter_set_info_table}\` WHERE filter_set_name = '~{filter_set_name}' \
-      AND calibration_sensitivity IS NOT NULL" | tail -1 > lite_count_file.txt
+    "BEGIN \
+      "SELECT COUNT(1) AS counted FROM \`~{fq_filter_set_info_table}\` WHERE filter_set_name = '~{filter_set_name}' \
+          AND calibration_sensitivity IS NOT NULL;
+    EXCEPTION WHEN ERROR THEN \
+        ## if there is an exception, then calibration_sensitivity does not exist, which means that this is an old schema, VQSR classic has been used and so we know count is 0
+       SELECT '0' AS counted ;
+    END" | tail -1 > lite_count_file.txt
     LITE_COUNT=`cat lite_count_file.txt`
 
     bq --apilog=false query --project_id='~{project_id}' --format=csv --use_legacy_sql=false ~{bq_labels} \

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -662,7 +662,7 @@ task IsVQSRLite {
 
     bq --apilog=false query --project_id='~{project_id}' --format=csv --use_legacy_sql=false ~{bq_labels} \
     "BEGIN \
-      "SELECT COUNT(1) AS counted FROM \`~{fq_filter_set_info_table}\` WHERE filter_set_name = '~{filter_set_name}' \
+      SELECT COUNT(1) AS counted FROM \`~{fq_filter_set_info_table}\` WHERE filter_set_name = '~{filter_set_name}' \
           AND calibration_sensitivity IS NOT NULL;
     EXCEPTION WHEN ERROR THEN \
        SELECT '0' AS counted ;

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -665,10 +665,10 @@ task IsVQSRLite {
       "SELECT COUNT(1) AS counted FROM \`~{fq_filter_set_info_table}\` WHERE filter_set_name = '~{filter_set_name}' \
           AND calibration_sensitivity IS NOT NULL;
     EXCEPTION WHEN ERROR THEN \
-        ## if there is an exception, then calibration_sensitivity does not exist, which means that this is an old schema, VQSR classic has been used and so we know count is 0
        SELECT '0' AS counted ;
     END" | tail -1 > lite_count_file.txt
     LITE_COUNT=`cat lite_count_file.txt`
+
 
     bq --apilog=false query --project_id='~{project_id}' --format=csv --use_legacy_sql=false ~{bq_labels} \
       "SELECT COUNT(1) FROM \`~{fq_filter_set_info_table}\` WHERE filter_set_name = '~{filter_set_name}' \


### PR DESCRIPTION
successful run:
https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20cremer/job_history/649ee4c9-1afc-473b-b460-2fc88d5f49d4

failing run with the bug:
https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20cremer/job_history/f1c952fc-7f05-4468-ae20-1c1cc5b9bf38


AC is:

Cohort builder subcohort extract in AoU and our extract workflow work with both VETS and VQSR callsets, including past callsets. (Note--I did not test in AoU, just on quickstart since the issue doesn't seem to be permission or scale related--see failure reproduced above)

Full extract with past callset & VQSR
https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20cremer/job_history/649ee4c9-1afc-473b-b460-2fc88d5f49d4

Subcohort extract with past callset & VQSR

Full extract with new callset & VETS
https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration/job_history/50ef3073-f618-42ee-b207-73712a783a8a
(note this failed but only on one of the 4 runs and it's based on query cost)

<img width="1202" alt="Screenshot 2023-08-25 at 1 22 58 PM" src="https://github.com/broadinstitute/gatk/assets/6863459/39468ed8-fe2b-4bf8-9326-3bfcf6dabbb1">

Kevin is able to run latest extract on Delta (still waiting on Kevin, but otherwise the above are all set)

note that there was briefly no "score" col but I dont _think_ we need to be backwards compatible for that as there was no release