### PR TITLE
Compressed reference smarts [VS-1138]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -310,7 +310,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - rc-vs-923-add-validation
+             - vs_1138_compressed_reference_smarts
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
+++ b/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
@@ -69,7 +69,6 @@
    - The extracted Avro files will then be used as an input for `GvsCreateVDS` workflow described below.
    - This workflow needs to be run with the `filter_set_name` from `GvsCreateFilterSet` step.
    - This workflow does not use the Terra Data Entity Model to run, so be sure to select the `Run workflow with inputs defined by file paths` workflow submission option.
-   - **NOTE** Set `use_compressed_references` to true.
 1. `GvsCreateVDS` workflow
    - This step creates a VDS based on the Avro files generated from the `GvsExtractAvroFilesForHail` workflow above.
    - For the `avro_path` input, Avro files from the above `GvsExtractAvroFilesForHail` step can be found in the Avro directory in the `OutputPath` task: `gs://fc-<workspace-id>/submissions/<submission id>/GvsExtractAvroFilesForHail/<workflow id>/call-OutputPath/avro`

--- a/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
+++ b/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
@@ -79,7 +79,6 @@
     - This workflow transforms the data in the vet tables into a schema optimized for callset stats creation and for calculating sensitivity and precision.
     - The `only_output_vet_tables` input should be set to "true" (the default value is `false`).
     - See [naming conventions doc](https://docs.google.com/document/d/1pNtuv7uDoiOFPbwe4zx5sAGH7MyxwKqXkyrpNmBxeow) for guidance on what to use for `extract_table_prefix` or cohort prefix, which you will need to keep track of for the callset stats.
-    - **NOTE** Set `use_compressed_references` to true.
     - This workflow does not use the Terra Data Entity Model to run, so be sure to select the `Run workflow with inputs defined by file paths` workflow submission option.
 1. `GvsCallsetStatistics` workflow
     - You will need to have the "BigQuery Data Viewer" role for your @pmi-ops proxy group on the `spec-ops-aou:gvs_public_reference_data.gnomad_v3_sites` table

--- a/scripts/variantstore/wdl/GvsCreateVDS.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVDS.wdl
@@ -81,6 +81,7 @@ workflow GvsCreateVDS {
 
     output {
         String cluster_name = create_vds.cluster_name
+        Boolean done = true
     }
 
 }
@@ -149,6 +150,10 @@ task create_vds {
             --temp-path ${hail_temp_path} \
             ~{true='--use-classic-vqsr' false='' use_classic_VQSR}
     >>>
+
+    output {
+        String cluster_name = read_string("cluster_name.txt")
+    }
 
     runtime {
         memory: "6.5 GB"

--- a/scripts/variantstore/wdl/GvsCreateVDS.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVDS.wdl
@@ -151,10 +151,6 @@ task create_vds {
             ~{true='--use-classic-vqsr' false='' use_classic_VQSR}
     >>>
 
-    output {
-        String cluster_name = read_string("cluster_name.txt")
-    }
-
     runtime {
         memory: "6.5 GB"
         disks: "local-disk 100 SSD"

--- a/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
+++ b/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
@@ -13,7 +13,6 @@ workflow GvsExtractAvroFilesForHail {
         String filter_set_name
         String call_set_identifier
         Boolean use_VQSR_lite = true
-        Boolean use_compressed_references = false
         Int scatter_width = 10
         String? basic_docker
         String? cloud_sdk_docker
@@ -77,6 +76,13 @@ workflow GvsExtractAvroFilesForHail {
             cloud_sdk_docker = effective_cloud_sdk_docker,
     }
 
+    call Utils.IsUsingCompressedReferences {
+        input:
+            project_id = project_id,
+            dataset_name = dataset_name,
+            cloud_sdk_docker = effective_cloud_sdk_docker,
+    }
+
     scatter (i in range(scatter_width)) {
         call ExtractFromSuperpartitionedTables {
             input:
@@ -88,7 +94,7 @@ workflow GvsExtractAvroFilesForHail {
                 shard_index = i,
                 num_shards = scatter_width,
                 variants_docker = effective_variants_docker,
-                use_compressed_references = use_compressed_references,
+                use_compressed_references = IsUsingCompressedReferences.is_using_compressed_references,
         }
     }
 

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -99,7 +99,8 @@ workflow GvsExtractCohortFromSampleNames {
       destination_project             = destination_project_id,
       destination_dataset             = destination_dataset_name,
       fq_temp_table_dataset           = fq_gvs_extraction_temp_tables_dataset,
-      write_cost_to_db                = write_cost_to_db
+      write_cost_to_db                = write_cost_to_db,
+      cloud_sdk_docker                = effective_cloud_sdk_docker,
   }
 
   call GvsExtractCallset.GvsExtractCallset {

--- a/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
+++ b/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
@@ -188,7 +188,7 @@ workflow GvsJointVariantCalling {
             query_labels = query_labels,
             sample_names_to_extract = sample_names_to_extract,
             variants_docker = effective_variants_docker,
-            use_compressed_references = use_compressed_references,
+            cloud_sdk_docker = effective_cloud_sdk_docker,
     }
 
     String effective_output_gcs_dir = select_first([extract_output_gcs_dir, "~{effective_workspace_bucket}/output_vcfs/by_submission_id/~{effective_submission_id}"])

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -34,7 +34,7 @@ workflow GvsPrepareCallset {
   String fq_sample_mapping_table = "~{project_id}.~{dataset_name}.sample_info"
   String fq_destination_dataset = "~{destination_project}.~{destination_dataset}"
 
-  if (!defined(git_hash) || !defined(variants_docker) || ! defined(cloud_sdk_docker)) {
+  if (!defined(git_hash) || !defined(variants_docker) || !defined(cloud_sdk_docker)) {
     call Utils.GetToolVersions {
       input:
         git_branch_or_tag = git_branch_or_tag,

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -23,7 +23,7 @@ workflow GvsPrepareCallset {
     File? sample_names_to_extract
     Boolean only_output_vet_tables = false
     Boolean write_cost_to_db = true
-    Boolean use_compressed_references = false
+    String? cloud_sdk_docker
     String? variants_docker
     String? git_branch_or_tag
     String? git_hash
@@ -34,7 +34,7 @@ workflow GvsPrepareCallset {
   String fq_sample_mapping_table = "~{project_id}.~{dataset_name}.sample_info"
   String fq_destination_dataset = "~{destination_project}.~{destination_dataset}"
 
-  if (!defined(git_hash) || !defined(variants_docker)) {
+  if (!defined(git_hash) || !defined(variants_docker) || ! defined(cloud_sdk_docker)) {
     call Utils.GetToolVersions {
       input:
         git_branch_or_tag = git_branch_or_tag,
@@ -42,7 +42,15 @@ workflow GvsPrepareCallset {
   }
 
   String effective_variants_docker = select_first([variants_docker, GetToolVersions.variants_docker])
+  String effective_cloud_sdk_docker = select_first([cloud_sdk_docker, GetToolVersions.cloud_sdk_docker])
   String effective_git_hash = select_first([git_hash, GetToolVersions.git_hash])
+
+  call Utils.IsUsingCompressedReferences {
+    input:
+      project_id = query_project,
+      dataset_name = dataset_name,
+      cloud_sdk_docker = effective_cloud_sdk_docker,
+  }
 
   call PrepareRangesCallsetTask {
     input:
@@ -60,7 +68,7 @@ workflow GvsPrepareCallset {
       only_output_vet_tables          = only_output_vet_tables,
       write_cost_to_db                = write_cost_to_db,
       variants_docker                 = effective_variants_docker,
-      use_compressed_references       = use_compressed_references,
+      use_compressed_references       = IsUsingCompressedReferences.is_using_compressed_references,
   }
 
   output {

--- a/scripts/variantstore/wdl/GvsQuickstartHailIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartHailIntegration.wdl
@@ -120,11 +120,10 @@ workflow GvsQuickstartHailIntegration {
     call TieOutVds {
         input:
             go = GvsCreateVDS.done,
-            git_branch_or_tag = git_branch_or_tag,
             vds_path = GvsExtractAvroFilesForHail.vds_output_path,
             tieout_vcfs = GvsQuickstartVcfIntegration.output_vcfs,
             tieout_vcf_indexes = GvsQuickstartVcfIntegration.output_vcf_indexes,
-            cloud_sdk_slim_docker = effective_cloud_sdk_slim_docker,
+            variants_docker = effective_variants_docker,
             hail_version = effective_hail_version,
     }
 
@@ -144,11 +143,10 @@ workflow GvsQuickstartHailIntegration {
 task TieOutVds {
     input {
         Boolean go
-        String git_branch_or_tag
         String vds_path
         Array[File] tieout_vcfs
         Array[File] tieout_vcf_indexes
-        String cloud_sdk_slim_docker
+        String variants_docker
         String hail_version
     }
     parameter_meta {
@@ -164,11 +162,9 @@ task TieOutVds {
         PS4='\D{+%F %T} \w $ '
         set -o errexit -o nounset -o pipefail -o xtrace
 
-        # Copy the versions of the Hail import and tieout scripts for this branch from GitHub.
-        script_url_prefix="https://raw.githubusercontent.com/broadinstitute/gatk/~{git_branch_or_tag}/scripts/variantstore/wdl/extract"
         for script in hail_gvs_import.py hail_join_vds_vcfs.py gvs_vds_tie_out.py import_gvs.py
         do
-            curl --silent --location --remote-name "${script_url_prefix}/${script}"
+            cp /app/${script} .
         done
 
         # Create a manifest of VCFs and indexes to bulk download with `gcloud storage cp`.
@@ -224,7 +220,7 @@ task TieOutVds {
     >>>
     runtime {
         # `slim` here to be able to use Java
-        docker: cloud_sdk_slim_docker
+        docker: variants_docker
         maxRetries: 2
         disks: "local-disk 2000 HDD"
         memory: "30 GiB"

--- a/scripts/variantstore/wdl/GvsQuickstartHailIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartHailIntegration.wdl
@@ -102,7 +102,6 @@ workflow GvsQuickstartHailIntegration {
             basic_docker = effective_basic_docker,
             cloud_sdk_docker = effective_cloud_sdk_docker,
             variants_docker = effective_variants_docker,
-            use_compressed_references = use_compressed_references,
     }
 
     call CreateVds.GvsCreateVDS {

--- a/scripts/variantstore/wdl/GvsQuickstartHailIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartHailIntegration.wdl
@@ -119,6 +119,7 @@ workflow GvsQuickstartHailIntegration {
 
     call TieOutVds {
         input:
+            go = GvsCreateVDS.done,
             git_branch_or_tag = git_branch_or_tag,
             vds_path = GvsExtractAvroFilesForHail.vds_output_path,
             tieout_vcfs = GvsQuickstartVcfIntegration.output_vcfs,
@@ -142,6 +143,7 @@ workflow GvsQuickstartHailIntegration {
 
 task TieOutVds {
     input {
+        Boolean go
         String git_branch_or_tag
         String vds_path
         Array[File] tieout_vcfs

--- a/scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
@@ -26,6 +26,7 @@ workflow GvsQuickstartIntegration {
         String? cloud_sdk_slim_docker
         String? variants_docker
         String? gatk_docker
+        String? hail_version
     }
 
     File full_wgs_interval_list = "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.noCentromeres.noTelomeres.interval_list"
@@ -49,6 +50,7 @@ workflow GvsQuickstartIntegration {
     String effective_cloud_sdk_slim_docker = select_first([cloud_sdk_slim_docker, GetToolVersions.cloud_sdk_slim_docker])
     String effective_variants_docker = select_first([variants_docker, GetToolVersions.variants_docker])
     String effective_gatk_docker = select_first([gatk_docker, GetToolVersions.gatk_docker])
+    String effective_hail_version = select_first([hail_version, GetToolVersions.hail_version])
 
     call FilterIntervalListChromosomes {
         input:
@@ -93,6 +95,7 @@ workflow GvsQuickstartIntegration {
                 workspace_bucket = GetToolVersions.workspace_bucket,
                 workspace_id = GetToolVersions.workspace_id,
                 submission_id = GetToolVersions.submission_id,
+                hail_version = effective_hail_version,
         }
         call QuickstartHailIntegration.GvsQuickstartHailIntegration as GvsQuickstartHailVQSRClassicIntegration {
             input:
@@ -118,6 +121,7 @@ workflow GvsQuickstartIntegration {
                 workspace_bucket = GetToolVersions.workspace_bucket,
                 workspace_id = GetToolVersions.workspace_id,
                 submission_id = GetToolVersions.submission_id,
+                hail_version = effective_hail_version,
         }
 
         if (GvsQuickstartHailVQSRLiteIntegration.used_tighter_gcp_quotas) {

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -72,7 +72,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
-    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-11-15-alpine-104a124c6"
+    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-11-15-alpine-14e0343b6"
     String gatk_docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_10_31_e7746ce7c38a8226bcac5b89284782de2a4cdda1"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -72,7 +72,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
-    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-11-15-alpine-402de60a3"
+    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-11-15-alpine-104a124c6"
     String gatk_docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_10_31_e7746ce7c38a8226bcac5b89284782de2a4cdda1"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -816,6 +816,9 @@ task IsUsingCompressedReferences {
         table_name = "ref_ranges_001"
       AND (column_name = "location" OR column_name = "packed_ref_data") ' | sed 1d > column_name.txt
 
+    # grep will return non-zero if the "query" term is not found and we don't want to fail the task for that.
+    set +o errexit
+
     grep packed_ref_data column_name.txt
     rc=$?
     if [[ $rc -eq 0 ]]
@@ -832,6 +835,7 @@ task IsUsingCompressedReferences {
         exit 1
       fi
     fi
+    set -o errexit
 
     echo $ret > ret.txt
   >>>

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -72,7 +72,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
-    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-11-15-alpine-104a124c6"
+    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-11-15-alpine-402de60a3"
     String gatk_docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_10_31_e7746ce7c38a8226bcac5b89284782de2a4cdda1"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/extract/hail_join_vds_vcfs.py
+++ b/scripts/variantstore/wdl/extract/hail_join_vds_vcfs.py
@@ -4,9 +4,6 @@ import hail as hl
 
 def vds_mt(vds_path):
     vds = hl.vds.read_vds(vds_path)
-    # This is currently required as otherwise GT takes priority but AC will be wrong as alleles will be in different
-    # orders in the VCF versus VDS representations.
-    vds.variant_data = vds.variant_data.drop('GT')
     mt = hl.vds.to_dense_mt(vds)
     dense_vds_path = 'vds_dense.mt'
     mt.write(dense_vds_path, overwrite=True)


### PR DESCRIPTION
Integration run in progress: https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration/job_history/b0ba98ae-a81f-4be2-bd72-c374359b644c

I actually don't expect this to pass due to VS-1141, but hopefully once this lands VS-1141 will be the *only* thing preventing integration from passing.

Stowaway bug fixes:

- Hail version defaulted properly
- VDS tie out now waits for VDS creation to finish