### PR TITLE
Integration testing tables are not forever [VS-1049]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -311,7 +311,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1099_composite_object_inputs
+             - vs_1049_tables_are_not_forever
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
@@ -250,7 +250,7 @@ workflow GvsQuickstartIntegration {
     if (run_beta_integration) {
         String project_id = "gvs-internal"
 
-        call Utils.CreateDataset {
+        call Utils.CreateDatasetForTest {
             input:
                 git_branch_or_tag = git_branch_or_tag,
                 dataset_prefix = "quickit",
@@ -261,7 +261,7 @@ workflow GvsQuickstartIntegration {
         call JointVariantCalling.GvsJointVariantCalling as QuickstartBeta {
             input:
                 call_set_identifier = git_branch_or_tag,
-                dataset_name = CreateDataset.dataset_name,
+                dataset_name = CreateDatasetForTest.dataset_name,
                 project_id = project_id,
                 gatk_override = if (use_default_dockers) then none else BuildGATKJar.jar,
                 extract_output_file_base_name = "quickit",

--- a/scripts/variantstore/wdl/GvsQuickstartVcfIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartVcfIntegration.wdl
@@ -67,7 +67,7 @@ workflow GvsQuickstartVcfIntegration {
       }
     }
 
-    call Utils.CreateDataset {
+    call Utils.CreateDatasetForTest {
         input:
             git_branch_or_tag = git_branch_or_tag,
             dataset_prefix = "quickit",
@@ -78,7 +78,7 @@ workflow GvsQuickstartVcfIntegration {
     call JointVariantCalling.GvsJointVariantCalling as JointVariantCalling {
         input:
             call_set_identifier = git_branch_or_tag,
-            dataset_name = CreateDataset.dataset_name,
+            dataset_name = CreateDatasetForTest.dataset_name,
             project_id = project_id,
             gatk_override = if (use_default_dockers) then none else select_first([gatk_override, BuildGATKJar.jar]),
             use_classic_VQSR = !use_VQSR_lite,
@@ -122,7 +122,7 @@ workflow GvsQuickstartVcfIntegration {
         call AssertCostIsTrackedAndExpected {
             input:
                 go = JointVariantCalling.done,
-                dataset_name = CreateDataset.dataset_name,
+                dataset_name = CreateDatasetForTest.dataset_name,
                 project_id = project_id,
                 expected_output_csv = expected_prefix + "cost_observability_expected.csv",
                 cloud_sdk_docker = effective_cloud_sdk_docker,
@@ -131,7 +131,7 @@ workflow GvsQuickstartVcfIntegration {
         call AssertTableSizesAreExpected {
             input:
                 go = JointVariantCalling.done,
-                dataset_name = CreateDataset.dataset_name,
+                dataset_name = CreateDatasetForTest.dataset_name,
                 project_id = project_id,
                 expected_output_csv = expected_prefix + "table_sizes_expected.csv",
                 cloud_sdk_docker = effective_cloud_sdk_docker,
@@ -143,7 +143,7 @@ workflow GvsQuickstartVcfIntegration {
         Array[File] output_vcf_indexes = JointVariantCalling.output_vcf_indexes
         Float total_vcfs_size_mb = JointVariantCalling.total_vcfs_size_mb
         File manifest = JointVariantCalling.manifest
-        String dataset_name = CreateDataset.dataset_name
+        String dataset_name = CreateDatasetForTest.dataset_name
         String filter_set_name = "quickit"
         String recorded_git_hash = effective_git_hash
         Boolean done = true

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -390,9 +390,8 @@ task CreateDatasetForTest {
     String dataset_prefix
     String dataset_suffix
     String cloud_sdk_docker
-    # By default uto-expire tables 2 weeks after their creation. Unfortunately there doesn't seem to be an automated way
-    # of auto-expiring the dataset, but the date is in the dataset name so old (and hopefully empty) datasets should be
-    # easy to identify and clean up.
+    # By default auto-expire tables 2 weeks after their creation. Unfortunately there doesn't seem to be an automated way
+    # of auto-expiring the dataset, but the date is in the dataset name so old datasets should be easy to identify.
     Int? table_ttl_seconds = 2 * 7 * 24 * 60 * 60
   }
   meta {

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -384,14 +384,19 @@ task BuildGATKJar {
   }
 }
 
-task CreateDataset {
+task CreateDatasetForTest {
   input {
     String? git_branch_or_tag
     String dataset_prefix
     String dataset_suffix
     String cloud_sdk_docker
+    # By default uto-expire tables 2 weeks after their creation. Unfortunately there doesn't seem to be an automated way
+    # of auto-expiring the dataset, but the date is in the dataset name so old (and hopefully empty) datasets should be
+    # easy to identify and clean up.
+    Int? table_ttl_seconds = 2 * 7 * 24 * 60 * 60
   }
   meta {
+    description: "Create a dataset for testing purposes whose tables are all set to auto-expire. Do not call this task for production code as the tables created within it will auto-delete!"
     # Branch may be updated so do not call cache!
     volatile: true
   }
@@ -422,9 +427,10 @@ task CreateDataset {
     # Build a dataset name based on the branch name and the git hash of the most recent commit on this branch.
     # Dataset names must be alphanumeric and underscores only. Convert any dashes to underscores, then delete
     # any remaining characters that are not alphanumeric or underscores.
-    dataset="$(echo ~{dataset_prefix}_${branch}_${hash}_~{dataset_suffix} | tr '-' '_' | tr -c -d '[:alnum:]_')"
+    today="$(date -Idate | sed 's/-/_/g')"
+    dataset="$(echo ~{dataset_prefix}_${today}_${branch}_${hash}_~{dataset_suffix} | tr '-' '_' | tr -c -d '[:alnum:]_')"
 
-    bq --apilog=false mk --project_id="gvs-internal" "$dataset"
+    bq --apilog=false mk --project_id="gvs-internal" --default_table_expiration="~{table_ttl_seconds}" "$dataset"
 
     # add labels for DSP Cloud Cost Control Labeling and Reporting
     bq --apilog=false update --set_label service:gvs gvs-internal:$dataset


### PR DESCRIPTION
Creates integration testing datasets so the tables within them auto-delete at 2 weeks. See the tables in `gvs-internal.quickit_2023_10_24_vs_1049_tables_are_not_forever_265f343_beta` for an example, integration run [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration/job_history/72e3c830-b4ba-4e52-a264-07acb81a9b5b).