### PR TITLE
VS-857. Change default behavior of GvsBulkIngestGenomes.wdl to drop state NONE.

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -280,6 +280,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_VS-857_MakeDropStateNoneTheDefaultInBulk
          tags:
              - /.*/
    - name: GvsQuickstartHailIntegration
@@ -289,6 +290,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_VS-857_MakeDropStateNoneTheDefaultInBulk
          tags:
              - /.*/
    - name: GvsQuickstartIntegration
@@ -298,6 +300,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_VS-857_MakeDropStateNoneTheDefaultInBulk
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -280,7 +280,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_VS-857_MakeDropStateNoneTheDefaultInBulk
          tags:
              - /.*/
    - name: GvsQuickstartHailIntegration
@@ -290,7 +289,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_VS-857_MakeDropStateNoneTheDefaultInBulk
          tags:
              - /.*/
    - name: GvsQuickstartIntegration
@@ -300,7 +298,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_VS-857_MakeDropStateNoneTheDefaultInBulk
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
+++ b/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
@@ -30,6 +30,7 @@
 1. `GvsBulkIngestGenomes` workflow
    - For use with **non-control** samples only! To ingest control samples (required for running `GvsCalculatePrecisionAndSensitivity`), use the`GvsAssignIds` and `GvsImportGenomes` workflows described below.
    - This workflow does not use the Terra Data Entity Model to run, so be sure to select the `Run workflow with inputs defined by file paths` workflow submission option.
+   - **NOTE** Be sure to set the input `drop_state` to ZERO. This will have the effect of dropping GQ0 reference blocks.
    - `GvsBulkIngestGenomes` performs the functions of both `GvsAssignIds` and `GvsImportGenomes` with a much more scalable design. Detailed bulk ingest documentation can be found [here](../gvs-bulk-ingest-details.md).
 1. `GvsAssignIds` workflow
    - For use with **control** samples only!
@@ -42,6 +43,7 @@
    - This will import the re-blocked gVCF files into GVS. The workflow will check whether data for that sample has already been loaded into GVS. It is designed to be re-run (with the same inputs) if there is a failure during one of the workflow tasks (e.g. BigQuery write API interrupts).
    - Run at the `sample set` level ("Step 1" in workflow submission).  You can either run this on a sample_set of all the samples and rely on the workflow logic to break it up into batches (or manually set the `load_data_batch_size` input) or run it on smaller sample_sets created by the "Fetch WGS metadata for samples from list" notebook mentioned above.  
    - You will want to set the `external_sample_names`, `input_vcfs` and `input_vcf_indexes` inputs based on the columns in the workspace Data table, e.g. "this.samples.research_id", "this.samples.reblocked_gvcf_v2" and "this.samples.reblocked_gvcf_index_v2".
+   - **NOTE** Be sure to set the input `drop_state` to ZERO. This will have the effect of dropping GQ0 reference blocks.
    - **NOTE** It appears that there is a rawls limit on the size of the input (list of gvcf files and indexes) per workflow run. 25K samples in a list worked for the Intermediate call set, 50K did not.
 1. `GvsWithdrawSamples` workflow
    - Run if there are any samples to withdraw from the last callset.

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -36,8 +36,8 @@ workflow GvsBulkIngestGenomes {
         # Begin GvsImportGenomes
         File interval_list = "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.noCentromeres.noTelomeres.interval_list"
 
-        # set to "ZERO" to drop GQ0 upon ingest into GVS for VDS (instead of VCF) output
-        String drop_state = "ZERO"
+        # set to "NONE" to ingest all the reference data into GVS for VDS (instead of VCF) output
+        String drop_state = "NONE"
 
         # The larger the `load_data_batch_size` the greater the probability of preemptions and non-retryable BigQuery errors,
         # so if specifying `load_data_batch_size`, adjust preemptible and maxretries accordingly. Or just take the defaults, as those should work fine in most cases.

--- a/scripts/variantstore/wdl/GvsQuickstartHailIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartHailIntegration.wdl
@@ -218,6 +218,7 @@ task CreateAndTieOutVds {
     runtime {
         # `slim` here to be able to use Java
         docker: cloud_sdk_slim_docker
+        maxRetries: 2
         disks: "local-disk 2000 HDD"
         memory: "30 GiB"
     }


### PR DESCRIPTION
VS-857.
Change default behavior of GvsBulkIngestGenomes.wdl BACK to not dropping GQ0 ref blocks.
Updated AoU documentation to say we need to do it there (as an input).

Passing Integration Test [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration/job_history/c4f921d8-52e7-4a44-9e0b-9f876eac71f3)