### PR TITLE
Rewrite complex SV functional annotation in SVAnnotate

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/GATKSVVCFConstants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/GATKSVVCFConstants.java
@@ -163,6 +163,7 @@ public final class GATKSVVCFConstants {
     public static final String NONCODING_BREAKPOINT = "PREDICTED_NONCODING_BREAKPOINT";
     public static final String NEAREST_TSS = "PREDICTED_NEAREST_TSS";
     public static final String TSS_DUP = "PREDICTED_TSS_DUP";
+    public static final String PARTIAL_DISPERSED_DUP = "PREDICTED_PARTIAL_DISPERSED_DUP";
 
     // SVTYPE classes
     public enum StructuralVariantAnnotationType {

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/GATKSVVCFConstants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/GATKSVVCFConstants.java
@@ -89,7 +89,9 @@ public final class GATKSVVCFConstants {
         piDUP_RF,
         dDUP,
         dDUP_iDEL,
-        INS_iDEL
+        INS_iDEL,
+        CTX_PP_QQ,
+        CTX_PQ_QP
     }
 
     // not defined in output vcf header but used in internal id that is currently output in the ID column

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotate.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotate.java
@@ -123,6 +123,10 @@ import java.util.*;
  *     duplicated. The partial duplication occurs when a duplication has one breakpoint within the transcript and one
  *     breakpoint after the end of the transcript. When the duplication is in tandem, the result is that there is one
  *     intact copy of the full endogenous gene.</p></li>
+ *     <li><p><i>PREDICTED_PARTIAL_DISPERSED_DUP</i><br />
+ *     Gene(s) which are partially overlapped by an SV's dispersed duplication. This annotation is applied to a
+ *     dispersed (non-tandem) duplication segment that is part of a complex SV if the duplicated segment overlaps part
+ *     of a transcript but not the entire transcript (which would be a PREDICTED_COPY_GAIN event).</p></li>
  *     <li><p><i>PREDICTED_INV_SPAN</i><br />
  *     Gene(s) which are entirely spanned by an SV's inversion. A whole-gene inversion occurs when an inversion spans
  *     the entire transcript, from the first base of the 5' UTR to the last base of the 3' UTR. </p></li>
@@ -354,6 +358,7 @@ public final class SVAnnotate extends VariantWalker {
         header.addMetaDataLine(new VCFInfoHeaderLine(GATKSVVCFConstants.NONCODING_SPAN, VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, "Class(es) of noncoding elements spanned by SV."));
         header.addMetaDataLine(new VCFInfoHeaderLine(GATKSVVCFConstants.NONCODING_BREAKPOINT, VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, "Class(es) of noncoding elements disrupted by SV breakpoint."));
         header.addMetaDataLine(new VCFInfoHeaderLine(GATKSVVCFConstants.NEAREST_TSS, VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, "Nearest transcription start site to an intergenic variant."));
+        header.addMetaDataLine(new VCFInfoHeaderLine(GATKSVVCFConstants.PARTIAL_DISPERSED_DUP, VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, "Gene(s) overlapped partially by a dispersed duplication in a complex SV."));
 
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotate.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotate.java
@@ -124,9 +124,10 @@ import java.util.*;
  *     breakpoint after the end of the transcript. When the duplication is in tandem, the result is that there is one
  *     intact copy of the full endogenous gene.</p></li>
  *     <li><p><i>PREDICTED_PARTIAL_DISPERSED_DUP</i><br />
- *     Gene(s) which are partially overlapped by an SV's dispersed duplication. This annotation is applied to a
- *     dispersed (non-tandem) duplication segment that is part of a complex SV if the duplicated segment overlaps part
- *     of a transcript but not the entire transcript (which would be a PREDICTED_COPY_GAIN event).</p></li>
+ *     Gene(s) which are partially overlapped by the duplicated segment involved in an SV's dispersed duplication.
+ *     This annotation is applied to a dispersed (non-tandem) duplication segment that is part of a complex SV if the
+ *     duplicated segment overlaps part of a transcript but not the entire transcript (which would be a
+ *     PREDICTED_COPY_GAIN event).</p></li>
  *     <li><p><i>PREDICTED_INV_SPAN</i><br />
  *     Gene(s) which are entirely spanned by an SV's inversion. A whole-gene inversion occurs when an inversion spans
  *     the entire transcript, from the first base of the 5' UTR to the last base of the 3' UTR. </p></li>
@@ -358,7 +359,7 @@ public final class SVAnnotate extends VariantWalker {
         header.addMetaDataLine(new VCFInfoHeaderLine(GATKSVVCFConstants.NONCODING_SPAN, VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, "Class(es) of noncoding elements spanned by SV."));
         header.addMetaDataLine(new VCFInfoHeaderLine(GATKSVVCFConstants.NONCODING_BREAKPOINT, VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, "Class(es) of noncoding elements disrupted by SV breakpoint."));
         header.addMetaDataLine(new VCFInfoHeaderLine(GATKSVVCFConstants.NEAREST_TSS, VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, "Nearest transcription start site to an intergenic variant."));
-        header.addMetaDataLine(new VCFInfoHeaderLine(GATKSVVCFConstants.PARTIAL_DISPERSED_DUP, VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, "Gene(s) overlapped partially by a dispersed duplication in a complex SV."));
+        header.addMetaDataLine(new VCFInfoHeaderLine(GATKSVVCFConstants.PARTIAL_DISPERSED_DUP, VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, "Gene(s) overlapped partially by the duplicated interval involved in a dispersed duplication event in a complex SV."));
 
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/SimpleInterval.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/SimpleInterval.java
@@ -1,6 +1,7 @@
  package org.broadinstitute.hellbender.utils;
 
 
+import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.util.Locatable;
@@ -273,6 +274,25 @@ public final class SimpleInterval implements Locatable, Serializable {
          return new SimpleInterval(getContig(),
                  Math.max(getStart(), that.getStart()),
                  Math.min( getEnd(), that.getEnd()) );
+     }
+
+     /**
+      * Get section of starting interval (this) that is not overlapped by the other interval (that)
+      * @param that - interval to subtract from starting interval. Must overlap (but not fully contain) starting interval
+      * @return - SimpleInterval representing the portion of starting interval (this) not overlapped by other interval (that)
+      */
+     @VisibleForTesting
+     public SimpleInterval subtract(final Locatable that) {
+         Utils.validateArg(this.overlaps(that), () ->
+                 "SimpleIntervaL::subtract(): The two intervals need to overlap: " + this + ", " + that);
+         Utils.validateArg(!that.contains(this), () ->
+                 "SimpleIntervaL::subtract(): Interval to subtract " + that + " cannot contain starting interval " + this);
+         if (this.getStart() < that.getStart()) {
+             return new SimpleInterval(this.getContig(), this.getStart(), that.getStart());
+         }
+         else {
+             return new SimpleInterval(this.getContig(), that.getEnd(), this.getEnd());
+         }
      }
 
      /**

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateEngineUnitTest.java
@@ -752,6 +752,14 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
                                 Arrays.asList(GATKSVVCFConstants.PROMOTER, GATKSVVCFConstants.COPY_GAIN,
                                         GATKSVVCFConstants.INTERGENIC),
                                 Arrays.asList("EMMA1", "EMMA2", false)) },
+                // dupINVdup with CG
+                { createVariantContext("chr1", 20, 3500, null, null, null,
+                        "<CPX>", 3480, null, "dupINVdup",
+                        Arrays.asList("DUP_chr1:20-70", "INV_chr1:20-3500", "DUP_chr1:2000-3500")),
+                        createAttributesMap(
+                                Arrays.asList(GATKSVVCFConstants.INV_SPAN, GATKSVVCFConstants.COPY_GAIN,
+                                        GATKSVVCFConstants.NONCODING_SPAN, GATKSVVCFConstants.INTERGENIC),
+                                Arrays.asList("EMMA1", "EMMA2", Arrays.asList("DNase", "Enhancer"), false)) },
                 // ignore INV for dDUP; ignore dDUP for promoter; CPX noncoding span; CPX intergenic
                 { createVariantContext("chr1", 1101, 1102, null, null, null,
                         "<CPX>", 700, null, "dDUP_iDEL",
@@ -785,8 +793,8 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
                                         GATKSVVCFConstants.INTERGENIC),
                                 Arrays.asList("EMMA1", "EMMA1", true)) },
                 // merge INV + DEL for nearest TSS; noncoding breakpoint for CPX
-                { createVariantContext("chr1", 10, 11, null, null, null,
-                        "<CPX>", 40, null, "delINV",
+                { createVariantContext("chr1", 1400, 1900, null, null, null,
+                        "<CPX>", 500, null, "delINV",
                         Arrays.asList("DEL_chr1:1400-1500", "INV_chr1:1500-1900")),
                         createAttributesMap(
                                 Arrays.asList(GATKSVVCFConstants.NONCODING_BREAKPOINT, GATKSVVCFConstants.NEAREST_TSS,

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateEngineUnitTest.java
@@ -279,17 +279,17 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
     @DataProvider(name = "complexVariantIntervals")
     public Object[][] getComplexVariantIntervalsTestData() {
         return new Object[][] {
-                { "dDUP", "DUP_chr1:280-420",
+                { GATKSVVCFConstants.ComplexVariantSubtype.dDUP, "DUP_chr1:280-420",
                         createListOfSVSegmentsDifferentTypes(new GATKSVVCFConstants.StructuralVariantAnnotationType[]{
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.DUP },
                                 new SimpleInterval[]{new SimpleInterval("chr1", 280, 420)}) },
-                { "dupINV", "DUP_chr1:44355904-44356327,INV_chr1:44355904-44357498",
+                { GATKSVVCFConstants.ComplexVariantSubtype.dupINV, "DUP_chr1:44355904-44356327,INV_chr1:44355904-44357498",
                         createListOfSVSegmentsDifferentTypes(new GATKSVVCFConstants.StructuralVariantAnnotationType[]{
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.DUP,
                                         GATKSVVCFConstants.StructuralVariantAnnotationType.INV},
                         new SimpleInterval[]{new SimpleInterval("chr1", 44355904, 44356327),
                                 new SimpleInterval("chr1", 44356327, 44357498)}) },
-                { "dupINVdup", "DUP_chr1:247660974-248129213,INV_chr1:247660974-248587216,DUP_chr1:248520217-248587216",
+                { GATKSVVCFConstants.ComplexVariantSubtype.dupINVdup, "DUP_chr1:247660974-248129213,INV_chr1:247660974-248587216,DUP_chr1:248520217-248587216",
                         createListOfSVSegmentsDifferentTypes(new GATKSVVCFConstants.StructuralVariantAnnotationType[]{
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.DUP,
                                         GATKSVVCFConstants.StructuralVariantAnnotationType.DUP,
@@ -297,35 +297,35 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
                         new SimpleInterval[]{new SimpleInterval("chr1", 247660974, 248129213),
                                 new SimpleInterval("chr1", 248520217, 248587216),
                                 new SimpleInterval("chr1", 248129213, 248520217)}) },
-                { "dDUP_iDEL", "DUP_chr2:131488885-131489335,INV_chr2:131488885-131489335,DEL_chr2:130185450-130185720",
+                { GATKSVVCFConstants.ComplexVariantSubtype.dDUP_iDEL, "DUP_chr2:131488885-131489335,INV_chr2:131488885-131489335,DEL_chr2:130185450-130185720",
                         createListOfSVSegmentsDifferentTypes(new GATKSVVCFConstants.StructuralVariantAnnotationType[]{
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.DUP,
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.DEL},
                         new SimpleInterval[]{new SimpleInterval("chr2", 131488885,131489335),
                                 new SimpleInterval("chr2", 130185450,130185720)}) },
-                { "dDUP_iDEL", "DUP_chr3:95751919-95752156,DEL_chr3:95746923-95749272",
+                { GATKSVVCFConstants.ComplexVariantSubtype.dDUP_iDEL, "DUP_chr3:95751919-95752156,DEL_chr3:95746923-95749272",
                         createListOfSVSegmentsDifferentTypes(new GATKSVVCFConstants.StructuralVariantAnnotationType[]{
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.DUP,
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.DEL},
                         new SimpleInterval[]{new SimpleInterval("chr3", 95751919,95752156),
                                 new SimpleInterval("chr3", 95746923,95749272)}) },
-                { "INS_iDEL", "DEL_chr3:60521333-60521483",
+                { GATKSVVCFConstants.ComplexVariantSubtype.INS_iDEL, "DEL_chr3:60521333-60521483",
                         createListOfSVSegmentsDifferentTypes(new GATKSVVCFConstants.StructuralVariantAnnotationType[]{
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.DEL},
                         new SimpleInterval[]{new SimpleInterval("chr3", 60521333,60521483)}) },
-                { "delINV", "DEL_chr2:120379742-120383130,INV_chr2:120383130-120384123",
+                { GATKSVVCFConstants.ComplexVariantSubtype.delINV, "DEL_chr2:120379742-120383130,INV_chr2:120383130-120384123",
                         createListOfSVSegmentsDifferentTypes(new GATKSVVCFConstants.StructuralVariantAnnotationType[]{
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.INV},
                         new SimpleInterval[]{new SimpleInterval("chr2", 120379742,120383130),
                                 new SimpleInterval("chr2", 120383130,120384123)}) },
-                { "INVdel", "INV_chr2:122719025-122719803,DEL_chr2:122719803-122724929",
+                { GATKSVVCFConstants.ComplexVariantSubtype.INVdel, "INV_chr2:122719025-122719803,DEL_chr2:122719803-122724929",
                         createListOfSVSegmentsDifferentTypes(new GATKSVVCFConstants.StructuralVariantAnnotationType[]{
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.INV,
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.DEL},
                         new SimpleInterval[]{new SimpleInterval("chr2", 122719025,122719803),
                                 new SimpleInterval("chr2", 122719803,122724929)}) },
-                { "delINVdup", "DEL_chr2:54002577-54003019,INV_chr2:54003019-54006204,DUP_chr2:54006057-54006204",
+                { GATKSVVCFConstants.ComplexVariantSubtype.delINVdup, "DEL_chr2:54002577-54003019,INV_chr2:54003019-54006204,DUP_chr2:54006057-54006204",
                         createListOfSVSegmentsDifferentTypes(new GATKSVVCFConstants.StructuralVariantAnnotationType[]{
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.DUP,
@@ -333,7 +333,7 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
                         new SimpleInterval[]{new SimpleInterval("chr2", 54002577,54003019),
                                 new SimpleInterval("chr2", 54006057,54006204),
                                 new SimpleInterval("chr2", 54003019,54006057)}) },
-                { "dupINVdel", "DUP_chr2:4157678-4157846,INV_chr2:4157678-4165085,DEL_chr2:4165085-4175888",
+                { GATKSVVCFConstants.ComplexVariantSubtype.dupINVdel, "DUP_chr2:4157678-4157846,INV_chr2:4157678-4165085,DEL_chr2:4165085-4175888",
                         createListOfSVSegmentsDifferentTypes(new GATKSVVCFConstants.StructuralVariantAnnotationType[]{
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.DUP,
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
@@ -341,7 +341,7 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
                         new SimpleInterval[]{new SimpleInterval("chr2", 4157678,4157846),
                                 new SimpleInterval("chr2", 4165085,4175888),
                                 new SimpleInterval("chr2", 4157846,4165085)}) },
-                { "delINVdel", "DEL_chr2:62384663-62387814,INV_chr2:62387814-62388322,DEL_chr2:62388322-62390272",
+                { GATKSVVCFConstants.ComplexVariantSubtype.delINVdel, "DEL_chr2:62384663-62387814,INV_chr2:62387814-62388322,DEL_chr2:62388322-62390272",
                         createListOfSVSegmentsDifferentTypes(new GATKSVVCFConstants.StructuralVariantAnnotationType[]{
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.INV,
@@ -355,11 +355,11 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
     // Test getComplexAnnotationIntervals()
     @Test(dataProvider = "complexVariantIntervals")
     public void testGetSegmentsFromComplexIntervals(
-            final String complexType,
+            final GATKSVVCFConstants.ComplexVariantSubtype complexType,
             final String cpxIntervalsString,
             final List<SVAnnotateEngine.SVSegment> expectedSVSegments
     ) {
-        final List<String> cpxIntervals = Arrays.asList(cpxIntervalsString.split(","));
+        final List<SVAnnotateEngine.SVSegment> cpxIntervals = SVAnnotateEngine.parseComplexIntervals(Arrays.asList(cpxIntervalsString.split(",")));
         final List<SVAnnotateEngine.SVSegment> actualSegments = SVAnnotateEngine.getComplexAnnotationIntervals(cpxIntervals,
                 complexType);
         assertSegmentListEqual(actualSegments, expectedSVSegments);
@@ -369,10 +369,10 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
     @DataProvider(name = "toyComplexVariants")
     public Object[][] getToyComplexVariantTestData() {
         return new Object[][] {
-                { "dDUP", "DUP_chr1:280-420", Sets.newHashSet(GATKSVVCFConstants.PARTIAL_DISPERSED_DUP) },
-                { "INVdup", "INV_chr1:90-1010,DUP_chr1:890-1010",
+                { GATKSVVCFConstants.ComplexVariantSubtype.dDUP, "DUP_chr1:280-420", Sets.newHashSet(GATKSVVCFConstants.PARTIAL_DISPERSED_DUP) },
+                { GATKSVVCFConstants.ComplexVariantSubtype.INVdup, "INV_chr1:90-1010,DUP_chr1:890-1010",
                         Sets.newHashSet(GATKSVVCFConstants.LOF, GATKSVVCFConstants.PARTIAL_DISPERSED_DUP) },
-                { "delINVdup", "DEL_chr1:250-450,INV_chr1:450-650,DUP_chr1:610-650",
+                { GATKSVVCFConstants.ComplexVariantSubtype.delINVdup, "DEL_chr1:250-450,INV_chr1:450-650,DUP_chr1:610-650",
                         Sets.newHashSet(GATKSVVCFConstants.LOF, GATKSVVCFConstants.PARTIAL_DISPERSED_DUP) }
         };
     }
@@ -380,7 +380,7 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
     // Test annotation of CPX events for gene overlaps from CPX_INTERVALS string
     @Test(dataProvider = "toyComplexVariants")
     public void testAnnotateComplexEvents(
-            final String complexType,
+            final GATKSVVCFConstants.ComplexVariantSubtype complexType,
             final String cpxIntervalsString,
             final Set<String> expectedConsequences
     ) {
@@ -394,7 +394,7 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
         SVAnnotateEngine svAnnotateEngine = new SVAnnotateEngine(gtfTrees, null, sequenceDictionary,
                 -1);
 
-        final List<String> cpxIntervals = Arrays.asList(cpxIntervalsString.split(","));
+        final List<SVAnnotateEngine.SVSegment> cpxIntervals = SVAnnotateEngine.parseComplexIntervals(Arrays.asList(cpxIntervalsString.split(",")));
         final List<SVAnnotateEngine.SVSegment> cpxSegments = SVAnnotateEngine.getComplexAnnotationIntervals(cpxIntervals, complexType);
         for (final SVAnnotateEngine.SVSegment cpxSegment: cpxSegments) {
             svAnnotateEngine.annotateGeneOverlaps(cpxSegment.getInterval(), cpxSegment.getIntervalSVType(), true,
@@ -404,18 +404,26 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
         Assert.assertEquals(variantConsequenceDict.keySet(), expectedConsequences);
     }
 
+    private Map<String, Set<String>> createVariantConsequenceDict(final String[] consequences,
+                                                                  final String[] features) {
+        Assert.assertEquals(consequences.length, features.length);
+        final Map<String, Set<String>> map = new HashMap<>();
+        for (int i = 0; i < consequences.length; i++) {
+            SVAnnotateEngine.updateVariantConsequenceDict(map, consequences[i], features[i]);
+        }
+        return map;
+    }
+
 
     // Test sortVariantConsequenceDict() sorts lists of genes in variant consequence map
     @Test
     public void testSortVariantConsequenceDict() {
-        final Map<String, Set<String>> before = new HashMap<>();
-        SVAnnotateEngine.updateVariantConsequenceDict(before, GATKSVVCFConstants.LOF, "NOC2L");
-        SVAnnotateEngine.updateVariantConsequenceDict(before, GATKSVVCFConstants.LOF, "KLHL17");
-        SVAnnotateEngine.updateVariantConsequenceDict(before, GATKSVVCFConstants.LOF, "PLEKHN1");
-        SVAnnotateEngine.updateVariantConsequenceDict(before, GATKSVVCFConstants.LOF, "PERM1");
-        SVAnnotateEngine.updateVariantConsequenceDict(before, GATKSVVCFConstants.DUP_PARTIAL, "SAMD11");
-        SVAnnotateEngine.updateVariantConsequenceDict(before, GATKSVVCFConstants.LOF, "HES4");
-        SVAnnotateEngine.updateVariantConsequenceDict(before, GATKSVVCFConstants.TSS_DUP, "ISG15");
+        final Map<String, Set<String>> before = createVariantConsequenceDict(
+                new String[]{GATKSVVCFConstants.LOF, GATKSVVCFConstants.LOF, GATKSVVCFConstants.LOF,
+                        GATKSVVCFConstants.LOF, GATKSVVCFConstants.DUP_PARTIAL, GATKSVVCFConstants.LOF,
+                        GATKSVVCFConstants.TSS_DUP},
+                new String[]{"NOC2L", "KLHL17", "PLEKHN1", "PERM1", "SAMD11", "HES4", "ISG15"}
+        );
 
         final Map<String, Object> expectedAfter = new HashMap<>();
         expectedAfter.put(GATKSVVCFConstants.DUP_PARTIAL, Arrays.asList("SAMD11"));
@@ -423,6 +431,34 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
         expectedAfter.put(GATKSVVCFConstants.LOF, Arrays.asList("HES4", "KLHL17", "NOC2L", "PERM1", "PLEKHN1"));
 
         Assert.assertEquals(SVAnnotateEngine.sortVariantConsequenceDict(before), expectedAfter);
+    }
+
+    @DataProvider(name = "proteinCodingConsequences")
+    public Object[][] getProteinCodingConsequences() {
+        return new Object[][] {
+                { createVariantConsequenceDict(
+                        new String[]{GATKSVVCFConstants.TSS_DUP, GATKSVVCFConstants.PARTIAL_DISPERSED_DUP},
+                        new String[]{"HES4", "SAMD11"}),
+                        false
+                },
+                { createVariantConsequenceDict(
+                        new String[]{GATKSVVCFConstants.PARTIAL_DISPERSED_DUP},
+                        new String[]{"SAMD11"}),
+                        true
+                },
+                { new HashMap<>(),
+                        true
+                }
+        };
+    }
+
+    @Test(dataProvider = "proteinCodingConsequences")
+    public void testIsIntergenic(
+            final Map<String, Set<String>> variantConsequenceDict,
+            final boolean expectedIsIntergenic
+    ){
+        final boolean actualIsIntergenic = SVAnnotateEngine.isIntergenic(variantConsequenceDict);
+        Assert.assertEquals(actualIsIntergenic, expectedIsIntergenic);
     }
 
 
@@ -491,6 +527,7 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
         return new Object[][] {
                 { createVariantContext("chr2", 86263976, 86263977, "chr19", 424309, "N",
                         "<CTX>", null, null, "CTX_PP/QQ", null),
+                        GATKSVVCFConstants.ComplexVariantSubtype.CTX_PP_QQ,
                         GATKSVVCFConstants.StructuralVariantAnnotationType.CTX,
                         createListOfSVSegments(GATKSVVCFConstants.StructuralVariantAnnotationType.CTX,
                                 new SimpleInterval[]{ new SimpleInterval("chr2", 86263976, 86263977),
@@ -498,66 +535,77 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
                         null },
                 { createVariantContext("chr2", 86263976, 86263976, null, 424309, "G",
                         "G]chr19:424309]", null, null,"CTX_PP/QQ", null),
+                        GATKSVVCFConstants.ComplexVariantSubtype.CTX_PP_QQ,
                         GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                         Arrays.asList(new SVAnnotateEngine.SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.CTX,
                                 new SimpleInterval("chr2", 86263976, 86263976))),
                         null},
                 { createVariantContext("chr2", 86263977, 86263977, null, 424309, "A",
                         "[chr19:424310[A", null, null, "CTX_PP/QQ", null),
+                        GATKSVVCFConstants.ComplexVariantSubtype.CTX_PP_QQ,
                         GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                         Arrays.asList(new SVAnnotateEngine.SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.CTX,
                                 new SimpleInterval("chr2", 86263977, 86263977))),
                         null },
                 { createVariantContext("chr2", 205522308, 205522384, "chr2", null, "N",
                         "<INV>", 76, null, null, null),
+                        null,
                         GATKSVVCFConstants.StructuralVariantAnnotationType.INV,
                         Arrays.asList(new SVAnnotateEngine.SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.INV,
                                 new SimpleInterval("chr2", 205522308, 205522384))),
                         null },
                 { createVariantContext("chr19", 424309, 424309, null, 424309, "T",
                         "T]chr2:86263976]", null, null, "CTX_PP/QQ", null),
+                        GATKSVVCFConstants.ComplexVariantSubtype.CTX_PP_QQ,
                         GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                         Arrays.asList(new SVAnnotateEngine.SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.CTX,
                                 new SimpleInterval("chr19", 424309, 424309))),
                         null },
                 { createVariantContext("chr19", 424310, 424310, null, 424309, "C",
                         "[chr2:86263977[C", null, null, "CTX_PP/QQ", null),
+                        GATKSVVCFConstants.ComplexVariantSubtype.CTX_PP_QQ,
                         GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                         Arrays.asList(new SVAnnotateEngine.SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.CTX,
                                 new SimpleInterval("chr19", 424310, 424310))),
                         null },
                 { createVariantContext("chr22", 10510000, 10694100, "chr22", null, "N",
                         "<DEL>", 184100, null, null, null),
+                        null,
                         GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
                         createListOfSVSegments(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
                                 new SimpleInterval[]{ new SimpleInterval("chr22", 10510000, 10694100)}),
                         null},
                 { createVariantContext("chr22", 10510000, 10694100, "chr22", null, "N",
                         "<DEL:ME:LINE1>", 184100, null, null, null),
+                        null,
                         GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
                         createListOfSVSegments(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
                                 new SimpleInterval[]{ new SimpleInterval("chr22", 10510000, 10694100)}),
                         null},
                 { createVariantContext("chr22", 10524000, 10710000, "chr22", null, "N",
                         "<DUP>", 186000, null, null, null),
+                        null,
                         GATKSVVCFConstants.StructuralVariantAnnotationType.DUP,
                         createListOfSVSegments(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP,
                                 new SimpleInterval[]{ new SimpleInterval("chr22", 10524000, 10710000)}),
                         null },
                 { createVariantContext("chr22", 10532563, 10532611, "chr22", null, "N",
                         "<INS:ME:ALU>", 245, null, null, null),
+                        null,
                         GATKSVVCFConstants.StructuralVariantAnnotationType.INS,
                         createListOfSVSegments(GATKSVVCFConstants.StructuralVariantAnnotationType.INS,
                                 new SimpleInterval[]{ new SimpleInterval("chr22", 10532563, 10532564)}),
                         null },
                 { createVariantContext("chr22", 10572758, 10572788, "chr22", null, "N",
                         "<INS>", 57, null, null, null),
+                        null,
                         GATKSVVCFConstants.StructuralVariantAnnotationType.INS,
                         createListOfSVSegments(GATKSVVCFConstants.StructuralVariantAnnotationType.INS,
                                 new SimpleInterval[]{ new SimpleInterval("chr22", 10572758, 10572759)}),
                         null },
                 { createVariantContext("chr22", 10717890, 10717890, "chr22", null, "N",
                         "<BND>", 5170, "-+", null, null),
+                        null,
                         GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                         createListOfSVSegments(GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                                 new SimpleInterval[]{ new SimpleInterval("chr22", 10717890, 10717890),
@@ -566,12 +614,14 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
                                 new SimpleInterval[]{ new SimpleInterval("chr22", 10717890, 10723060)}) },
                 { createVariantContext("chr22", 10774600, 10784500, "chr22", null, "N",
                         "<CNV>", 9900, null, null, null),
+                        null,
                         GATKSVVCFConstants.StructuralVariantAnnotationType.CNV,
                         createListOfSVSegments(GATKSVVCFConstants.StructuralVariantAnnotationType.CNV,
                                 new SimpleInterval[]{ new SimpleInterval("chr22", 10774600, 10784500)}),
                         null },
                 { createVariantContext("chr22", 10930458, 10930458, "chr22", 11564561, "N",
                         "<BND>", 634103, "--", null, null),
+                        null,
                         GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                         createListOfSVSegments(GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                                 new SimpleInterval[]{ new SimpleInterval("chr22", 10930458, 10930458),
@@ -579,6 +629,7 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
                         null },
                 { createVariantContext("chr22", 17636024, 17636024, "chr22", null, "N",
                         "<BND>", 10709, "+-", null, null),
+                        null,
                         GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                         createListOfSVSegments(GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                                 new SimpleInterval[]{ new SimpleInterval("chr22", 17636024, 17636024),
@@ -588,6 +639,7 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
                 { createVariantContext("chr22", 18971159, 18971435, "chr22", null, "N",
                         "<CPX>", 386, null, "dDUP",
                         Arrays.asList("INV_chr22:20267228-20267614","DUP_chr22:20267228-20267614")),
+                        GATKSVVCFConstants.ComplexVariantSubtype.dDUP,
                         GATKSVVCFConstants.StructuralVariantAnnotationType.CPX,
                         Arrays.asList(
                                 new SVAnnotateEngine.SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP,
@@ -597,6 +649,7 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
                         null },
                 { createVariantContext("chr22", 22120897, 22120897, "chrX", 126356858, "N",
                         "<BND>", -1, "++", null, null),
+                        null,
                         GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                         createListOfSVSegments(GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                                 new SimpleInterval[]{ new SimpleInterval("chr22", 22120897, 22120897),
@@ -604,6 +657,7 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
                         null },
                 { createVariantContext("chr22", 22196261, 22196261, "chr22", null, "N",
                         "<BND>", 708725, "+-", null, null),
+                        null,
                         GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                         createListOfSVSegments(GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                                 new SimpleInterval[]{ new SimpleInterval("chr22", 22196261, 22196261),
@@ -611,12 +665,14 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
                         null },
                 { createVariantContext("chr22", 22196261, 22196261, null, null, "A",
                         "A[chr22:22904986[", null, "+-", null, null),
+                        null,
                         GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                         createListOfSVSegments(GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                                 new SimpleInterval[]{ new SimpleInterval("chr22", 22196261, 22196261) }),
                         null },
                 { createVariantContext("chr22", 22904986, 22904986, null, null, "T",
                         "]chr22:22196261]T", null, "+-", null, null),
+                        null,
                         GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                         createListOfSVSegments(GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                                 new SimpleInterval[]{ new SimpleInterval("chr22", 22904986, 22904986) }),
@@ -624,6 +680,7 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
                 { createVariantContext("chr22", 36533058, 36538234, "chr22", null, "N",
                         "<CPX>", 5176, null, "dupINV",
                         Arrays.asList("DUP_chr22:36533058-36533299","INV_chr22:36533058-36538234")),
+                        GATKSVVCFConstants.ComplexVariantSubtype.dupINV,
                         GATKSVVCFConstants.StructuralVariantAnnotationType.CPX,
                         Arrays.asList(
                                 new SVAnnotateEngine.SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP,
@@ -638,6 +695,7 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
     @Test(dataProvider = "typesAndSegments")
     public void testGetSVTypeAndSegments(
             final VariantContext variant,
+            final GATKSVVCFConstants.ComplexVariantSubtype complexType,
             final GATKSVVCFConstants.StructuralVariantAnnotationType expectedSVType,
             final List<SVAnnotateEngine.SVSegment> expectedSVSegments,
             final List<SVAnnotateEngine.SVSegment> expectedSVSegmentsWithBNDOverlap
@@ -646,11 +704,11 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
         Assert.assertEquals(actualSVType, expectedSVType);
 
         final List<SVAnnotateEngine.SVSegment> actualSegments = SVAnnotateEngine.getSVSegments(variant,
-                actualSVType, -1);
+                actualSVType, -1, complexType);
         assertSegmentListEqual(actualSegments, expectedSVSegments);
 
         final List<SVAnnotateEngine.SVSegment> actualSegmentsWithBNDOverlap = SVAnnotateEngine.getSVSegments(variant,
-                actualSVType, 15000);
+                actualSVType, 15000, complexType);
         assertSegmentListEqual(actualSegmentsWithBNDOverlap,
                 expectedSVSegmentsWithBNDOverlap != null ? expectedSVSegmentsWithBNDOverlap : expectedSVSegments);
     }
@@ -702,6 +760,14 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
                                 Arrays.asList(GATKSVVCFConstants.NONCODING_SPAN, GATKSVVCFConstants.NEAREST_TSS,
                                         GATKSVVCFConstants.INTERGENIC),
                                 Arrays.asList("Enhancer", "EMMA1", true)) },
+                // Ignore INV and source INS in CPX_INTERVALS for INS_iDEL
+                { createVariantContext("chr1", 1101, 1102, null, null, null,
+                        "<CPX>", 700, null, "INS_iDEL",
+                        Arrays.asList("INV_chr1:10-60","DEL_chr1:1100-1700","INS_chr1:10-60")),
+                        createAttributesMap(
+                                Arrays.asList(GATKSVVCFConstants.NONCODING_SPAN, GATKSVVCFConstants.NEAREST_TSS,
+                                        GATKSVVCFConstants.INTERGENIC),
+                                Arrays.asList("Enhancer", "EMMA1", true)) },
                 // no noncoding breakpoint for DUP segment of CPX; modify INV interval; multiple genes for a consequence
                 { createVariantContext("chr1", 450, 3100, null, null, null,
                         "<CPX>", 2650, null, "dupINV",
@@ -710,6 +776,14 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
                                 Arrays.asList(GATKSVVCFConstants.PARTIAL_DISPERSED_DUP, GATKSVVCFConstants.LOF,
                                         GATKSVVCFConstants.INTERGENIC),
                                 Arrays.asList(Arrays.asList("EMMA1", "EMMA2"), "EMMA2", false)) },
+                // intergenic with partial dispersed dup
+                { createVariantContext("chr1", 1100, 1100, null, null, null,
+                        "<CPX>", 550, null, "dDUP",
+                        Arrays.asList("DUP_chr1:450-1000")),
+                        createAttributesMap(
+                                Arrays.asList(GATKSVVCFConstants.PARTIAL_DISPERSED_DUP, GATKSVVCFConstants.NEAREST_TSS,
+                                        GATKSVVCFConstants.INTERGENIC),
+                                Arrays.asList("EMMA1", "EMMA1", true)) },
                 // merge INV + DEL for nearest TSS; noncoding breakpoint for CPX
                 { createVariantContext("chr1", 10, 11, null, null, null,
                         "<CPX>", 40, null, "delINV",
@@ -787,6 +861,4 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
 
         Assert.assertEquals(actualAttributes, expectedAttributes);
     }
-
-
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateIntegrationTest.java
@@ -28,7 +28,8 @@ public class SVAnnotateIntegrationTest extends CommandLineProgramTest {
             GATKSVVCFConstants.INV_SPAN, GATKSVVCFConstants.PROMOTER, GATKSVVCFConstants.COPY_GAIN,
             GATKSVVCFConstants.INTERGENIC, GATKSVVCFConstants.NEAREST_TSS, GATKSVVCFConstants.INT_EXON_DUP,
             GATKSVVCFConstants.PARTIAL_EXON_DUP, GATKSVVCFConstants.MSV_EXON_OVERLAP, GATKSVVCFConstants.UTR,
-            GATKSVVCFConstants.INTRONIC, GATKSVVCFConstants.TSS_DUP, GATKSVVCFConstants.BREAKEND_EXON);
+            GATKSVVCFConstants.INTRONIC, GATKSVVCFConstants.TSS_DUP, GATKSVVCFConstants.BREAKEND_EXON,
+            GATKSVVCFConstants.PARTIAL_DISPERSED_DUP);
 
     private void assertVariantAnnotatedAsExpected(final List<VariantContext> vcf, final String variantID,
                                                   Map<String, Object> expectedAnnotations) {

--- a/src/test/java/org/broadinstitute/hellbender/utils/SimpleIntervalUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/SimpleIntervalUnitTest.java
@@ -260,6 +260,116 @@ public final class SimpleIntervalUnitTest extends GATKBaseTest {
                             "contains() returned incorrect result for intervals " + firstInterval + " and " + secondInterval);
     }
 
+    @DataProvider(name = "subtractIntervalData")
+    private Object[][] subtractIntervalData() {
+        return new Object[][] {
+                { new SimpleInterval("chr1", 10, 30),
+                        new SimpleInterval("chr1", 20, 40),
+                        new SimpleInterval("chr1", 10, 20) },
+                { new SimpleInterval("chr1", 10, 30),
+                        new SimpleInterval("chr1", 5, 15),
+                        new SimpleInterval("chr1", 15, 30) },
+                { new SimpleInterval("chr1", 10, 30),
+                        new SimpleInterval("chr1", 10, 20),
+                        new SimpleInterval("chr1", 20, 30) },
+                { new SimpleInterval("chr1", 10, 30),
+                        new SimpleInterval("chr1", 20, 30),
+                        new SimpleInterval("chr1", 10, 20) }
+        };
+    }
+
+    @Test(dataProvider = "subtractIntervalData")
+    public void testSubtractInterval( final SimpleInterval firstInterval,
+                                      final SimpleInterval secondInterval,
+                                      final SimpleInterval expectedResult ) {
+        Assert.assertEquals(firstInterval.subtract(secondInterval), expectedResult);
+    }
+
+    @DataProvider(name = "subtractIntervalDataExpectingException")
+    private Object[][] subtractIntervalDataExpectingException() {
+        return new Object[][] {
+                // different contigs
+                { new SimpleInterval("chr1", 10, 30),
+                        new SimpleInterval("chr2", 20, 40) },
+                // non-overlapping intervals on same contig
+                { new SimpleInterval("chr1", 10, 30),
+                        new SimpleInterval("chr1", 50, 150) },
+                // second interval contains first
+                { new SimpleInterval("chr1", 10, 30),
+                        new SimpleInterval("chr1", 10, 40) }
+        };
+    }
+    @Test(dataProvider = "subtractIntervalDataExpectingException", expectedExceptions = IllegalArgumentException.class)
+    public void testSubtractIntervalExpectingException( final SimpleInterval firstInterval,
+                                                        final SimpleInterval secondInterval) {
+        firstInterval.subtract(secondInterval);
+    }
+
+    @DataProvider(name = "mergeWithContiguousData")
+    private Object[][] mergeWithContiguousData() {
+        return new Object[][] {
+                // first is upstream, overlapping
+                { new SimpleInterval("chr1", 10, 30),
+                        new SimpleInterval("chr1", 20, 40),
+                        new SimpleInterval("chr1", 10, 40) },
+                // first is downstream, overlapping
+                { new SimpleInterval("chr1", 10, 30),
+                        new SimpleInterval("chr1", 5, 15),
+                        new SimpleInterval("chr1", 5, 30) },
+                // first contains second
+                { new SimpleInterval("chr1", 10, 30),
+                        new SimpleInterval("chr1", 15, 20),
+                        new SimpleInterval("chr1", 10, 30) },
+                // second contains first
+                { new SimpleInterval("chr1", 20, 30),
+                        new SimpleInterval("chr1", 10, 30),
+                        new SimpleInterval("chr1", 10, 30) },
+                // first is upstream, overlapping by 1
+                { new SimpleInterval("chr1", 10, 30),
+                        new SimpleInterval("chr1", 30, 50),
+                        new SimpleInterval("chr1", 10, 50) },
+                // first is upstream, adjacent
+                { new SimpleInterval("chr1", 10, 30),
+                        new SimpleInterval("chr1", 31, 50),
+                        new SimpleInterval("chr1", 10, 50) },
+                // first is downstream, overlapping by 1
+                { new SimpleInterval("chr1", 40, 60),
+                        new SimpleInterval("chr1", 30, 40),
+                        new SimpleInterval("chr1", 30, 60) },
+                // first is downstream, adjacent
+                { new SimpleInterval("chr1", 40, 60),
+                        new SimpleInterval("chr1", 30, 39),
+                        new SimpleInterval("chr1", 30, 60) }
+        };
+    }
+
+    @Test(dataProvider = "mergeWithContiguousData")
+    public void testMergeWithContiguous( final SimpleInterval firstInterval,
+                                      final SimpleInterval secondInterval,
+                                      final SimpleInterval expectedResult ) {
+        Assert.assertEquals(firstInterval.mergeWithContiguous(secondInterval), expectedResult);
+    }
+
+    @DataProvider(name = "mergeWithContiguousDataExpectingException")
+    private Object[][] mergeWithContiguousDataExpectingException() {
+        return new Object[][] {
+                // different contigs
+                { new SimpleInterval("chr1", 10, 30),
+                        new SimpleInterval("chr2", 20, 40) },
+                // non-contiguous intervals on same contig, first is upstream
+                { new SimpleInterval("chr1", 10, 30),
+                        new SimpleInterval("chr1", 50, 150) },
+                // non-contiguous intervals on same contig, first is downstream
+                { new SimpleInterval("chr1", 20, 30),
+                        new SimpleInterval("chr1", 5, 15) }
+        };
+    }
+    @Test(dataProvider = "mergeWithContiguousDataExpectingException", expectedExceptions = GATKException.class)
+    public void testMergeWithContiguousExpectingException( final SimpleInterval firstInterval,
+                                                        final SimpleInterval secondInterval) {
+        firstInterval.mergeWithContiguous(secondInterval);
+    }
+
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testNoNullInConstruction() throws Exception {
         new SimpleInterval((String)null);


### PR DESCRIPTION
Updates SVAnnotate's functional consequence annotation of complex SVs.
* Introduce PREDICTED_PARTIAL_DISPERSED_DUP annotation to describe dispersed duplications of coding sequence that are not expected to behave the same way as tandem duplications
* Ignore INV intervals in dDUP events
* Modify INV intervals in dupINV and similar events to more accurately capture the overall impact of the complex SV
* Ignore complex DUP segments for promoter, noncoding, and nearest TSS annotations because these DUPs are never in tandem
* Merge relevant intervals before annotating nearest TSS for complex events containing DELs
* Update documentation

Testing
* Add unit test for CPX SV segment determination
* Add CPX SV unit test cases
* Update unit/integration test expected outputs
* All unit & integration tests for SVAnnotate ran successfully