### PR TITLE
Fixing LoadData error discovered in delcho run

### DIFF
--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -72,7 +72,7 @@ task GetToolVersions {
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
     String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-10-13-alpine-8d14f01e9"
-    String gatk_docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_10_11"
+    String gatk_docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_10_18"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"
     String gotc_imputation_docker = "us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.5-1.10.2-0.1.16-1649948623"

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/RefCreator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/RefCreator.java
@@ -184,11 +184,20 @@ public final class RefCreator {
             long localStart = start;
             while ( localStart <= end ) {
                 int length = (int) Math.min(end - localStart + 1, IngestConstants.MAX_REFERENCE_BLOCK_BASES);
-                refRangesWriter.write(localStart,
-                        sampleId,
-                        length,
-                        GQStateEnum.MISSING.getValue()
-                );
+                if (storeCompressedReferences) {
+                    String chromosome = SchemaUtils.decodeContig(localStart);
+                    refRangesWriter.writeCompressed(
+                            SchemaUtils.encodeCompressedRefBlock(chromosome, localStart, length,
+                                    GQStateEnum.MISSING.getCompressedValue()),
+                            sampleId
+                    );
+                } else {
+                    refRangesWriter.write(localStart,
+                            sampleId,
+                            length,
+                            GQStateEnum.MISSING.getValue()
+                    );
+                }
                 localStart = localStart + length ;
             }
         }


### PR DESCRIPTION
there was a code path that didn't get exercised in integration tests or quickstart data (writeMissingIntervals) that wasn't made aware of the storeCompressedReferences flag.  Updated to operate correctly in its presence