### PR TITLE
Update to gatk script to contain custom jdk path parameter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -830,19 +830,19 @@ task gatkTabComplete(type: Javadoc, dependsOn: classes) {
 
     options.addStringOption("caller-script-name", "gatk")
 
-    options.addStringOption("caller-pre-legal-args", "--help --list --dry-run --java-options")
-    options.addStringOption("caller-pre-arg-val-types", "null null null String")
-    options.addStringOption("caller-pre-mutex-args", "--help;list,dry-run,java-options --list;help,dry-run,java-options")
+    options.addStringOption("caller-pre-legal-args", "--help --list --dry-run --jdk-path --java-options")
+    options.addStringOption("caller-pre-arg-val-types", "null null null String String")
+    options.addStringOption("caller-pre-mutex-args", "--help;list,dry-run,jdk-path,java-options --list;help,dry-run,jdk-path,java-options")
     options.addStringOption("caller-pre-alias-args", "--help;-h")
-    options.addStringOption("caller-pre-arg-min-occurs", "0 0 0 0")
-    options.addStringOption("caller-pre-arg-max-occurs", "1 1 1 1")
+    options.addStringOption("caller-pre-arg-min-occurs", "0 0 0 0 0")
+    options.addStringOption("caller-pre-arg-max-occurs", "1 1 1 1 1")
 
-    options.addStringOption("caller-post-legal-args", "--spark-runner --spark-master --cluster --dry-run --java-options --conf --driver-memory --driver-cores --executor-memory --executor-cores --num-executors")
-    options.addStringOption("caller-post-arg-val-types", "String String String null String file int int int int int")
+    options.addStringOption("caller-post-legal-args", "--spark-runner --spark-master --cluster --dry-run --jdk-path --java-options --conf --driver-memory --driver-cores --executor-memory --executor-cores --num-executors")
+    options.addStringOption("caller-post-arg-val-types", "String String String null String String file int int int int int")
     options.addStringOption("caller-post-mutex-args", "")
     options.addStringOption("caller-post-alias-args", "")
-    options.addStringOption("caller-post-arg-min-occurs", "0 0 0 0 0 0 0 0 0 0")
-    options.addStringOption("caller-post-arg-max-occurs", "1 1 1 1 1 1 1 1 1 1")
+    options.addStringOption("caller-post-arg-min-occurs", "0 0 0 0 0 0 0 0 0 0 0")
+    options.addStringOption("caller-post-arg-max-occurs", "1 1 1 1 1 1 1 1 1 1 1")
 }
 
 def getWDLInputJSONTestFileNameFromWDLName(File wdlName) {

--- a/gatk
+++ b/gatk
@@ -111,7 +111,7 @@ def main(args):
             print("                 to dataproc equivalents")
             print("")
             print("   --dry-run      may be specified to output the generated command line without running it")
-            print("   --jdk-path    sets up java executable path to a specified folder. Default:System default java path")
+            print("   --jdk-path    sets up java executable path to a specified folder.")
             print("   --java-options 'OPTION1[ OPTION2=Y ... ]'   optional - pass the given string of options to the ")
             print("                 java JVM at runtime.  ")
             print("                 Java options MUST be passed inside a single string with space-separated values.")


### PR DESCRIPTION
Bundled jdk path was set to 

`scriptpath + "/gatkbundle/jdk/bin/java"`

arbitrarily. It may be changed depending on the consensus of how to bundle a jdk with gatk. 