### PR TITLE
Hail Dataproc from WDL, cluster tracking [VS-1013] [VS-1021]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -346,7 +346,7 @@ workflows:
      filters:
        branches:
          - master
-         - ah_var_store
+         - vs_1013_hail_dataproc_wdl
        tags:
          - /.*/
    - name: MitochondriaPipeline

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -340,6 +340,15 @@ workflows:
              - ah_var_store
          tags:
              - /.*/
+   - name: HailFromWdl
+     subclass: WDL
+     primaryDescriptorPath: /scripts/variantstore/wdl/HailFromWdl.wdl
+     filters:
+       branches:
+         - master
+         - ah_var_store
+       tags:
+         - /.*/
    - name: MitochondriaPipeline
      subclass: WDL
      primaryDescriptorPath: /scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -344,11 +344,11 @@ workflows:
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/HailFromWdl.wdl
      filters:
-       branches:
-         - master
-         - vs_1013_hail_dataproc_wdl
-       tags:
-         - /.*/
+         branches:
+             - master
+             - vs_1013_hail_dataproc_wdl
+         tags:
+             - /.*/
    - name: MitochondriaPipeline
      subclass: WDL
      primaryDescriptorPath: /scripts/mitochondria_m2_wdl/MitochondriaPipeline.wdl

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -27,6 +27,9 @@ workflow GvsBulkIngestGenomes {
         String? git_branch_or_tag
         String? git_hash
 
+        String? workspace_id
+        String? workspace_bucket
+
         File? gatk_override
         # End GvsAssignIds
 
@@ -53,7 +56,9 @@ workflow GvsBulkIngestGenomes {
         sample_set_name: "The recommended way to load samples; Sample sets must be created by the user. If no sample_set_name is specified, all samples will be loaded into GVS"
     }
 
-    if (!defined(git_hash) || !defined(basic_docker) || !defined(cloud_sdk_docker) || !defined(variants_docker) || !defined(gatk_docker)) {
+    if (!defined(git_hash) ||
+        !defined(basic_docker) || !defined(cloud_sdk_docker) || !defined(variants_docker) || !defined(gatk_docker) ||
+        !defined(workspace_id) || !defined(workspace_bucket)) {
         call Utils.GetToolVersions {
             input:
                 git_branch_or_tag = git_branch_or_tag,
@@ -65,6 +70,8 @@ workflow GvsBulkIngestGenomes {
     String effective_variants_docker = select_first([variants_docker, GetToolVersions.variants_docker])
     String effective_gatk_docker = select_first([gatk_docker, GetToolVersions.gatk_docker])
     String effective_git_hash = select_first([git_hash, GetToolVersions.git_hash])
+    String effective_workspace_id = select_first([workspace_id, GetToolVersions.workspace_id])
+    String effective_workspace_bucket = select_first([workspace_bucket, GetToolVersions.workspace_bucket])
 
     call GenerateImportFofnFromDataTable {
         input:
@@ -74,6 +81,8 @@ workflow GvsBulkIngestGenomes {
             user_defined_sample_id_column_name = sample_id_column_name, ## NOTE: the user needs to define this, or it will default to the <entity>_id column
             vcf_files_column_name = vcf_files_column_name,
             vcf_index_files_column_name = vcf_index_files_column_name,
+            workspace_id = effective_workspace_id,
+            workspace_bucket = effective_workspace_bucket,
     }
 
     call SplitBulkImportFofn {
@@ -123,10 +132,6 @@ workflow GvsBulkIngestGenomes {
 
     output {
         Boolean done = true
-        String workspace_bucket = GenerateImportFofnFromDataTable.workspace_bucket
-        String workspace_id = GenerateImportFofnFromDataTable.workspace_id
-        String submission_id = GenerateImportFofnFromDataTable.submission_id
-        String workflow_id = GenerateImportFofnFromDataTable.workflow_id
         String recorded_git_hash = effective_git_hash
     }
 }
@@ -140,6 +145,8 @@ task GenerateImportFofnFromDataTable {
         String? user_defined_sample_id_column_name
         String? vcf_files_column_name
         String? vcf_index_files_column_name
+        String workspace_id
+        String workspace_bucket
         String variants_docker
     }
 
@@ -152,12 +159,8 @@ task GenerateImportFofnFromDataTable {
     String output_fofn_name = "output.tsv"
     String error_file_name = "errors.txt"
 
-    String workspace_id_output = "workspace_id.txt"
     String workspace_name_output = "workspace_name.txt"
     String workspace_namespace_output = "workspace_namespace.txt"
-    String workspace_bucket_output = "workspace_bucket.txt"
-    String submission_id_output = "submission_id.txt"
-    String workflow_id_output = "workflow_id.txt"
 
     String sample_name_column = if (defined(user_defined_sample_id_column_name)) then select_first([user_defined_sample_id_column_name]) else entity_id
 
@@ -167,14 +170,8 @@ task GenerateImportFofnFromDataTable {
         PS4='\D{+%F %T} \w $ '
         set -o errexit -o nounset -o pipefail -o xtrace
 
-        # Sniff the workspace bucket out of the delocalization script and extract the workspace id from that.
-        sed -n -E 's!.*gs://fc-(secure-)?([^\/]+).*!\2!p' /cromwell_root/gcs_delocalization.sh | sort -u > ~{workspace_id_output}
-        sed -n -E 's!.*gs://(fc-(secure-)?[^\/]+).*!\1!p' /cromwell_root/gcs_delocalization.sh | sort -u > ~{workspace_bucket_output}
-        sed -n -E 's!.*gs://fc-(secure-)?([^\/]+)/submissions/([^\/]+).*!\3!p' /cromwell_root/gcs_delocalization.sh | sort -u > ~{submission_id_output}
-        sed -n -E 's!.*gs://fc-(secure-)?([^\/]+)/submissions/([^\/]+)/([^\/]+)/([^\/]+).*!\5!p' /cromwell_root/gcs_delocalization.sh | sort -u > ~{workflow_id_output}
-
-        export WORKSPACE_ID="$(cat '~{workspace_id_output}')"
-        export WORKSPACE_BUCKET="$(cat '~{workspace_bucket_output}')"
+        export WORKSPACE_ID="~{workspace_id}"
+        export WORKSPACE_BUCKET="~{workspace_bucket}"
 
         # Hit rawls with the workspace ID
 
@@ -239,10 +236,6 @@ task GenerateImportFofnFromDataTable {
     }
 
     output {
-        String workspace_bucket = read_string("~{workspace_bucket_output}")
-        String workspace_id = read_string("~{workspace_id_output}")
-        String submission_id = read_string("~{submission_id_output}")
-        String workflow_id = read_string("~{workflow_id_output}")
         File output_fofn = output_fofn_name
     }
 }

--- a/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
+++ b/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
@@ -34,6 +34,9 @@ workflow GvsJointVariantCalling {
         String? variants_docker
         String? gatk_docker
 
+        String? workspace_bucket
+        String? submission_id
+
         # NOTE: `gatk_override` is not intended for production runs of the GVS pipeline! If defined, `gatk_override`
         # should be at least as recent as `gatk_docker`. Legitimate uses of `gatk_override` include integration test
         # runs and feature development.
@@ -85,7 +88,9 @@ workflow GvsJointVariantCalling {
       Int split_intervals_mem_override = ""
     }
 
-    if (!defined(git_hash) || !defined(basic_docker) || !defined(cloud_sdk_docker) || !defined(variants_docker) || !defined(gatk_docker)) {
+    if (!defined(git_hash) ||
+        !defined(basic_docker) || !defined(cloud_sdk_docker) || !defined(variants_docker) || !defined(gatk_docker) ||
+        !defined(workspace_bucket) || !defined(submission_id)) {
         call Utils.GetToolVersions {
             input:
                 git_branch_or_tag = git_branch_or_tag,
@@ -169,7 +174,7 @@ workflow GvsJointVariantCalling {
             variants_docker = effective_variants_docker,
     }
 
-    String effective_output_gcs_dir = select_first([extract_output_gcs_dir, "gs://~{BulkIngestGenomes.workspace_bucket}/output_vcfs/by_submission_id/~{BulkIngestGenomes.submission_id}"])
+    String effective_output_gcs_dir = select_first([extract_output_gcs_dir, "gs://~{GetToolVersions.workspace_bucket}/output_vcfs/by_submission_id/~{GetToolVersions.submission_id}"])
 
     call ExtractCallset.GvsExtractCallset {
         input:

--- a/scripts/variantstore/wdl/GvsQuickstartHailIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartHailIntegration.wdl
@@ -28,6 +28,9 @@ workflow GvsQuickstartHailIntegration {
         String? vcf_files_column_name
         String? vcf_index_files_column_name
         String? sample_set_name ## NOTE: currently we only allow the loading of one sample set at a time
+
+        String? workspace_bucket
+        String? submission_id
     }
 
     String project_id = "gvs-internal"
@@ -46,6 +49,9 @@ workflow GvsQuickstartHailIntegration {
     String effective_variants_docker = select_first([variants_docker, GetToolVersions.variants_docker])
     String effective_gatk_docker = select_first([gatk_docker, GetToolVersions.gatk_docker])
     String effective_git_hash = select_first([git_hash, GetToolVersions.git_hash])
+
+    String effective_workspace_bucket = select_first([workspace_bucket, GetToolVersions.workspace_bucket])
+    String effective_submission_id = select_first([submission_id, GetToolVersions.submission_id])
 
     call QuickstartVcfIntegration.GvsQuickstartVcfIntegration {
         input:
@@ -69,6 +75,8 @@ workflow GvsQuickstartHailIntegration {
             cloud_sdk_slim_docker = effective_cloud_sdk_slim_docker,
             variants_docker = effective_variants_docker,
             gatk_docker = effective_gatk_docker,
+            workspace_bucket = effective_workspace_bucket,
+            submission_id = effective_submission_id,
     }
 
     call ExtractAvroFilesForHail.GvsExtractAvroFilesForHail {

--- a/scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
@@ -89,6 +89,8 @@ workflow GvsQuickstartIntegration {
                 cloud_sdk_slim_docker = effective_cloud_sdk_slim_docker,
                 variants_docker = effective_variants_docker,
                 gatk_docker = effective_gatk_docker,
+                workspace_bucket = GetToolVersions.workspace_bucket,
+                submission_id = GetToolVersions.submission_id,
         }
         call QuickstartHailIntegration.GvsQuickstartHailIntegration as GvsQuickstartHailVQSRClassicIntegration {
             input:
@@ -112,6 +114,8 @@ workflow GvsQuickstartIntegration {
                 cloud_sdk_slim_docker = effective_cloud_sdk_slim_docker,
                 variants_docker = effective_variants_docker,
                 gatk_docker = effective_gatk_docker,
+                workspace_bucket = GetToolVersions.workspace_bucket,
+                submission_id = GetToolVersions.submission_id,
         }
     }
 
@@ -138,6 +142,8 @@ workflow GvsQuickstartIntegration {
                 cloud_sdk_slim_docker = effective_cloud_sdk_slim_docker,
                 variants_docker = effective_variants_docker,
                 gatk_docker = effective_gatk_docker,
+                workspace_bucket = GetToolVersions.workspace_bucket,
+                submission_id = GetToolVersions.submission_id,
         }
         call QuickstartVcfIntegration.GvsQuickstartVcfIntegration as QuickstartVcfVQSRClassicIntegration {
             input:
@@ -161,6 +167,8 @@ workflow GvsQuickstartIntegration {
                 cloud_sdk_slim_docker = effective_cloud_sdk_slim_docker,
                 variants_docker = effective_variants_docker,
                 gatk_docker = effective_gatk_docker,
+                workspace_bucket = GetToolVersions.workspace_bucket,
+                submission_id = GetToolVersions.submission_id,
         }
     }
 
@@ -187,6 +195,8 @@ workflow GvsQuickstartIntegration {
                 cloud_sdk_slim_docker = effective_cloud_sdk_slim_docker,
                 variants_docker = effective_variants_docker,
                 gatk_docker = effective_gatk_docker,
+                workspace_bucket = GetToolVersions.workspace_bucket,
+                submission_id = GetToolVersions.submission_id,
         }
     }
 

--- a/scripts/variantstore/wdl/GvsQuickstartVcfIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartVcfIntegration.wdl
@@ -26,6 +26,9 @@ workflow GvsQuickstartVcfIntegration {
         String? vcf_files_column_name
         String? vcf_index_files_column_name
         String? sample_set_name ## NOTE: currently we only allow the loading of one sample set at a time
+
+        String? workspace_bucket
+        String? submission_id
     }
     String project_id = "gvs-internal"
 
@@ -34,8 +37,9 @@ workflow GvsQuickstartVcfIntegration {
       File? none = ""
     }
 
-    if (!defined(git_hash) || !defined(cloud_sdk_docker) || !defined(cloud_sdk_slim_docker) || !defined(variants_docker) ||
-        !defined(basic_docker) || !defined(gatk_docker)) {
+    if (!defined(git_hash) ||
+        !defined(cloud_sdk_docker) || !defined(cloud_sdk_slim_docker) || !defined(variants_docker) || !defined(basic_docker) || !defined(gatk_docker) ||
+        !defined(workspace_bucket) || !defined(submission_id)) {
         call Utils.GetToolVersions {
             input:
                 git_branch_or_tag = git_branch_or_tag,
@@ -48,6 +52,9 @@ workflow GvsQuickstartVcfIntegration {
     String effective_variants_docker = select_first([variants_docker, GetToolVersions.variants_docker])
     String effective_gatk_docker = select_first([gatk_docker, GetToolVersions.gatk_docker])
     String effective_git_hash = select_first([git_hash, GetToolVersions.git_hash])
+
+    String effective_workspace_bucket = select_first([workspace_bucket, GetToolVersions.workspace_bucket])
+    String effective_submission_id = select_first([submission_id, GetToolVersions.submission_id])
 
     if (!use_default_dockers && !defined(gatk_override)) {
       call Utils.BuildGATKJar {
@@ -89,6 +96,8 @@ workflow GvsQuickstartVcfIntegration {
             cloud_sdk_docker = effective_cloud_sdk_docker,
             variants_docker = effective_variants_docker,
             gatk_docker = effective_gatk_docker,
+            workspace_bucket = effective_workspace_bucket,
+            submission_id = effective_submission_id,
     }
 
     # Only assert identical outputs if we did not filter (filtering is not deterministic) OR if we are using VQSR Lite (which is deterministic)

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -76,8 +76,6 @@ task GetToolVersions {
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"
     String gotc_imputation_docker = "us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.5-1.10.2-0.1.16-1649948623"
-    # The docker to be used on the VM.  This will need both Hail and Google Cloud SDK installed.
-    String hail_docker = "us.gcr.io/broad-dsde-methods/lichtens/hail_dataproc_wdl:1.1"
 
     String workspace_bucket = read_string(workspace_bucket_output)
     String workspace_id = read_string(workspace_id_output)

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -32,7 +32,7 @@ task GetToolVersions {
     PS4='\D{+%F %T} \w $ '
     set -o errexit -o nounset -o pipefail -o xtrace
 
-    # Scrape out various workflow infos from the delocalization script
+    # Scrape out various workflow / workspace info from the localization and delocalization scripts.
     sed -n -E 's!.*gs://fc-(secure-)?([^\/]+).*!\2!p' /cromwell_root/gcs_delocalization.sh | sort -u > ~{workspace_id_output}
     sed -n -E 's!.*gs://(fc-(secure-)?[^\/]+).*!\1!p' /cromwell_root/gcs_delocalization.sh | sort -u > ~{workspace_bucket_output}
     sed -n -E 's!.*gs://fc-(secure-)?([^\/]+)/submissions/([^\/]+).*!\3!p' /cromwell_root/gcs_delocalization.sh | sort -u > ~{submission_id_output}

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -37,7 +37,7 @@ task GetToolVersions {
     sed -n -E 's!.*gs://(fc-(secure-)?[^\/]+).*!\1!p' /cromwell_root/gcs_delocalization.sh | sort -u > ~{workspace_bucket_output}
     sed -n -E 's!.*gs://fc-(secure-)?([^\/]+)/submissions/([^\/]+).*!\3!p' /cromwell_root/gcs_delocalization.sh | sort -u > ~{submission_id_output}
     sed -n -E 's!.*gs://fc-(secure-)?([^\/]+)/submissions/([^\/]+)/([^\/]+)/([^\/]+).*!\5!p' /cromwell_root/gcs_delocalization.sh | sort -u > ~{workflow_id_output}
-    sed -n -E 's!.*(terra-[0-9a-f]{6}).*# project to use if requester pays$!\1!p' /cromwell_root/gcs_localization.sh | sort -u > ~{google_project_output}
+    sed -n -E 's!.*(terra-[0-9a-f]+).*# project to use if requester pays$!\1!p' /cromwell_root/gcs_localization.sh | sort -u > ~{google_project_output}
 
     echo "~{effective_version}" > version.txt
 

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -77,7 +77,7 @@ task GetToolVersions {
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"
     String gotc_imputation_docker = "us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.5-1.10.2-0.1.16-1649948623"
     # The docker to be used on the VM.  This will need both Hail and Google Cloud SDK installed.
-    String hail_docker="us.gcr.io/broad-dsde-methods/lichtens/hail_dataproc_wdl:1.1"
+    String hail_docker = "us.gcr.io/broad-dsde-methods/lichtens/hail_dataproc_wdl:1.1"
 
     String workspace_bucket = read_string(workspace_bucket_output)
     String workspace_id = read_string(workspace_id_output)

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -71,7 +71,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
-    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-08-31-alpine"
+    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-09-25-alpine-bffcf3434"
     String gatk_docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_09_13"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -71,7 +71,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
-    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-09-26-alpine-a2f8ffe60"
+    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-09-27-alpine-0e28c99ad"
     String gatk_docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_09_13"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -71,7 +71,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
-    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-09-26-alpine-f047c77c0"
+    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-09-26-alpine-3fae2872e"
     String gatk_docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_09_13"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -76,6 +76,8 @@ task GetToolVersions {
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"
     String gotc_imputation_docker = "us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.5-1.10.2-0.1.16-1649948623"
+    # The docker to be used on the VM.  This will need both Hail and Google Cloud SDK installed.
+    String hail_docker="us.gcr.io/broad-dsde-methods/lichtens/hail_dataproc_wdl:1.1"
 
     String workspace_bucket = read_string(workspace_bucket_output)
     String workspace_id = read_string(workspace_id_output)

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -18,10 +18,26 @@ task GetToolVersions {
   String version = "unspecified"
 
   String effective_version = select_first([git_branch_or_tag, version])
+
+  String workspace_id_output = "workspace_id.txt"
+  String workspace_name_output = "workspace_name.txt"
+  String workspace_namespace_output = "workspace_namespace.txt"
+  String workspace_bucket_output = "workspace_bucket.txt"
+  String submission_id_output = "submission_id.txt"
+  String workflow_id_output = "workflow_id.txt"
+  String google_project_output = "google_project.txt"
+
   command <<<
     # Prepend date, time and pwd to xtrace log entries.
     PS4='\D{+%F %T} \w $ '
     set -o errexit -o nounset -o pipefail -o xtrace
+
+    # Scrape out various workflow infos from the delocalization script
+    sed -n -E 's!.*gs://fc-(secure-)?([^\/]+).*!\2!p' /cromwell_root/gcs_delocalization.sh | sort -u > ~{workspace_id_output}
+    sed -n -E 's!.*gs://(fc-(secure-)?[^\/]+).*!\1!p' /cromwell_root/gcs_delocalization.sh | sort -u > ~{workspace_bucket_output}
+    sed -n -E 's!.*gs://fc-(secure-)?([^\/]+)/submissions/([^\/]+).*!\3!p' /cromwell_root/gcs_delocalization.sh | sort -u > ~{submission_id_output}
+    sed -n -E 's!.*gs://fc-(secure-)?([^\/]+)/submissions/([^\/]+)/([^\/]+)/([^\/]+).*!\5!p' /cromwell_root/gcs_delocalization.sh | sort -u > ~{workflow_id_output}
+    sed -n -E 's!.*(terra-[0-9a-f]{6}).*# project to use if requester pays$!\1!p' /cromwell_root/gcs_localization.sh | sort -u > ~{google_project_output}
 
     echo "~{effective_version}" > version.txt
 
@@ -60,6 +76,12 @@ task GetToolVersions {
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"
     String gotc_imputation_docker = "us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.5-1.10.2-0.1.16-1649948623"
+
+    String workspace_bucket = read_string(workspace_bucket_output)
+    String workspace_id = read_string(workspace_id_output)
+    String submission_id = read_string(submission_id_output)
+    String workflow_id = read_string(workflow_id_output)
+    String google_project = read_string(google_project_output)
   }
 }
 

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -71,7 +71,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
-    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-09-26-alpine-3fae2872e"
+    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-09-26-alpine-a2f8ffe60"
     String gatk_docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_09_13"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -71,7 +71,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
-    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-09-25-alpine-a3e227c35"
+    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-09-26-alpine-f047c77c0"
     String gatk_docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_09_13"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -71,7 +71,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
-    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-09-25-alpine-bffcf3434"
+    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-09-25-alpine-a3e227c35"
     String gatk_docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_09_13"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -71,7 +71,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
-    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-09-27-alpine-0e28c99ad"
+    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-09-27-alpine"
     String gatk_docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_09_13"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/HailFromWdl.wdl
+++ b/scripts/variantstore/wdl/HailFromWdl.wdl
@@ -164,7 +164,7 @@ task filter_vds_and_export_as_vcf {
     }
 
     RuntimeAttr runtime_default = object {
-                                      mem_gb: 6.5,
+                                      mem_gb: 30,
                                       disk_gb: 100,
                                       cpu_cores: 1,
                                       preemptible_tries: 0,
@@ -191,10 +191,11 @@ task filter_vds_and_export_as_vcf {
         apt -qq install -y temurin-8-jdk
 
         pip install --upgrade pip
-        # floating the hail version, but needed to pin the cloud dataproc version for compatibility with hail :/
-        pip install hail google-cloud-dataproc==5.4.2
+        pip install hail google-cloud-dataproc
 
-        if [[ -z "~{git_branch_or_tag}" && -z "~{submission_script}" ]] || [ ! -z "~{git_branch_or_tag}" && ! -z "~{submission_script}" ]]
+        export PYSPARK_SUBMIT_ARGS='--driver-memory 16g --executor-memory 16g pyspark-shell'
+
+        if [[ -z "~{git_branch_or_tag}" && -z "~{submission_script}" ]] || [[ ! -z "~{git_branch_or_tag}" && ! -z "~{submission_script}" ]]
         then
             echo "Must specify git_branch_or_tag XOR submission_script"
             exit 1

--- a/scripts/variantstore/wdl/HailFromWdl.wdl
+++ b/scripts/variantstore/wdl/HailFromWdl.wdl
@@ -226,7 +226,7 @@ task filter_vds_and_export_as_vcf {
         print("account: " + account)
 
         try:
-            cluster_start_cmd = "hailctl dataproc start --num-workers ~{num_workers} --region {} --project {} --service-account {} --num-master-local-ssds 1 --num-worker-local-ssds 1 --max-idle=60m --max-age=1440m --subnet={} {}".format("~{region}", "~{gcs_project}", account, "projects/~{gcs_project}/regions/~{region}/subnetworks/~{gcs_subnetwork_name}", cluster_name)
+            cluster_start_cmd = "hailctl dataproc start --num-workers ~{num_workers} --worker-machine-type n1-standard-16 --region {} --project {} --service-account {} --num-master-local-ssds 1 --num-worker-local-ssds 1 --max-idle=60m --max-age=1440m --subnet={} {}".format("~{region}", "~{gcs_project}", account, "projects/~{gcs_project}/regions/~{region}/subnetworks/~{gcs_subnetwork_name}", cluster_name)
             print("Starting cluster...")
             print(cluster_start_cmd)
             print(os.popen(cluster_start_cmd).read())

--- a/scripts/variantstore/wdl/HailFromWdl.wdl
+++ b/scripts/variantstore/wdl/HailFromWdl.wdl
@@ -209,6 +209,12 @@ task filter_vds_and_export_as_vcf {
             script_path="~{default_script_filename}"
         fi
 
+        # Generate a UUIDish random hex string of <8 hex chars (4 bytes)>-<4 hex chars (2 bytes)>
+        hex="$(head -c4 < /dev/urandom | xxd -p)-$(head -c2 < /dev/urandom | xxd -p)"
+
+        cluster_name="~{prefix}-~{contig}-hail-${hex}"
+        echo ${cluster_name} > cluster_name.txt
+
         python3 /app/run_in_hail_cluster.py \
             --script-path ${script_path} \
             --account ${account_name} \
@@ -216,7 +222,7 @@ task filter_vds_and_export_as_vcf {
             ~{'--worker-machine-type' + worker_machine_type} \
             --region ~{region} \
             --gcs-project ~{gcs_project} \
-            --prefix ~{prefix} \
+            --cluster-name ${cluster_name} \
             --contig ~{contig} \
             --vds-url ~{vds_url} \
             --vcf-header-url ~{vcf_header_url} \
@@ -226,6 +232,7 @@ task filter_vds_and_export_as_vcf {
     >>>
 
     output {
+        String cluster_name = read_string("cluster_name.txt")
         File vcf = "~{prefix}.~{contig}.vcf.bgz"
     }
 

--- a/scripts/variantstore/wdl/HailFromWdl.wdl
+++ b/scripts/variantstore/wdl/HailFromWdl.wdl
@@ -97,7 +97,7 @@ workflow filter_vds_to_VCF_by_chr {
         #   In other words, this is a contig level intersection with the bed file.
         #     This list of contigs that must be present in the reference.  Each contig will be processed separately (shard)
         # This list should be ordered.  Eg, ["chr21", "chr22"]
-        Array[String] contigs = ["chr20"]
+        Array[String] contigs = ["chr20", "chrX", "chrY"]
 
         # String used in construction of output filename
         #  Cannot contain any special characters, ie, characters must be alphanumeric or "-"

--- a/scripts/variantstore/wdl/HailFromWdl.wdl
+++ b/scripts/variantstore/wdl/HailFromWdl.wdl
@@ -199,7 +199,7 @@ task filter_vds_and_export_as_vcf {
         then
             echo "Must specify git_branch_or_tag XOR submission_script"
             exit 1
-        elif [[ ! -z "~{git_branch_or_tag} ]]
+        elif [[ ! -z "~{git_branch_or_tag}" ]]
         then
             script_url="https://raw.githubusercontent.com/broadinstitute/gatk/~{git_branch_or_tag}/scripts/variantstore/wdl/extract/~{default_script_filename}"
             curl --silent --location --remote-name "${script_url}"

--- a/scripts/variantstore/wdl/HailFromWdl.wdl
+++ b/scripts/variantstore/wdl/HailFromWdl.wdl
@@ -191,7 +191,8 @@ task filter_vds_and_export_as_vcf {
         apt -qq install -y temurin-8-jdk
 
         pip install --upgrade pip
-        pip install hail
+        # floating the hail version, but needed to pin the cloud dataproc version for compatibility with hail :/
+        pip install hail google-cloud-dataproc==5.4.2
 
         if [[ -z "~{git_branch_or_tag}" && -z "~{submission_script}" ]] || [ ! -z "~{git_branch_or_tag}" && ! -z "~{submission_script}" ]]
         then

--- a/scripts/variantstore/wdl/HailFromWdl.wdl
+++ b/scripts/variantstore/wdl/HailFromWdl.wdl
@@ -188,9 +188,9 @@ task filter_vds_and_export_as_vcf {
 
         account_name=$(gcloud config list account --format "value(core.account)")
 
-        pip install --upgrade pip
-        pip install hail~{'==' + hail_version}
-        pip install --upgrade google-cloud-dataproc
+        pip3 install --upgrade pip
+        pip3 install hail~{'==' + hail_version}
+        pip3 install --upgrade google-cloud-dataproc
 
         if [[ -z "~{git_branch_or_tag}" && -z "~{submission_script}" ]] || [[ ! -z "~{git_branch_or_tag}" && ! -z "~{submission_script}" ]]
         then

--- a/scripts/variantstore/wdl/HailFromWdl.wdl
+++ b/scripts/variantstore/wdl/HailFromWdl.wdl
@@ -26,7 +26,7 @@ version 1.0
 #        Array[String] contigs
 #
 #        # String used in construction of output filename
-#        #  Cannot contain any special characters, ie, characters must be alphanumeric or "_"
+#        #  Cannot contain any special characters, ie, characters must be alphanumeric or "-"
 #        String prefix
 #
 #        ## CLUSTER PARAMETERS
@@ -243,7 +243,6 @@ task filter_vds_and_export_as_vcf {
         cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
         preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
         maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
-        # `slim` here to be able to use Java
         docker: variants_docker
         bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
     }

--- a/scripts/variantstore/wdl/HailFromWdl.wdl
+++ b/scripts/variantstore/wdl/HailFromWdl.wdl
@@ -223,7 +223,7 @@ task filter_vds_and_export_as_vcf {
             --region ~{region} \
             --gcs-project ~{gcs_project} \
             --cluster-name ${cluster_name} \
-            --prefix ${prefix} \
+            --prefix ~{prefix} \
             --contig ~{contig} \
             --vds-url ~{vds_url} \
             --vcf-header-url ~{vcf_header_url} \

--- a/scripts/variantstore/wdl/HailFromWdl.wdl
+++ b/scripts/variantstore/wdl/HailFromWdl.wdl
@@ -97,7 +97,7 @@ workflow filter_vds_to_VCF_by_chr {
         #   In other words, this is a contig level intersection with the bed file.
         #     This list of contigs that must be present in the reference.  Each contig will be processed separately (shard)
         # This list should be ordered.  Eg, ["chr21", "chr22"]
-        Array[String] contigs = ["chr20", "chrX", "chrY"]
+        Array[String] contigs = ["chr20"]
 
         # String used in construction of output filename
         #  Cannot contain any special characters, ie, characters must be alphanumeric or "-"

--- a/scripts/variantstore/wdl/HailFromWdl.wdl
+++ b/scripts/variantstore/wdl/HailFromWdl.wdl
@@ -96,7 +96,7 @@ workflow filter_vds_to_VCF_by_chr {
         Array[String] contigs
 
         # String used in construction of output filename
-        #  Cannot contain any special characters, ie, characters must be alphanumeric or "_"
+        #  Cannot contain any special characters, ie, characters must be alphanumeric or "-"
         String prefix
 
         ## CLUSTER PARAMETERS

--- a/scripts/variantstore/wdl/HailFromWdl.wdl
+++ b/scripts/variantstore/wdl/HailFromWdl.wdl
@@ -223,6 +223,7 @@ task filter_vds_and_export_as_vcf {
             --region ~{region} \
             --gcs-project ~{gcs_project} \
             --cluster-name ${cluster_name} \
+            --prefix ${prefix} \
             --contig ~{contig} \
             --vds-url ~{vds_url} \
             --vcf-header-url ~{vcf_header_url} \

--- a/scripts/variantstore/wdl/HailFromWdl.wdl
+++ b/scripts/variantstore/wdl/HailFromWdl.wdl
@@ -1,0 +1,270 @@
+version 1.0
+# Largely "borrowing" from Lee's work
+# https://github.com/broadinstitute/aou-ancestry/blob/a57bbab3ccee4d06317fecb8ca109424bca373b7/script/wdl/hail_in_wdl/filter_VDS_and_shard_by_contig.wdl
+
+#
+# Given a VDS and a bed file, render a VCF (sharded by chromosome).
+#   All bed files referenced in this WDL are UCSC bed files (as opposed to PLINK bed files).
+#
+# This has not been tested on any reference other than hg38.
+# Inputs:
+#
+#         ## ANALYSIS PARAMETERS
+#        #  ie, parameters that go to the Hail python code (submission_script below)
+#        String vds_url
+#
+#        # Genomic region for the output VCFs to cover
+#        File bed_url
+#
+#        # VCF Header that will be used in the output
+#        File vcf_header_url
+#
+#        # Contigs of interest.  If a contig is present in the bed file, but not in this list, the contig will be ignored.
+#        #   In other words, this is a contig level intersection with the bed file.
+#        #     This list of contigs that must be present in the reference.  Each contig will be processed separately (shard)
+#        # This list should be ordered.  Eg, ["chr21", "chr22"]
+#        Array[String] contigs
+#
+#        # String used in construction of output filename
+#        #  Cannot contain any special characters, ie, characters must be alphanumeric or "_"
+#        String prefix
+#
+#        ## CLUSTER PARAMETERS
+#        # Number of workers (per shard) to use in the Hail cluster.
+#        Int num_workers
+#
+#        # Set to 'subnetwork' if running in Terra Cromwell
+#        String gcs_subnetwork_name='subnetwork'
+#
+#        # The script that is run on the cluster
+#        #  See filter_VDS_and_shard_by_contig.py for an example.
+#        File submission_script
+#
+#        # Set to "us-central1" if running in Terra Cromwell
+#        String region = "us-central1"
+#
+#        ## VM PARAMETERS
+#        # Please note that there is a RuntimeAttr struct and a task parameter that can be used to override the defaults
+#        #  of the VM.  These are task parameters.
+#        #  However, since this can be a lightweight VM, overriding is unlikely to be necessary.
+#
+#        # The docker to be used on the VM.  This will need both Hail and Google Cloud SDK installed.
+#        String hail_docker="us.gcr.io/broad-dsde-methods/lichtens/hail_dataproc_wdl:1.0"
+#
+# Important notes:
+#   - Hail will save the VCFs in the cloud.  You will need to provide this storage space.  In other words, the runtime
+#     parameters must have enough storage space to support a single contig
+#   - This WDL script is still dependent on the python/Hail script that it calls.  You will see this when the parameters
+#    are passed into the script.
+#   - This WDL is boilerplate, except for input parameters, output parameters, and where marked in the main task.
+#   - We HIGHLY recommend that the WDL do NOT run on a preemptible VM
+#    (reminder, this is a single VM that spins up the dataproc cluster and submits jobs -- it is not doing any of the
+#     actual computation.  In other words, it does not need to be a heavy machine.)
+#     In other words, always set `preemptible_tries` to zero (default).
+#
+
+import "GvsUtils.wdl" as Utils
+
+struct RuntimeAttr {
+    Float? mem_gb
+    Int? cpu_cores
+    Int? disk_gb
+    Int? boot_disk_gb
+    Int? preemptible_tries
+    Int? max_retries
+}
+
+workflow filter_vds_to_VCF_by_chr {
+    ### Change here:  You will need to specify all parameters (both analysis and runtime) that need to go to the
+    # cluster, VM spinning up the cluster, and the script being run on the cluster.
+    input {
+
+        ## ANALYSIS PARAMETERS
+        #  ie, parameters that go to the Hail python code (submission_script below)
+        String vds_url
+
+        # Genomic region for the output VCFs to cover
+        File bed_url
+
+        # VCF Header that will be used in the output
+        File vcf_header_url
+
+        # Contigs of interest.  If a contig is present in the bed file, but not in this list, the contig will be ignored.
+        #   In other words, this is a contig level intersection with the bed file.
+        #     This list of contigs that must be present in the reference.  Each contig will be processed separately (shard)
+        # This list should be ordered.  Eg, ["chr21", "chr22"]
+        Array[String] contigs
+
+        # String used in construction of output filename
+        #  Cannot contain any special characters, ie, characters must be alphanumeric or "_"
+        String prefix
+
+        ## CLUSTER PARAMETERS
+        # Number of workers (per shard) to use in the Hail cluster.
+        Int num_workers
+
+        # Set to 'subnetwork' if running in Terra Cromwell
+        String gcs_subnetwork_name='subnetwork'
+
+        # The script that is run on the cluster
+        #  See filter_VDS_and_shard_by_contig.py for an example.
+        File submission_script
+
+        # Set to "us-central1" if running in Terra Cromwell
+        String region = "us-central1"
+    }
+
+    call Utils.GetToolVersions
+
+    scatter (contig in contigs) {
+        call filter_vds_and_export_as_vcf {
+            input:
+                vds_url = vds_url,
+                bed_url = bed_url,
+                contig = contig,
+                prefix = prefix,
+                gcs_project = GetToolVersions.google_project,
+                num_workers = num_workers,
+                gcs_subnetwork_name = gcs_subnetwork_name,
+                vcf_header_url = vcf_header_url,
+                submission_script = submission_script,
+                hail_docker = GetToolVersions.hail_docker,
+                region = region,
+        }
+    }
+
+    output {
+        Array[File] vcfs = filter_vds_and_export_as_vcf.vcf
+    }
+}
+
+task filter_vds_and_export_as_vcf {
+    input {
+        # You must treat a VDS as a String, since it is a directory and not a single file
+        String vds_url
+        File bed_url
+        File vcf_header_url
+
+        # Cannot make this localization_optional
+        File submission_script
+
+        # contig must be in the reference
+        String contig
+        String prefix
+        String gcs_project
+        String region = "us-central1"
+        Int num_workers
+        RuntimeAttr? runtime_attr_override
+        String gcs_subnetwork_name
+
+        String hail_docker
+    }
+
+    parameter_meta {
+        bed_url: {
+                     localization_optional: true
+                 }
+        vcf_header_url: {
+                            localization_optional: true
+                        }
+    }
+
+    RuntimeAttr runtime_default = object {
+                                      mem_gb: 6.5,
+                                      disk_gb: 100,
+                                      cpu_cores: 1,
+                                      preemptible_tries: 0,
+                                      max_retries: 0,
+                                      boot_disk_gb: 10
+                                  }
+    RuntimeAttr runtime_override = select_first([runtime_attr_override, runtime_default])
+
+    command <<<
+        set -euxo pipefail
+
+        gcloud config list account --format "value(core.account)" 1> account.txt
+
+        #### TEST:  Make sure that this docker image is configured for python3
+        if which python3 > /dev/null 2>&1; then
+        pt3="$(which python3)"
+        echo "** python3 located at $pt3"
+        echo "** magic: $(file $pt3)"
+        echo "** Version info:"
+        echo "$(python3 -V)"
+        echo "** -c test"
+        python3 -c "print('hello world')"
+        else
+        echo "!! No 'python3' in path."
+        exit 1
+        fi
+        #### END TEST
+
+        python3 <<EOF
+        print("Running python code...")
+        import hail as hl
+        import os
+        import uuid
+        from google.cloud import dataproc_v1 as dataproc
+
+        # Must match pattern (?:[a-z](?:[-a-z0-9]{0,49}[a-z0-9])?)
+        cluster_name = f'~{prefix}-~{contig}-hail-{str(uuid.uuid4())[0:13]}'
+
+        # Must be local filepath
+        script_path = "~{submission_script}"
+
+        with open("account.txt", "r") as account_file:
+        account = account_file.readline().strip()
+        print("account: " + account)
+
+        try:
+        cluster_start_cmd = "hailctl dataproc start --num-workers ~{num_workers} --region {} --project {} --service-account {} --num-master-local-ssds 1 --num-worker-local-ssds 1 --max-idle=60m --max-age=1440m --subnet={} {}".format("~{region}", "~{gcs_project}", account, "projects/~{gcs_project}/regions/~{region}/subnetworks/~{gcs_subnetwork_name}", cluster_name)
+        print("Starting cluster...")
+        print(cluster_start_cmd)
+        print(os.popen(cluster_start_cmd).read())
+
+        cluster_client = dataproc.ClusterControllerClient(
+        client_options={"api_endpoint": f"~{region}-dataproc.googleapis.com:443"}
+        )
+
+        for cluster in cluster_client.list_clusters(request={"project_id": "~{gcs_project}", "region": "~{region}"}):
+        if cluster.cluster_name == cluster_name:
+        cluster_staging_bucket = cluster.config.temp_bucket
+
+        #### THIS IS WHERE YOU CALL YOUR SCRIPT AND COPY THE OUTPUT LOCALLY (so that it can get back into WDL-space)
+        submit_cmd = f'gcloud dataproc jobs submit pyspark {script_path} --cluster={cluster_name} --project ~{gcs_project}  --region=~{region} --account {account} --driver-log-levels root=WARN -- --vds_url ~{vds_url} --bed_url ~{bed_url} --vcf_header_url ~{vcf_header_url} --contig ~{contig} --output_gs_url gs://{cluster_staging_bucket}/{cluster_name}/~{prefix}.~{contig}.vcf.bgz'
+        print("Running: " + submit_cmd)
+        os.popen(submit_cmd).read()
+        print("Copying results out of staging bucket...")
+        staging_cmd = f'gsutil cp -r gs://{cluster_staging_bucket}/{cluster_name}/~{prefix}.~{contig}.vcf.bgz ~{prefix}.~{contig}.vcf.bgz'
+        print(staging_cmd)
+        os.popen(staging_cmd).read()
+        ###########
+
+        break
+
+        except Exception as e:
+        print(e)
+        raise
+        finally:
+        print(f'Stopping cluster: {cluster_name}')
+        os.popen("gcloud dataproc clusters delete --project {} --region {} --account {} {}".format("~{gcs_project}", "~{region}", account, cluster_name)).read()
+
+        EOF
+
+        echo "Complete"
+    >>>
+
+    output {
+        File vcf = "~{prefix}.~{contig}.vcf.bgz"
+    }
+
+    runtime {
+        memory: select_first([runtime_override.mem_gb, runtime_default.mem_gb]) + " GB"
+        disks: "local-disk " + select_first([runtime_override.disk_gb, runtime_default.disk_gb]) + " SSD"
+        cpu: select_first([runtime_override.cpu_cores, runtime_default.cpu_cores])
+        preemptible: select_first([runtime_override.preemptible_tries, runtime_default.preemptible_tries])
+        maxRetries: select_first([runtime_override.max_retries, runtime_default.max_retries])
+        docker: hail_docker
+        bootDiskSizeGb: select_first([runtime_override.boot_disk_gb, runtime_default.boot_disk_gb])
+    }
+}

--- a/scripts/variantstore/wdl/HailFromWdl.wdl
+++ b/scripts/variantstore/wdl/HailFromWdl.wdl
@@ -161,12 +161,8 @@ task filter_vds_and_export_as_vcf {
     }
 
     parameter_meta {
-        bed_url: {
-                     localization_optional: true
-                 }
-        vcf_header_url: {
-                            localization_optional: true
-                        }
+        bed_url: { localization_optional: true }
+        vcf_header_url: { localization_optional: true }
     }
 
     RuntimeAttr runtime_default = object {

--- a/scripts/variantstore/wdl/HailFromWdl.wdl
+++ b/scripts/variantstore/wdl/HailFromWdl.wdl
@@ -14,10 +14,10 @@ version 1.0
 #        String vds_url
 #
 #        # Genomic region for the output VCFs to cover
-#        File bed_url
+#        String bed_url
 #
 #        # VCF Header that will be used in the output
-#        File vcf_header_url
+#        String vcf_header_url
 #
 #        # Contigs of interest.  If a contig is present in the bed file, but not in this list, the contig will be ignored.
 #        #   In other words, this is a contig level intersection with the bed file.
@@ -86,10 +86,10 @@ workflow filter_vds_to_VCF_by_chr {
         String? git_branch_or_tag
 
         # Genomic region for the output VCFs to cover
-        File bed_url = "gs://broad-public-datasets/gvs/weights/gvs_vet_weights_1kb.bed"
+        String bed_url = "gs://broad-public-datasets/gvs/weights/gvs_vet_weights_1kb.bed"
 
         # VCF Header that will be used in the output
-        File vcf_header_url = "gs://gvs_quickstart_storage/hail_from_wdl/vcf_header.txt"
+        String vcf_header_url = "gs://gvs_quickstart_storage/hail_from_wdl/vcf_header.txt"
 
         # Contigs of interest.  If a contig is present in the bed file, but not in this list, the contig will be ignored.
         #   In other words, this is a contig level intersection with the bed file.
@@ -145,8 +145,8 @@ task filter_vds_and_export_as_vcf {
     input {
         # You must treat a VDS as a String, since it is a directory and not a single file
         String vds_url
-        File bed_url
-        File vcf_header_url
+        String bed_url
+        String vcf_header_url
 
         String? git_branch_or_tag
         File? submission_script

--- a/scripts/variantstore/wdl/HailFromWdl.wdl
+++ b/scripts/variantstore/wdl/HailFromWdl.wdl
@@ -57,7 +57,7 @@ version 1.0
 #   - This WDL script is still dependent on the python/Hail script that it calls.  You will see this when the parameters
 #    are passed into the script.
 #   - This WDL is boilerplate, except for input parameters, output parameters, and where marked in the main task.
-#   - We HIGHLY recommend that the WDL do NOT run on a preemptible VM
+#   - We HIGHLY recommend that the WDL is NOT run on a preemptible VM
 #    (reminder, this is a single VM that spins up the dataproc cluster and submits jobs -- it is not doing any of the
 #     actual computation.  In other words, it does not need to be a heavy machine.)
 #     In other words, always set `preemptible_tries` to zero (default).

--- a/scripts/variantstore/wdl/HailFromWdl.wdl
+++ b/scripts/variantstore/wdl/HailFromWdl.wdl
@@ -186,16 +186,16 @@ task filter_vds_and_export_as_vcf {
 
         #### TEST:  Make sure that this docker image is configured for python3
         if which python3 > /dev/null 2>&1; then
-        pt3="$(which python3)"
-        echo "** python3 located at $pt3"
-        echo "** magic: $(file $pt3)"
-        echo "** Version info:"
-        echo "$(python3 -V)"
-        echo "** -c test"
-        python3 -c "print('hello world')"
+            pt3="$(which python3)"
+            echo "** python3 located at $pt3"
+            echo "** magic: $(file $pt3)"
+            echo "** Version info:"
+            echo "$(python3 -V)"
+            echo "** -c test"
+            python3 -c "print('hello world')"
         else
-        echo "!! No 'python3' in path."
-        exit 1
+            echo "!! No 'python3' in path."
+            exit 1
         fi
         #### END TEST
 
@@ -213,41 +213,41 @@ task filter_vds_and_export_as_vcf {
         script_path = "~{submission_script}"
 
         with open("account.txt", "r") as account_file:
-        account = account_file.readline().strip()
+            account = account_file.readline().strip()
         print("account: " + account)
 
         try:
-        cluster_start_cmd = "hailctl dataproc start --num-workers ~{num_workers} --region {} --project {} --service-account {} --num-master-local-ssds 1 --num-worker-local-ssds 1 --max-idle=60m --max-age=1440m --subnet={} {}".format("~{region}", "~{gcs_project}", account, "projects/~{gcs_project}/regions/~{region}/subnetworks/~{gcs_subnetwork_name}", cluster_name)
-        print("Starting cluster...")
-        print(cluster_start_cmd)
-        print(os.popen(cluster_start_cmd).read())
+            cluster_start_cmd = "hailctl dataproc start --num-workers ~{num_workers} --region {} --project {} --service-account {} --num-master-local-ssds 1 --num-worker-local-ssds 1 --max-idle=60m --max-age=1440m --subnet={} {}".format("~{region}", "~{gcs_project}", account, "projects/~{gcs_project}/regions/~{region}/subnetworks/~{gcs_subnetwork_name}", cluster_name)
+            print("Starting cluster...")
+            print(cluster_start_cmd)
+            print(os.popen(cluster_start_cmd).read())
 
-        cluster_client = dataproc.ClusterControllerClient(
-        client_options={"api_endpoint": f"~{region}-dataproc.googleapis.com:443"}
-        )
+            cluster_client = dataproc.ClusterControllerClient(
+                client_options={"api_endpoint": f"~{region}-dataproc.googleapis.com:443"}
+            )
 
-        for cluster in cluster_client.list_clusters(request={"project_id": "~{gcs_project}", "region": "~{region}"}):
-        if cluster.cluster_name == cluster_name:
-        cluster_staging_bucket = cluster.config.temp_bucket
+            for cluster in cluster_client.list_clusters(request={"project_id": "~{gcs_project}", "region": "~{region}"}):
+                if cluster.cluster_name == cluster_name:
+                    cluster_staging_bucket = cluster.config.temp_bucket
 
-        #### THIS IS WHERE YOU CALL YOUR SCRIPT AND COPY THE OUTPUT LOCALLY (so that it can get back into WDL-space)
-        submit_cmd = f'gcloud dataproc jobs submit pyspark {script_path} --cluster={cluster_name} --project ~{gcs_project}  --region=~{region} --account {account} --driver-log-levels root=WARN -- --vds_url ~{vds_url} --bed_url ~{bed_url} --vcf_header_url ~{vcf_header_url} --contig ~{contig} --output_gs_url gs://{cluster_staging_bucket}/{cluster_name}/~{prefix}.~{contig}.vcf.bgz'
-        print("Running: " + submit_cmd)
-        os.popen(submit_cmd).read()
-        print("Copying results out of staging bucket...")
-        staging_cmd = f'gsutil cp -r gs://{cluster_staging_bucket}/{cluster_name}/~{prefix}.~{contig}.vcf.bgz ~{prefix}.~{contig}.vcf.bgz'
-        print(staging_cmd)
-        os.popen(staging_cmd).read()
-        ###########
+                    #### THIS IS WHERE YOU CALL YOUR SCRIPT AND COPY THE OUTPUT LOCALLY (so that it can get back into WDL-space)
+                    submit_cmd = f'gcloud dataproc jobs submit pyspark {script_path} --cluster={cluster_name} --project ~{gcs_project}  --region=~{region} --account {account} --driver-log-levels root=WARN -- --vds_url ~{vds_url} --bed_url ~{bed_url} --vcf_header_url ~{vcf_header_url} --contig ~{contig} --output_gs_url gs://{cluster_staging_bucket}/{cluster_name}/~{prefix}.~{contig}.vcf.bgz'
+                    print("Running: " + submit_cmd)
+                    os.popen(submit_cmd).read()
+                    print("Copying results out of staging bucket...")
+                    staging_cmd = f'gsutil cp -r gs://{cluster_staging_bucket}/{cluster_name}/~{prefix}.~{contig}.vcf.bgz ~{prefix}.~{contig}.vcf.bgz'
+                    print(staging_cmd)
+                    os.popen(staging_cmd).read()
+                    ###########
 
-        break
+                    break
 
         except Exception as e:
-        print(e)
-        raise
+            print(e)
+            raise
         finally:
-        print(f'Stopping cluster: {cluster_name}')
-        os.popen("gcloud dataproc clusters delete --project {} --region {} --account {} {}".format("~{gcs_project}", "~{region}", account, cluster_name)).read()
+            print(f'Stopping cluster: {cluster_name}')
+            os.popen("gcloud dataproc clusters delete --project {} --region {} --account {} {}".format("~{gcs_project}", "~{region}", account, cluster_name)).read()
 
         EOF
 

--- a/scripts/variantstore/wdl/extract/filter_VDS_and_shard_by_contig.py
+++ b/scripts/variantstore/wdl/extract/filter_VDS_and_shard_by_contig.py
@@ -1,0 +1,112 @@
+import hail as hl
+import argparse
+
+
+# requires multiallelic mt as input
+def write_chr_vcf(mt, chrom, full_path, metadata, tabix=True):
+    print(f'writing VCF for chr={chrom}')
+    mt = mt.filter_rows(mt.locus.contig == chrom)
+    hl.export_vcf(mt, full_path, tabix=tabix, metadata=metadata)
+
+
+def make_dense_mt(vds, max_alt_alleles=None, is_keep_as_vqsr_fields=False):
+    """
+    Given a VDS, follow a standard method to densify into a MatrixTable.
+    This process includes:
+        - Rendering genotypes (GT), genotype allelic depth (AD)
+        - Transmute FT to from a boolean to a string
+        - Drop an artifact of Hail: the gvcf_info field
+        - Put AC, AF, and AN into the standard MatrixTable convention (ie, in info) for rendering as VCF.
+        - Drop local (eg, LAD, LGT) and other extraneous fields.  Please note that this code is smart enough to silently
+            skip any fields that are not present without throwing an error.
+
+    :param vds: input VDS as a gs URL
+    :param max_alt_alleles (None):  Drop any variant sites that have the number of alt alleles exceeding this value.
+        Specify None to not prune any variant sites by this criteria.
+    :param is_keep_as_vqsr_fields (False):  If True, keep the AS_VQSR fields, but move the fields to the info field.
+    :return: a dense MatrixTable
+    """
+    vd_gt = vds.variant_data
+
+    # if going to filter alleles, do it here
+    if max_alt_alleles is not None:
+        vd_gt = vd_gt.filter_rows(hl.len(vd_gt.alleles) < max_alt_alleles)
+
+    vd_gt = vd_gt.annotate_entries(AD = hl.vds.local_to_global(vd_gt.LAD,
+                                                               vd_gt.LA, n_alleles=hl.len(vd_gt.alleles),
+                                                               fill_value=0, number='R'))
+
+    # Update the variant data to include GT and convert FT to a string.
+    vd_gt = vd_gt.transmute_entries(
+        GT = hl.vds.lgt_to_gt(vd_gt.LGT, vd_gt.LA),
+    )
+
+    # Some VDS do not have FT and Hail will throw an exception if you try to modify it w/ transmute.
+    if 'FT' in vd_gt.entry:
+        vd_gt = vd_gt.transmute_entries(FT = hl.if_else(vd_gt.FT, "PASS", "FAIL"))
+
+    # Drop gvcf_info (if it exists) since it causes issues in test data we have seen.
+    if 'gvcf_info' in vd_gt.entry:
+        vd_gt = vd_gt.drop('gvcf_info')
+
+    # Densify and calculate AC, AN, etc
+    d_callset = hl.vds.to_dense_mt(hl.vds.VariantDataset(vds.reference_data, vd_gt))
+
+    # ## Add variant_qc
+    # Make sure to prune duplicate fields
+    d_callset = hl.variant_qc(d_callset)
+
+    d_callset = d_callset.annotate_rows(info = hl.struct(AC=d_callset.variant_qc.AC[1:],
+                                                             AF=d_callset.variant_qc.AF[1:],
+                                                             AN=d_callset.variant_qc.AN,
+                                                             homozygote_count=d_callset.variant_qc.homozygote_count))
+
+    if is_keep_as_vqsr_fields and ('as_vqsr' in d_callset.row):
+        d_callset = d_callset.annotate_rows(info = d_callset.info.annotate(AS_VQSLOD = d_callset.as_vqsr.values().vqslod,
+                                         AS_YNG = d_callset.as_vqsr.values().yng_status))
+
+    # Drop duplicate nested fields that are already in INFO field rendered by call_stats()
+    d_callset = d_callset.annotate_rows(variant_qc = d_callset.variant_qc.drop("AC", "AF", "AN", "homozygote_count"))
+
+    # ## Drop a bunch of unused fields
+    #  'LGT', 'LA' have already been removed
+    # Please note that this cell is specific to AoU VDS and fields specified here may not exist in test data.
+    # This will not fail if a field is missing.
+    fields_to_drop = ['as_vqsr', 'LAD',
+                'tranche_data', 'truth_sensitivity_snp_threshold',
+             'truth_sensitivity_indel_threshold','snp_vqslod_threshold','indel_vqslod_threshold']
+    d_callset = d_callset.drop(*(f for f in fields_to_drop if f in d_callset.entry or f in d_callset.row or f in d_callset.col))
+    return d_callset
+
+
+# Parse the arguments
+parser = argparse.ArgumentParser()
+parser.add_argument('--vds_url')
+parser.add_argument('--bed_url')
+parser.add_argument('--vcf_header_url')
+parser.add_argument('--contig')
+parser.add_argument('--output_gs_url')
+args = parser.parse_args()
+
+# Load the arguments
+vds_url = args.vds_url
+bed_url = args.bed_url
+vcf_header_url = args.vcf_header_url
+contig = args.contig
+output_gs_url = args.output_gs_url
+
+# Load only the contig of interest.
+vds1 = hl.vds.read_vds(vds_url)
+vds1 = hl.vds.filter_chromosomes(vds1, keep=contig)
+
+# Load bed file
+bed_intervals = hl.import_bed(bed_url, reference_genome='GRCh38')
+
+# Filter by bed file
+callset = hl.vds.filter_intervals(vds1, bed_intervals, split_reference_blocks=True)
+
+# Densify into a MatrixTable
+mt = make_dense_mt(vds1, max_alt_alleles=50)
+
+# Write this contig as a VCF
+write_chr_vcf(mt, contig, output_gs_url, hl.get_vcf_metadata(vcf_header_url), tabix=True)

--- a/scripts/variantstore/wdl/extract/run_in_hail_cluster.py
+++ b/scripts/variantstore/wdl/extract/run_in_hail_cluster.py
@@ -83,7 +83,7 @@ def run_in_cluster(prefix, contig, account, num_workers, worker_machine_type, re
             """.replace("\n", "")).read()
 
 
-if __name__ == '__main':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(allow_abbrev=False,
                                      description='Get workspace information')
 

--- a/scripts/variantstore/wdl/extract/run_in_hail_cluster.py
+++ b/scripts/variantstore/wdl/extract/run_in_hail_cluster.py
@@ -87,17 +87,18 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(allow_abbrev=False,
                                      description='Get workspace information')
 
-    parser.add_argument('--script-path', type=str, required=True, help='Path to script to run in Hail cluster')
     parser.add_argument('--prefix', type=str, required=True, help='Prefix used as part of Hail cluster name')
     parser.add_argument('--contig', type=str, required=True, help='Contig to extract')
-    parser.add_argument('--account-name', type=str, required=True, help='GCP account name')
+    parser.add_argument('--account', type=str, required=True, help='GCP account name')
     parser.add_argument('--num-workers', type=str, required=True, help='Number of workers in Hail cluster')
+    parser.add_argument('--worker-machine-type', type=str, required=False, help='Dataproc cluster worker machine type')
     parser.add_argument('--region', type=str, required=True, help='GCS region')
     parser.add_argument('--gcs-project', type=str, required=True, help='GCS project')
+    parser.add_argument('--script-path', type=str, required=True, help='Path to script to run in Hail cluster')
     parser.add_argument('--vds-url', type=str, required=True, help='VDS URL')
     parser.add_argument('--bed-url', type=str, required=True, help='Bed URL')
     parser.add_argument('--vcf-header-url', type=str, required=True, help='VCF Header URL')
-    parser.add_argument('--worker-machine-type', type=str, required=False, help='Dataproc cluster worker machine type')
+
 
     args = parser.parse_args()
 
@@ -105,5 +106,11 @@ if __name__ == "__main__":
                    contig=args.contig,
                    account=args.account,
                    num_workers=args.num_workers,
-                   worker_machine_type=f"args.worker_machine_type" if args.worker_machine_type else "n1-standard-8"
+                   worker_machine_type=args.worker_machine_type if args.worker_machine_type else "n1-standard-8",
+                   region=args.region,
+                   gcs_project=args.gcs_project,
+                   script_path=args.script_path,
+                   vds_url=args.vds_url,
+                   bed_url=args.bed_url,
+                   vcf_header_url=args.vcf_header_url
                    )

--- a/scripts/variantstore/wdl/extract/run_in_hail_cluster.py
+++ b/scripts/variantstore/wdl/extract/run_in_hail_cluster.py
@@ -23,10 +23,8 @@ def wrap(string):
     return re.sub("\\s{2,}", " ", string).strip()
 
 
-def run_in_cluster(prefix, contig, account, num_workers, worker_machine_type, region, gcs_project, script_path,
+def run_in_cluster(cluster_name, contig, account, num_workers, worker_machine_type, region, gcs_project, script_path,
                    vds_url, bed_url, vcf_header_url):
-    # Must match pattern (?:[a-z](?:[-a-z0-9]{0,49}[a-z0-9])?)
-    cluster_name = f'{prefix}-{contig}-hail-{str(uuid.uuid4())[0:13]}'
 
     try:
         cluster_start_cmd = wrap(f"""
@@ -46,7 +44,7 @@ def run_in_cluster(prefix, contig, account, num_workers, worker_machine_type, re
          
         """)
 
-        info("Starting cluster...")
+        info(f"Starting cluster '{cluster_name}'...")
         info(cluster_start_cmd)
         info(os.popen(cluster_start_cmd).read())
 
@@ -109,7 +107,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(allow_abbrev=False,
                                      description='Get workspace information')
 
-    parser.add_argument('--prefix', type=str, required=True, help='Prefix used as part of Hail cluster name')
+    parser.add_argument('--cluster-name', type=str, required=True, help='Name of the Hail cluster')
     parser.add_argument('--contig', type=str, required=True, help='Contig to extract')
     parser.add_argument('--account', type=str, required=True, help='GCP account name')
     parser.add_argument('--num-workers', type=str, required=True, help='Number of workers in Hail cluster')
@@ -124,7 +122,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    run_in_cluster(prefix=args.prefix,
+    run_in_cluster(cluster_name=args.cluster_name,
                    contig=args.contig,
                    account=args.account,
                    num_workers=args.num_workers,

--- a/scripts/variantstore/wdl/extract/run_in_hail_cluster.py
+++ b/scripts/variantstore/wdl/extract/run_in_hail_cluster.py
@@ -52,6 +52,8 @@ def run_in_cluster(cluster_name, contig, account, num_workers, worker_machine_ty
             client_options={"api_endpoint": f"{region}-dataproc.googleapis.com:443"}
         )
 
+        prefix='hail-wdl'
+
         for cluster in cluster_client.list_clusters(request={"project_id": gcs_project, "region": region}):
             if cluster.cluster_name == cluster_name:
                 cluster_staging_bucket = cluster.config.temp_bucket

--- a/scripts/variantstore/wdl/extract/run_in_hail_cluster.py
+++ b/scripts/variantstore/wdl/extract/run_in_hail_cluster.py
@@ -1,0 +1,109 @@
+import argparse
+import os
+import uuid
+from google.cloud import dataproc_v1 as dataproc
+
+
+def run_in_cluster(prefix, contig, account, num_workers, worker_machine_type, region, gcs_project, script_path,
+                   vds_url, bed_url, vcf_header_url):
+    # Must match pattern (?:[a-z](?:[-a-z0-9]{0,49}[a-z0-9])?)
+    cluster_name = f'{prefix}-{contig}-hail-{str(uuid.uuid4())[0:13]}'
+
+    try:
+        cluster_start_cmd = f"""
+        
+        hailctl dataproc start 
+         --num-workers {num_workers}
+         --worker-machine-type {worker_machine_type}
+         --region {region}
+         --project {gcs_project}
+         --service-account {account}
+         --num-master-local-ssds 1
+         --num-worker-local-ssds 1 
+         --max-idle=60m
+         --max-age=1440m
+         --subnet=projects/{gcs_project}/regions/{region}/subnetworks/subnetwork
+         {cluster_name}
+         
+        """.replace("\n", "")
+
+        print("Starting cluster...")
+        print(cluster_start_cmd)
+        print(os.popen(cluster_start_cmd).read())
+
+        cluster_client = dataproc.ClusterControllerClient(
+            client_options={"api_endpoint": f"{region}-dataproc.googleapis.com:443"}
+        )
+
+        for cluster in cluster_client.list_clusters(request={"project_id": gcs_project, "region": region}):
+            if cluster.cluster_name == cluster_name:
+                cluster_staging_bucket = cluster.config.temp_bucket
+
+                # THIS IS WHERE YOU CALL YOUR SCRIPT AND COPY THE OUTPUT LOCALLY (to get it back into WDL-space)
+                submit_cmd = f"""
+                
+                gcloud dataproc jobs submit pyspark {script_path}
+                 --cluster={cluster_name}
+                 --project {gcs_project}
+                 --region={region}
+                 --account {account}
+                 --driver-log-levels root=WARN
+                 --
+                 --vds_url {vds_url}
+                 --bed_url {bed_url}
+                 --vcf_header_url {vcf_header_url}
+                 --contig {contig}
+                 --output_gs_url gs://{cluster_staging_bucket}/{cluster_name}/{prefix}.{contig}.vcf.bgz
+                 
+                """.replace("\n", "")
+
+                print("Running: " + submit_cmd)
+                os.popen(submit_cmd).read()
+                print("Copying results out of staging bucket...")
+                staging_cmd = f"""
+                
+                gsutil cp -r gs://{cluster_staging_bucket}/{cluster_name}/{prefix}.{contig}.vcf.bgz '{prefix}.{contig}.vcf.bgz'
+                
+                """.replace("\n", "")
+
+                print(staging_cmd)
+                os.popen(staging_cmd).read()
+                ###########
+                break
+    except Exception as e:
+        print(e)
+        raise
+    finally:
+        print(f'Stopping cluster: {cluster_name}')
+        os.popen(
+            f"""
+            
+            gcloud dataproc clusters delete --project {gcs_project} --region {region} --account {account} {cluster_name}
+            
+            """.replace("\n", "")).read()
+
+
+if __name__ == '__main':
+    parser = argparse.ArgumentParser(allow_abbrev=False,
+                                     description='Get workspace information')
+
+    parser.add_argument('--script-path', type=str, required=True, help='Path to script to run in Hail cluster')
+    parser.add_argument('--prefix', type=str, required=True, help='Prefix used as part of Hail cluster name')
+    parser.add_argument('--contig', type=str, required=True, help='Contig to extract')
+    parser.add_argument('--account-name', type=str, required=True, help='GCP account name')
+    parser.add_argument('--num-workers', type=str, required=True, help='Number of workers in Hail cluster')
+    parser.add_argument('--region', type=str, required=True, help='GCS region')
+    parser.add_argument('--gcs-project', type=str, required=True, help='GCS project')
+    parser.add_argument('--vds-url', type=str, required=True, help='VDS URL')
+    parser.add_argument('--bed-url', type=str, required=True, help='Bed URL')
+    parser.add_argument('--vcf-header-url', type=str, required=True, help='VCF Header URL')
+    parser.add_argument('--worker-machine-type', type=str, required=False, help='Dataproc cluster worker machine type')
+
+    args = parser.parse_args()
+
+    run_in_cluster(prefix=args.prefix,
+                   contig=args.contig,
+                   account=args.account,
+                   num_workers=args.num_workers,
+                   worker_machine_type=f"args.worker_machine_type" if args.worker_machine_type else "n1-standard-8"
+                   )


### PR DESCRIPTION
Largely taken from Lee's sample code, see JIRA ticket for details. Spins up a Hail cluster and runs a script to extract from a VDS to VCF files on a per-chromosome basis. Includes some refactoring to move some of the workspace-sniffing that was part of bulk ingest into more generic utility code.

In terms of cluster tracking:

- Cluster name is calculated in shell script and visible in the logs
- Cluster name is written to a file which is delocalized even if the workload script fails. 

Unintended but useful example [here](https://job-manager.dsde-prod.broadinstitute.org/jobs/a96667a7-e08c-43f4-abad-b55fbe7f0c06) where not only is the cluster name logged and written to an output file which is delocalized, but the cluster gets shut down anyway by cleanup code.