### PR TITLE
Use `gcloud storage cp` to sidestep composite object issues [VS-1090]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -185,6 +185,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - vs_1099_composite_object_inputs
          tags:
              - /.*/
    - name: GvsPrepareRangesCallset

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -264,6 +264,7 @@ workflows:
              # `master` is here so there will be *something* under the branches filter, but GVS WDLs are not on `master`
              # so this shouldn't show up in the list of available versions in Dockstore or Terra.
              - master
+             - vs_1099_composite_object_inputs
          tags:
              - /.*/
    - name: GvsJointVariantCallsetCost

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -309,7 +309,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - rc-vs-1064-wdl-quickstart-vds
+             - vs_1099_composite_object_inputs
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/docs/CHANGELOG.md
+++ b/scripts/variantstore/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Genomic Variant Store (GVS) Changelog
 
+## 0.4.1 - 2023-10-16
+
+### Fixed
+
+- Updated input VCF and VCF index localization commands in ingest to support Google Cloud Storage composite objects.
+
 ## 0.4.0 - 2023-10-10
 
 ### Added

--- a/scripts/variantstore/docs/CHANGELOG.md
+++ b/scripts/variantstore/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Updated input VCF and VCF index localization commands in ingest to support Google Cloud Storage composite objects.
+- Updated input VCF and VCF index localization in ingest to support Google Cloud Storage composite objects.
 
 ## 0.4.0 - 2023-10-10
 

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -319,8 +319,8 @@ task LoadData {
       sample_name="${SAMPLE_NAMES_ARRAY[$i]}"
 
       # we always do our own localization
-      gsutil ~{"-u " + billing_project_id} cp $gs_input_vcf input_vcf_$i.vcf.gz
-      gsutil ~{"-u " + billing_project_id} cp $gs_input_vcf_index input_vcf_$i.vcf.gz.tbi
+      gcloud storage ~{"--billing-project " + billing_project_id} cp $gs_input_vcf input_vcf_$i.vcf.gz
+      gcloud storage ~{"--billing-project " + billing_project_id} cp $gs_input_vcf_index input_vcf_$i.vcf.gz.tbi
       updated_input_vcf=input_vcf_$i.vcf.gz
 
       gatk --java-options "-Xmx2g" CreateVariantIngestFiles \


### PR DESCRIPTION
Normally one provides passing workflow runs with a PR. For the integration run [that is here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration/job_history/ab86fb6d-c5d6-48b6-8322-923af691751c). There's also a "real" run taking place using this branch [here](https://job-manager.dsde-prod.broadinstitute.org/jobs/db59d5b8-e2ac-4619-9563-aa5631bf053c).

However for testing correctness of these changes with respect to the requester pays flag, my pet "does not have serviceusage.services.use access to the Google Cloud project". I therefore present instead a [run with my changes](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration/job_history/9e712055-f466-4929-b6eb-5306f3cde1a0) that fails in exactly the same way as a [run without my changes](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration/job_history/185506f5-9dc1-4c02-997d-6fe3f5695259).