### PR TITLE
Update hail version to 120 in Integration test VS 1025

### DIFF
--- a/scripts/variantstore/wdl/GvsQuickstartHailIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartHailIntegration.wdl
@@ -172,7 +172,7 @@ task CreateAndTieOutVds {
 
         export PYSPARK_SUBMIT_ARGS='--driver-memory 16g --executor-memory 16g pyspark-shell'
         pip install --upgrade pip
-        pip install hail==0.2.119
+        pip install hail==0.2.120
 
         export WORK=$PWD/work
         mkdir ${WORK}

--- a/scripts/variantstore/wdl/extract/hail_join_vds_vcfs.py
+++ b/scripts/variantstore/wdl/extract/hail_join_vds_vcfs.py
@@ -15,6 +15,8 @@ def vds_mt(vds_path):
 
 
 def vcf_mt(vcf_paths):
+    # Import a VCF that we will use a truth data for this test
+    # Setting array_elements_required to false is done as a workaround because Hail has a hard time with unconventional fields with empty values e.g. AS_YNG=.,.,. Avoiding explicitly acknowledging the use of missing elements in arrays requires Hail to make a decision in several ambiguous cases
     mt = hl.import_vcf(vcf_paths, force_bgz=True, reference_genome='GRCh38', array_elements_required=False).key_rows_by('locus')
     return mt
 
@@ -35,7 +37,7 @@ def joined_mt(mt_path):
     return mt
 
 
-if __name__ == '__main__':
+if __name__ == '__main__':oh
     parser = argparse.ArgumentParser()
     parser.add_argument('--vds-path', required=True,
                         help='Input VDS for tieout')

--- a/scripts/variantstore/wdl/extract/hail_join_vds_vcfs.py
+++ b/scripts/variantstore/wdl/extract/hail_join_vds_vcfs.py
@@ -15,7 +15,7 @@ def vds_mt(vds_path):
 
 
 def vcf_mt(vcf_paths):
-    mt = hl.import_vcf(vcf_paths, force_bgz=True, reference_genome='GRCh38').key_rows_by('locus')
+    mt = hl.import_vcf(vcf_paths, force_bgz=True, reference_genome='GRCh38', array_elements_required=False).key_rows_by('locus')
     return mt
 
 

--- a/scripts/variantstore/wdl/extract/hail_join_vds_vcfs.py
+++ b/scripts/variantstore/wdl/extract/hail_join_vds_vcfs.py
@@ -15,8 +15,9 @@ def vds_mt(vds_path):
 
 
 def vcf_mt(vcf_paths):
-    # Import a VCF that we will use a truth data for this test
-    # Setting array_elements_required to false is done as a workaround because Hail has a hard time with unconventional fields with empty values e.g. AS_YNG=.,.,. Avoiding explicitly acknowledging the use of missing elements in arrays requires Hail to make a decision in several ambiguous cases
+    # Import a VCF that we will use as truth data for this test
+    # Setting array_elements_required to false is done as a workaround because Hail has a hard time with unconventional fields with empty values e.g. AS_YNG=.,.,.
+    # Avoiding explicitly acknowledging the use of missing elements in arrays requires Hail to make a decision in several ambiguous cases
     mt = hl.import_vcf(vcf_paths, force_bgz=True, reference_genome='GRCh38', array_elements_required=False).key_rows_by('locus')
     return mt
 
@@ -37,7 +38,7 @@ def joined_mt(mt_path):
     return mt
 
 
-if __name__ == '__main__':oh
+if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--vds-path', required=True,
                         help='Input VDS for tieout')

--- a/scripts/variantstore/wdl/extract/import_gvs.py
+++ b/scripts/variantstore/wdl/extract/import_gvs.py
@@ -2,7 +2,7 @@ import os
 from typing import List
 
 import hail as hl
-from hail.experimental.vcf_combiner.vcf_combiner import merge_alleles
+from hail.vds.combiner.combine import merge_alleles
 from hail.genetics.reference_genome import reference_genome_type
 from hail.typecheck import typecheck, sequenceof, numeric
 


### PR DESCRIPTION
AC:

While in a Notebook, I can run Hail 120 and I can specifically run the new vcf_combiner code
merge_alleles() works in the 120
and we must use array_elements_required=False in import_VCF to get around the missing data issue Dan pointed out
![image](https://github.com/broadinstitute/gatk/assets/6863459/3da27122-8b6b-4bec-b785-55846e671cff)


Hail version 120 has been pinned in the Integration test -- pinned!

Integration test with above pin has succeeded.
https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration/job_history/a1c5e4c4-2058-4dad-8261-87b23c8bb0f3