### PR TITLE
Add RealignSoftClippedReads tool

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaReadAligner.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/bwa/BwaReadAligner.java
@@ -1,0 +1,131 @@
+package org.broadinstitute.hellbender.tools.spark.bwa;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.bwa.*;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
+
+import java.util.*;
+
+/**
+ * Class for aligning reads with BWA. Supports both paired and unpaired alignments.
+ */
+public final class BwaReadAligner {
+    private final BwaMemIndex bwaMemIndex;
+    private final SAMFileHeader readsHeader;
+    private final boolean alignsPairs;
+    private final boolean retainDuplicateFlag;
+    private int nThreads = 1;  // -t option
+    private boolean softClipSupplementaryAlignments = false;  // -Y option
+
+    /**
+     * Main constructor
+     * @param indexFileName path to BWA index image file
+     * @param readsHeader   input reads header
+     * @param alignsPairs   whether this is a paired-end alignment
+     * @param retainDuplicateFlag  carry over duplicate read flag
+     */
+    public BwaReadAligner(final String indexFileName, final SAMFileHeader readsHeader, final boolean alignsPairs,
+                          final boolean retainDuplicateFlag) {
+        this.bwaMemIndex = BwaMemIndexCache.getInstance(indexFileName);
+        this.readsHeader = readsHeader;
+        this.alignsPairs = alignsPairs;
+        this.retainDuplicateFlag = retainDuplicateFlag;
+        if (alignsPairs && readsHeader.getSortOrder() != SAMFileHeader.SortOrder.queryname) {
+            throw new UserException("Input must be queryname sorted unless you use single-ended alignment mode.");
+        }
+    }
+
+    /**
+     * Sets the number of threads used by BWA (-t option)
+     */
+    public void setNThreads(final int n) {
+        nThreads = n;
+    }
+
+    /**
+     * Sets whether to soft-clip supplementary alignments (-Y option)
+     */
+    public void setSoftClipSupplementaryAlignments(final boolean softClipSupplementaryAlignments) {
+        this.softClipSupplementaryAlignments = softClipSupplementaryAlignments;
+    }
+
+    /**
+     * Overloaded alignment method for Spark
+     */
+    public Iterator<GATKRead> apply(final Iterator<GATKRead> readItr, final int estimatedInputSize) {
+        final List<GATKRead> inputReads = new ArrayList<>(estimatedInputSize);
+        while (readItr.hasNext()) {
+            inputReads.add(readItr.next());
+        }
+        return apply(inputReads);
+    }
+
+    /**
+     * Performs alignment on a list of reads
+     */
+    public Iterator<GATKRead> apply(final List<GATKRead> inputReads) {
+        final int nReads = inputReads.size();
+        if (alignsPairs) {
+            if ((nReads & 1) != 0) {
+                throw new GATKException("We're supposed to be aligning paired reads, but there are an odd number of them.");
+            }
+            for (int idx = 0; idx != nReads; idx += 2) {
+                final String readName1 = inputReads.get(idx).getName();
+                final String readName2 = inputReads.get(idx + 1).getName();
+                if (!Objects.equals(readName1, readName2)) {
+                    throw new GATKException("Read pair has varying template name: " + readName1 + " .vs " + readName2);
+                }
+            }
+        }
+        // Reset to forward strand for the aligner
+        for (final GATKRead read : inputReads) {
+            if (read.isReverseStrand()) {
+                read.reverseComplement();
+            }
+        }
+        final List<List<BwaMemAlignment>> allAlignments;
+        if (nReads == 0) allAlignments = Collections.emptyList();
+        else {
+            final List<byte[]> seqs = new ArrayList<>(nReads);
+            for (final GATKRead read : inputReads) {
+                seqs.add(read.getBases());
+            }
+            final BwaMemAligner aligner = new BwaMemAligner(bwaMemIndex);
+            aligner.setNThreadsOption(nThreads);
+            if (softClipSupplementaryAlignments) {
+                aligner.setFlagOption(BwaMemAligner.MEM_F_SOFTCLIP);
+            }
+            // we are dealing with interleaved, paired reads.  tell BWA that they're paired.
+            if (alignsPairs) {
+                aligner.alignPairs();
+            }
+            allAlignments = aligner.alignSeqs(seqs);
+        }
+        final List<String> refNames = bwaMemIndex.getReferenceContigNames();
+        final List<GATKRead> outputReads = new ArrayList<>(allAlignments.stream().mapToInt(List::size).sum());
+        for (int idx = 0; idx != nReads; ++idx) {
+            final GATKRead originalRead = inputReads.get(idx);
+            final String readName = originalRead.getName();
+            final byte[] bases =  originalRead.getBases();
+            final byte[] quals = originalRead.getBaseQualities();
+            final String readGroup = originalRead.getReadGroup();
+            final List<BwaMemAlignment> alignments = allAlignments.get(idx);
+            final Map<BwaMemAlignment, String> saTagMap = BwaMemAlignmentUtils.createSATags(alignments, refNames);
+            for (final BwaMemAlignment alignment : alignments) {
+                final SAMRecord samRecord =
+                        BwaMemAlignmentUtils.applyAlignment(readName, bases, quals, readGroup,
+                                alignment, refNames, readsHeader, false, true);
+                samRecord.setDuplicateReadFlag(retainDuplicateFlag && originalRead.isDuplicate());
+                final GATKRead rec = SAMRecordToGATKReadAdapter.headerlessReadAdapter(samRecord);
+                final String saTag = saTagMap.get(alignment);
+                if (saTag != null) rec.setAttribute("SA", saTag);
+                outputReads.add(rec);
+            }
+        }
+        return outputReads.iterator();
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/softcliprealignment/RealignSoftClippedReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/softcliprealignment/RealignSoftClippedReads.java
@@ -1,0 +1,199 @@
+package org.broadinstitute.hellbender.tools.walkers.softcliprealignment;
+
+import com.google.common.annotations.VisibleForTesting;
+import htsjdk.samtools.CigarElement;
+import htsjdk.samtools.CigarOperator;
+import htsjdk.samtools.util.MergingIterator;
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.ArgumentCollection;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.ExperimentalFeature;
+import org.broadinstitute.barclay.help.DocumentedFeature;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.engine.FeatureContext;
+import org.broadinstitute.hellbender.engine.GATKPath;
+import org.broadinstitute.hellbender.engine.MultiplePassReadWalker;
+import org.broadinstitute.hellbender.engine.ReferenceContext;
+import org.broadinstitute.hellbender.engine.filters.ReadFilter;
+import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.SAMFileGATKReadWriter;
+import picard.cmdline.programgroups.OtherProgramGroup;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Realigns soft-clipped reads using BWA.
+ *
+ * <p>
+ * This tool consumes coordinate-sorted alignments and realigns all soft-clipped primary reads and their mates.
+ * The new alignments are then efficiently merged with the non-clipped reads. The tool works in the following steps:
+ * </p>
+ *
+ * <ol>
+ *     <li>Traverse input to identify soft-clipped primary alignments</li>
+ *     <li>Traverse input a second time to pull out soft-clipped primary alignments and their mates</li>
+ *     <li>Realign the soft-clipped reads/read pairs with BWA</li>
+ *     <li>Sort the realignments and merge them with the original unclipped read pairs</li>
+ * </ol>
+ *
+ * <p>
+ * Input reads may be paired or unpaired or a mixture. For paired reads, their names must be identical
+ * (no "/1" or "/2" suffixes; SAM flags are ignored). Also, the BWA index image must match the reference of the input
+ * alignments. In other words, the realignment must be to the same reference as the original reads.
+ * </p>
+ *
+ * <p>
+ * Default BWA alignment parameters are used, with the exception of the addition of the -Y command line argument,
+ * which enables soft-clipping of supplementary alignments.
+ * </p>
+ *
+ * <p>
+ * Unclipped reads (whose mates are also not soft-clipped) are emitted in the output exactly as they appear in the
+ * input. That is, SAM flags and tags are not changed. For the realigned reads, the only tags retained are read
+ * groups (RG). The "--keep-duplicate-flag" option may be enabled to retain the duplicate read SAM flag
+ * for realigned reads. Reads that were realigned can be identified by an "RA" tag set to "1" in the output.
+ * </p>
+ *
+ * <p>
+ * In order to minimize the memory footprint, this tool caches reads to disk in BAM format. Therefore, it is
+ * recommended to have free disk space equal to 2-3x of the input BAM size on the java.io.tmpdir volume.
+ * </p>
+ *
+ * <p>
+ * It is highly recommended to utilize BWA multi-threading with the "--bwa-threads" parameter. Runtime is also
+ * substantially reduced (~2x) using BAM input/output compared to CRAM.
+ * </p>
+ *
+ * <p>
+ * Use of interval subsetting (with -L/-XL) is supported. However, use caution because mates outside of the selected
+ * intervals will NOT be included. Reads with mates lying outside the intervals will be aligned in unpaired mode.
+ * </p>
+ *
+ * <p>
+ * The reference (provided with -R) is strictly required when handling CRAM files.
+ * </p>
+ *
+ * <h3> Input </h3>
+ * <ul>
+ *     <li> Coordinate-sorted and indexed SAM/BAM/CRAM </li>
+ *     <li> BWA index image file of the reference (created with BwaMemIndexImageCreator) </li>
+ * </ul>
+ *
+ * <h3> Output </h3>
+ * <ul>
+ *     <li> Coordinate-sorted and indexed SAM/BAM/CRAM </li>
+ * </ul>
+ *
+ * <h3>Usage example</h3>
+ * Realign reads with soft-clips of at least 10 bases, utilizing 4 threads for alignment.
+ * <pre>
+ * gatk RealignSoftClippedReads \
+ *   -I input.bam \
+ *   --bwa-mem-index-image ref.fasta.img \
+ *   --bwa-threads 4 \
+ *   --min-clipped-length 10 \
+ *   -O output.bam
+ * </pre>
+ *
+ * {@GATK.walkertype ReadWalker}
+ */
+@CommandLineProgramProperties(
+        summary = "Realigns soft-clipped reads to a given reference using BWA.",
+        oneLineSummary = "Realigns soft-clipped reads to a given reference using BWA.",
+        programGroup = OtherProgramGroup.class
+)
+@DocumentedFeature
+@ExperimentalFeature
+public final class RealignSoftClippedReads extends MultiplePassReadWalker {
+
+    public static final String MIN_SOFT_CLIP_LENGTH_LONG_NAME = "min-clipped-length";
+
+    @Argument(doc="Output bam file.",
+            fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
+            shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME)
+    public GATKPath output;
+
+    @Argument(doc="Minimum length of soft clips required for realignment. Setting to 0 will realign all reads.",
+            fullName = MIN_SOFT_CLIP_LENGTH_LONG_NAME,
+            optional = true,
+            minValue = 0)
+    public int minSoftClipLength = 1;
+
+    @ArgumentCollection
+    public SubsettingRealignmentArgumentCollection args = new SubsettingRealignmentArgumentCollection();
+
+    @Override
+    public boolean requiresReads() {
+        return true;
+    }
+
+    @Override
+    public List<ReadFilter> getDefaultReadFilters() {
+        return Collections.singletonList(ReadFilterLibrary.ALLOW_ALL_READS);
+    }
+
+    @Override
+    public void traverseReads() {
+        logger.info("Identifying soft-clipped reads...");
+        final Set<String> softclippedReadNames = new HashSet<>();
+        forEachRead((GATKRead read, ReferenceContext reference, FeatureContext features) ->
+                checkIfClipped(read, softclippedReadNames, minSoftClipLength)
+        );
+        logger.info("Found " + softclippedReadNames.size() + " soft-clipped reads / read pairs.");
+        try (final SubsettingRealignmentEngine engine = new SubsettingRealignmentEngine(args.indexImage.toString(),
+                getHeaderForReads(), args.bufferSize, args.bwaThreads, args.keepDuplicateFlag);
+             final SAMFileGATKReadWriter writer = createSAMWriter(output, true)) {
+            logger.info("Subsetting soft-clipped reads and mates...");
+            forEachRead((GATKRead read, ReferenceContext reference, FeatureContext features) -> {
+                // Clear realignment tags in case the input was previously realigned
+                read.clearAttribute(SubsettingRealignmentEngine.REALIGNED_READ_TAG);
+                // Submit the read to the engine, selecting soft-clipped reads and their mates
+                engine.addRead(read, r -> softclippedReadNames.contains(r.getName()));
+            });
+            logger.info("Found " + engine.getSelectedReadsCount() + " soft-clipped reads and mates.");
+            logger.info("Found " + engine.getNonselectedReadsCount() + " non-clipped reads.");
+            logger.info("Realigning and merging reads...");
+            try (final MergingIterator<GATKRead> iter = engine.alignAndMerge()) {
+                while (iter.hasNext()) {
+                    writer.addRead(iter.next());
+                }
+            }
+            logger.info("Realigned " + engine.getPairedAlignmentReadsCount() + " paired and " +
+                    engine.getUnpairedAlignmentReadsCount() + " unpaired reads.");
+        }
+    }
+
+    /**
+     * Gather names of soft-clipped reads
+     */
+    @VisibleForTesting
+    static void checkIfClipped(final GATKRead read, final Set<String> softclippedReadNames, final int minSoftClipLength) {
+        if (isValidSoftClip(read, minSoftClipLength)) {
+            softclippedReadNames.add(read.getName());
+        }
+    }
+
+    /**
+     * Returns whether the read is non-secondary/non-supplementary and sufficiently soft-clipped
+     */
+    @VisibleForTesting
+    static boolean isValidSoftClip(final GATKRead read, final int minSoftClipLength) {
+        return ReadFilterLibrary.PRIMARY_LINE.test(read) && hasMinSoftClip(read, minSoftClipLength);
+    }
+
+    private static boolean hasMinSoftClip(final GATKRead read, final int minSoftClipLength) {
+        if (minSoftClipLength == 0) {
+            return true;
+        }
+        for (final CigarElement e : read.getCigarElements()) {
+            if (e.getOperator() == CigarOperator.SOFT_CLIP && e.getLength() >= minSoftClipLength) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/softcliprealignment/RealignSoftClippedReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/softcliprealignment/RealignSoftClippedReads.java
@@ -223,9 +223,8 @@ public final class RealignSoftClippedReads extends MultiplePassReadWalker {
     }
 
     static void addMateLocus(final GATKRead read, final List<MateInfo> loci, final OverlapDetector<SimpleInterval> traversalIntervals) {
-        if (ReadFilterLibrary.PRIMARY_LINE.test(read) && read.isPaired()) {
-            final SimpleInterval mateLocus = new SimpleInterval(read.getMateContig(), read.getMateStart(), read.getMateStart());
-            if (traversalIntervals == null || !traversalIntervals.overlapsAny(mateLocus)) {
+        if (ReadFilterLibrary.PRIMARY_LINE.test(read) && read.isPaired()) {;
+            if (traversalIntervals == null || !traversalIntervals.overlapsAny(new SimpleInterval(read.getMateContig(), read.getMateStart(), read.getMateStart()))) {
                 loci.add(new MateInfo(read.getMateContig(), read.getMateStart(), !read.isFirstOfPair(), read.getName()));
             }
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/softcliprealignment/SubsettingRealignmentArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/softcliprealignment/SubsettingRealignmentArgumentCollection.java
@@ -1,0 +1,39 @@
+package org.broadinstitute.hellbender.tools.walkers.softcliprealignment;
+
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.hellbender.engine.GATKPath;
+import org.broadinstitute.hellbender.tools.spark.bwa.BwaArgumentCollection;
+
+public class SubsettingRealignmentArgumentCollection {
+
+    public static final String BWA_IMAGE_LONG_NAME = BwaArgumentCollection.BWA_MEM_INDEX_IMAGE_FULL_NAME;
+    public static final String BUFFER_SIZE_LONG_NAME = "buffer-size";
+    public static final String BWA_THREADS_LONG_NAME = "bwa-threads";
+    public static final String KEEP_DUPLCIATE_FLAG = "keep-duplicate-flag";
+
+    @Argument(doc="BWA index image path generated with BwaMemIndexImageCreator.",
+            fullName = BwaArgumentCollection.BWA_MEM_INDEX_IMAGE_FULL_NAME)
+    public GATKPath indexImage;
+
+    /**
+     * Larger buffers will use more memory but reduce some overhead of restarting the aligner. This should be
+     * sufficiently large that the aligner can accurately estimate the insert size distribution.
+     */
+    @Argument(doc="Number of reads to hold in the buffer before aligning as a batch.",
+            fullName = BUFFER_SIZE_LONG_NAME,
+            optional = true,
+            minValue = 100)
+    public int bufferSize = 40000;
+
+    @Argument(doc="Number of bwa threads.",
+            fullName = BWA_THREADS_LONG_NAME,
+            optional = true,
+            minValue = 1)
+    public int bwaThreads = 2;
+
+    @Argument(doc="Retain duplicate flag on realigned reads.",
+            fullName = KEEP_DUPLCIATE_FLAG,
+            optional = true)
+    public boolean keepDuplicateFlag = false;
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/softcliprealignment/SubsettingRealignmentEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/softcliprealignment/SubsettingRealignmentEngine.java
@@ -1,0 +1,365 @@
+package org.broadinstitute.hellbender.tools.walkers.softcliprealignment;
+
+import com.google.common.collect.Lists;
+import htsjdk.samtools.*;
+import htsjdk.samtools.util.CloseableIterator;
+import htsjdk.samtools.util.FileExtensions;
+import htsjdk.samtools.util.MergingIterator;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReadsPathDataSource;
+import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.tools.spark.bwa.BwaReadAligner;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.function.Predicate;
+
+/**
+ * Multipurpose class for performing read alignment on a subset of reads using BWA. Automatically detects paired and
+ * unpaired reads using read names (flags are ignored for this) and uses the appropriate alignment mode for each.
+ * It merges the realigned subset ("selected" reads) with the rest of the original reads ("non-selected" reads)
+ * and returns them in coordinate sorted order.
+ *
+ * This class is used as follows. First, each read is passed in with the {@link #addRead(GATKRead, Predicate)}
+ * method, which requires one to specify the predicate for whether that read should be realigned. The reads must
+ * be provided in coordinate sorted order. Once all reads have been added, a single call to {@link #alignAndMerge()}
+ * can be made to perform the alignment and merge with the non-realigned reads.
+ *
+ * To ensure a consistently small memory footprint, reads are cached to disk using temporary BAM files and buffered
+ * for realignment. Also remember to call {@link #close()} or use try-with-resources to ensure that cached data is
+ * properly cleaned up.
+ *
+ * Note that instances of this class are NOT idempotent because calls to {@link #addRead(GATKRead, Predicate)} and
+ * {@link #alignAndMerge()} must be made in this specific order.
+ */
+public final class SubsettingRealignmentEngine implements AutoCloseable {
+
+    // Read buffers
+    private GATKRead lastRead = null;
+    private List<GATKRead> pairedBuffer;
+    private List<GATKRead> unpairedBuffer;
+    private final int bufferSize;
+
+    // Read headers
+    private final SAMFileHeader inputHeader;  // coordinate sorted (input and final output)
+    private final SAMFileHeader alignmentHeader; // same as input header but queryname sorted
+
+    // Aligners
+    private final BwaReadAligner pairedAligner;
+    private final BwaReadAligner unpairedAligner;
+
+    // Temporary files for the first pass, which divides reads into "selected" and "non-selected" groups
+    private File selectedReadsBam;
+    private File nonselectedReadsBam;
+    private SAMFileWriter selectedReadsWriter;
+    private SAMFileWriter nonselectedReadsWriter;
+
+    // Iterators for the final merge of non-selected and aligned reads
+    private CloseableIterator<GATKRead> unselectedRecordsIter;
+    private CloseableIterator<GATKRead> alignedRecordsIter;
+
+    // Read counters, for logging
+    private long selectedReadsCount = 0;
+    private long nonselectedReadsCount = 0;
+    private long pairedAlignmentReadsCount = 0;
+    private long unpairedAlignmentReadsCount = 0;
+
+    // Tag assigned to reads that were realigned
+    public static final String REALIGNED_READ_TAG = "RA";
+    public static final int REALIGNED_READ_TAG_VALUE = 1;
+
+    /**
+     * Constructor
+     * @param indexImagePath path to image created with {@link org.broadinstitute.hellbender.tools.BwaMemIndexImageCreator}
+     * @param inputHeader    input reads header (coordinate-sorted)
+     * @param bufferSize     number of reads for the alignment buffers
+     * @param bwaThreads     number of bwa threads
+     * @param retainDuplicateFlag  keep duplicate flag for each realigned read
+     */
+    public SubsettingRealignmentEngine(final String indexImagePath, final SAMFileHeader inputHeader,
+                                       final int bufferSize, final int bwaThreads, final boolean retainDuplicateFlag) {
+        if (!inputHeader.getSortOrder().equals(SAMFileHeader.SortOrder.coordinate)) {
+            throw new UserException.BadInput("Input is not coordinate sorted");
+        }
+        this.bufferSize = bufferSize;
+        pairedBuffer = new ArrayList<>(bufferSize);
+        unpairedBuffer = new ArrayList<>(bufferSize);
+        this.inputHeader = inputHeader;
+
+        // The input must be queryname sorted
+        alignmentHeader = inputHeader.clone();
+        alignmentHeader.setSortOrder(SAMFileHeader.SortOrder.queryname);
+
+        pairedAligner = new BwaReadAligner(indexImagePath, alignmentHeader, true, retainDuplicateFlag);
+        pairedAligner.setSoftClipSupplementaryAlignments(true);  // as in the Warp pipeline
+        pairedAligner.setNThreads(bwaThreads);
+
+        unpairedAligner = new BwaReadAligner(indexImagePath, alignmentHeader, false, retainDuplicateFlag);
+        pairedAligner.setSoftClipSupplementaryAlignments(true);
+        unpairedAligner.setNThreads(bwaThreads);
+
+        selectedReadsBam = FileUtils.createTempFile("realign_1", FileExtensions.BAM, null);
+        nonselectedReadsBam = FileUtils.createTempFile("realign_2", FileExtensions.BAM, null);
+        selectedReadsWriter = new SAMFileWriterFactory().makeWriter(alignmentHeader, false, selectedReadsBam, null);
+        nonselectedReadsWriter = new SAMFileWriterFactory().makeWriter(inputHeader, true, nonselectedReadsBam, null);
+    }
+
+    /**
+     * Cleans up temporary files and writers
+     */
+    @Override
+    public void close() {
+        closeFirstPassWriters();
+        cleanUpFile(selectedReadsBam);
+        selectedReadsBam = null;
+        cleanUpFile(nonselectedReadsBam);
+        nonselectedReadsBam = null;
+        if (unselectedRecordsIter != null) {
+            unselectedRecordsIter.close();
+            unselectedRecordsIter = null;
+        }
+        if (alignedRecordsIter != null) {
+            alignedRecordsIter.close();
+            alignedRecordsIter = null;
+        }
+    }
+
+    private void closeFirstPassWriters() {
+        if (selectedReadsWriter != null) {
+            selectedReadsWriter.close();
+            selectedReadsWriter = null;
+        }
+        if (nonselectedReadsWriter != null) {
+            nonselectedReadsWriter.close();
+            nonselectedReadsWriter = null;
+        }
+    }
+
+    /**
+     * For deleting temporary files
+     */
+    private void cleanUpFile(final File file) {
+        if (file == null) {
+            return;
+        }
+        try {
+            FileUtils.forceDelete(file);
+        } catch (final IOException e) {
+            throw new GATKException("Could not clean up temporary file", e);
+        }
+    }
+
+    /**
+     * Add an input read. Note that any {@link #REALIGNED_READ_TAG} tags should be cleared prior. All reads are
+     * cached on disk in BAM format. This method may NOT be called after any call to @{link #alignAndMerge} or
+     * @{link #close}. Also, it is assumed that mates have the same name (i.e. no "/1" and "/2") to detect pairs.
+     * @param read  candidate realignment read
+     * @param predicate  returns true iff the read should be realigned
+     */
+    public void addRead(final GATKRead read, final Predicate<GATKRead> predicate) {
+        Utils.nonNull(selectedReadsWriter, "This instance has been closed");
+        Utils.nonNull(nonselectedReadsWriter, "This instance has been closed");
+        if (predicate.test(read)) {
+            if (ReadFilterLibrary.PRIMARY_LINE.test(read)) {
+                selectedReadsWriter.addAlignment(read.convertToSAMRecord(selectedReadsWriter.getFileHeader()));
+                selectedReadsCount++;
+            }
+        } else {
+            nonselectedReadsWriter.addAlignment(read.convertToSAMRecord(nonselectedReadsWriter.getFileHeader()));
+            nonselectedReadsCount++;
+        }
+    }
+
+    /**
+     * Performs realignment on the reads submitted with @{@link #addRead(GATKRead, Predicate)}, and merges
+     * the alignments with non-selected reads. Caches realignments to disk before merging. This method may NOT be
+     * called after a previous call to this method or @{link #close}.
+     * @return merged iterator of realigned and non-selected reads, all coordinate-sorted
+     */
+    public MergingIterator<GATKRead> alignAndMerge() {
+        Utils.nonNull(selectedReadsBam, "This instance has been run already");
+        Utils.nonNull(nonselectedReadsBam, "This instance has been closed");
+        // Assume we're done with adding reads, so we can close the first set of temp files
+        closeFirstPassWriters();
+        
+        // Align selected reads
+        final File alignmentBam = FileUtils.createTempFile("realign_3", FileExtensions.BAM, null);
+        try (final ReadsDataSource selectedSource = new ReadsPathDataSource(selectedReadsBam.toPath());
+             final SAMFileWriter alignmentWriter = new SAMFileWriterFactory().makeWriter(inputHeader, false, alignmentBam, null)) {
+            for (final GATKRead read : selectedSource) {
+                writeAlignments(addReadToBuffer(read), alignmentWriter);
+            }
+            // Flush leftover reads
+            writeAlignments(flushPairedBuffer(), alignmentWriter);
+            addLastReadToBuffer();
+            writeAlignments(flushUnpairedBuffer(), alignmentWriter);
+        }
+
+        // Delete unneeded temp file of the original selected reads
+        cleanUpFile(selectedReadsBam);
+        selectedReadsBam = null;
+
+        // Merge the non-selected reads with the new alignments
+        final ReadsDataSource unselectedSource = new ReadsPathDataSource(nonselectedReadsBam.toPath());
+        final ReadsDataSource alignmentSource = new ReadsPathDataSource(alignmentBam.toPath());
+        unselectedRecordsIter = new ClosableReadSourceIterator(unselectedSource);
+        alignedRecordsIter = new ClosableReadSourceIterator(alignmentSource);
+        // htsjdk read comparators attempt tie-breaking after comparing coordinates, but this is generally too
+        // strict for data in the wild, so we won't enforce it here.
+        final Comparator<GATKRead> weakComparator = new Comparator<>() {
+            final SAMRecordComparator strongComparator = inputHeader.getSortOrder().getComparatorInstance();
+            @Override
+            public int compare(GATKRead o1, GATKRead o2) {
+                return strongComparator.fileOrderCompare(o1.convertToSAMRecord(inputHeader), o2.convertToSAMRecord(inputHeader));
+            }
+        };
+        return new MergingIterator<>(weakComparator, List.of(unselectedRecordsIter, alignedRecordsIter));
+    }
+
+    /**
+     * Simple helper method for writing alignment output
+     */
+    private void writeAlignments(final List<GATKRead> reads, final SAMFileWriter writer) {
+        for (final GATKRead read: reads) {
+            writer.addAlignment(read.convertToSAMRecord(inputHeader));
+        }
+    }
+
+    /**
+     * Realigns the given reads and properly handles pairedness. Note that the buffers and {@link #lastRead} may
+     * not be empty/null at the end and must be flushed afterward.
+     */
+    private List<GATKRead> addReadToBuffer(final GATKRead read) {
+        if (lastRead == null) {
+            lastRead = read;
+        } else if (lastRead.getName().equals(read.getName())) {
+            pairedBuffer.add(lastRead);
+            pairedBuffer.add(read);
+            lastRead = null;
+            if (pairedBuffer.size() == bufferSize || pairedBuffer.size() + 1 == bufferSize) {
+                return flushPairedBuffer();
+            }
+        } else {
+            // Names don't match, so the previous read was unpaired
+            unpairedBuffer.add(lastRead);
+            lastRead = read;
+            return flushUnpairedBuffer();
+        }
+        return Collections.emptyList();
+    }
+    private List<GATKRead> flushPairedBuffer() {
+        pairedAlignmentReadsCount += pairedBuffer.size();
+        return flushBuffer(pairedBuffer, pairedAligner);
+    }
+
+    private List<GATKRead> flushUnpairedBuffer() {
+        unpairedAlignmentReadsCount += unpairedBuffer.size();
+        return flushBuffer(unpairedBuffer, unpairedAligner);
+    }
+
+    private void addLastReadToBuffer() {
+        if (lastRead != null) {
+            unpairedBuffer.add(lastRead);
+            lastRead = null;
+        }
+    }
+
+    /**
+     * Realign all reads in the given buffer and clear it
+     */
+    private List<GATKRead> flushBuffer(final List<GATKRead> mutableBuffer, final BwaReadAligner aligner) {
+        final List<GATKRead> alignments = Lists.newArrayList(aligner.apply(mutableBuffer));
+        alignments.forEach(SubsettingRealignmentEngine::setRealignedTag);
+        mutableBuffer.clear();
+        return alignments;
+    }
+
+    /**
+     * Sets tag {@link #REALIGNED_READ_TAG} to mark it as realigned
+     */
+    private static void setRealignedTag(final GATKRead read) {
+        read.setAttribute(REALIGNED_READ_TAG, REALIGNED_READ_TAG_VALUE);
+    }
+
+    /**
+     * Returns true if the read was realigned
+     */
+    public static boolean readIsRealigned(final GATKRead read) {
+        return read.hasAttribute(REALIGNED_READ_TAG) && read.getAttributeAsInteger(REALIGNED_READ_TAG) == REALIGNED_READ_TAG_VALUE;
+    }
+
+    /**
+     * Number of reads selected for realignment
+     */
+    public long getSelectedReadsCount() {
+        return selectedReadsCount;
+    }
+
+    /**
+     * Number of reads not selected for realignment
+     */
+    public long getNonselectedReadsCount() {
+        return nonselectedReadsCount;
+    }
+
+    /**
+     * Number of realigned paired reads
+     */
+    public long getPairedAlignmentReadsCount() {
+        return pairedAlignmentReadsCount;
+    }
+
+    /**
+     * Number of realigned unpaired reads
+     */
+    public long getUnpairedAlignmentReadsCount() {
+        return unpairedAlignmentReadsCount;
+    }
+
+    /**
+     * Helper class to map a {@link ReadsDataSource} iterator to a {@link CloseableIterator} and each input read to a
+     * {@link SAMRecord} as well.
+     */
+    static final class ClosableReadSourceIterator implements CloseableIterator<GATKRead> {
+
+        ReadsDataSource source;
+        final Iterator<GATKRead> iterator;
+
+        public ClosableReadSourceIterator(final ReadsDataSource source) {
+            this.source = source;
+            this.iterator = source.iterator();
+        }
+
+        @Override
+        public void close() {
+            if (source != null) {
+                source.close();
+                source = null;
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (!iterator.hasNext()) {
+                close();
+                return false;
+            }
+            return iterator.hasNext();
+        }
+
+        @Override
+        public GATKRead next() {
+            if (source == null) {
+                throw new NoSuchElementException("Source has been closed");
+            }
+            return iterator.next();
+        }
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/softcliprealignment/SubsettingRealignmentEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/softcliprealignment/SubsettingRealignmentEngine.java
@@ -176,6 +176,15 @@ public final class SubsettingRealignmentEngine implements AutoCloseable {
         }
     }
 
+    public void addDistantMate(final GATKRead mate) {
+        Utils.nonNull(selectedReadsWriter, "This instance has been closed");
+        Utils.nonNull(nonselectedReadsWriter, "This instance has been closed");
+        if (ReadFilterLibrary.PRIMARY_LINE.test(mate)) {
+            selectedReadsWriter.addAlignment(mate.convertToSAMRecord(selectedReadsWriter.getFileHeader()));
+            selectedReadsCount++;
+        }
+    }
+
     /**
      * Performs realignment on the reads submitted with @{@link #addRead(GATKRead, Predicate)}, and merges
      * the alignments with non-selected reads. Caches realignments to disk before merging. This method may NOT be

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/softcliprealignment/RealignSoftClippedReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/softcliprealignment/RealignSoftClippedReadsIntegrationTest.java
@@ -1,0 +1,128 @@
+package org.broadinstitute.hellbender.tools.walkers.softcliprealignment;
+
+import htsjdk.samtools.*;
+import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
+import org.broadinstitute.hellbender.testutils.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.read.CigarBuilder;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class RealignSoftClippedReadsIntegrationTest extends CommandLineProgramTest {
+
+    // If true, update the expected outputs in tests that assert an exact or approximate match vs. prior output,
+    // instead of actually running the tests.
+    public static final boolean UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS = false;
+
+    private static final String BWA_IMAGE_PATH = SubsettingRealignmentEngineTest.BWA_IMAGE_PATH;
+    private final String INPUT_BAM_FILE = SubsettingRealignmentEngineTest.BAM_FILE;
+    private final String EXPECTED_BAM_FILE = SubsettingRealignmentEngineTest.TEST_DATA_DIR + "/test.expected.bam";
+
+    @Test
+    public void testSoftClipRealignment() throws IOException {
+        final ArgumentsBuilder args = new ArgumentsBuilder();
+        args.addInput(INPUT_BAM_FILE);
+        args.add(SubsettingRealignmentArgumentCollection.BWA_IMAGE_LONG_NAME, BWA_IMAGE_PATH);
+        if (UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS) {
+            args.addOutput(EXPECTED_BAM_FILE);
+            runCommandLine(args);
+        } else {
+            args.addOutput("%s");
+            IntegrationTestSpec testSpec = new IntegrationTestSpec(args.toString(), Arrays.asList(EXPECTED_BAM_FILE));
+            testSpec.executeTest("testSoftClipRealignment", this);
+        }
+    }
+
+    /**
+     * Make sure that someone didn't leave the {@value UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS} toggle turned on
+     */
+    @Test
+    public void assertThatExpectedOutputUpdateToggleIsDisabled() {
+        Assert.assertFalse(UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS, "The toggle to update expected outputs should not be left enabled");
+    }
+
+    @DataProvider(name = "testCheckIfClippedData")
+    public Object[][] testCheckIfClippedData() {
+        return new Object[][]{
+                // 150M
+                {new CigarBuilder().add(new CigarElement(150, CigarOperator.MATCH_OR_MISMATCH)), 1, false},
+                {new CigarBuilder().add(new CigarElement(150, CigarOperator.MATCH_OR_MISMATCH)), 0, true},
+                // 149M/1S
+                {new CigarBuilder()
+                        .add(new CigarElement(149, CigarOperator.MATCH_OR_MISMATCH))
+                        .add(new CigarElement(1, CigarOperator.SOFT_CLIP)), 0, true},
+                {new CigarBuilder()
+                        .add(new CigarElement(149, CigarOperator.MATCH_OR_MISMATCH))
+                        .add(new CigarElement(1, CigarOperator.SOFT_CLIP)), 1, true},
+                {new CigarBuilder()
+                        .add(new CigarElement(149, CigarOperator.MATCH_OR_MISMATCH))
+                        .add(new CigarElement(1, CigarOperator.SOFT_CLIP)), 2, false},
+                // 1S/149M
+                {new CigarBuilder()
+                        .add(new CigarElement(1, CigarOperator.SOFT_CLIP))
+                        .add(new CigarElement(149, CigarOperator.MATCH_OR_MISMATCH)), 1, true},
+                {new CigarBuilder()
+                        .add(new CigarElement(1, CigarOperator.SOFT_CLIP))
+                        .add(new CigarElement(149, CigarOperator.MATCH_OR_MISMATCH)), 2, false},
+                // 50M/10I/40M/5D/40M/5S
+                {new CigarBuilder()
+                        .add(new CigarElement(50, CigarOperator.MATCH_OR_MISMATCH))
+                        .add(new CigarElement(10, CigarOperator.INSERTION))
+                        .add(new CigarElement(40, CigarOperator.MATCH_OR_MISMATCH))
+                        .add(new CigarElement(5, CigarOperator.DELETION))
+                        .add(new CigarElement(40, CigarOperator.MATCH_OR_MISMATCH))
+                        .add(new CigarElement(5, CigarOperator.SOFT_CLIP)), 5, true},
+                {new CigarBuilder()
+                        .add(new CigarElement(50, CigarOperator.MATCH_OR_MISMATCH))
+                        .add(new CigarElement(10, CigarOperator.INSERTION))
+                        .add(new CigarElement(40, CigarOperator.MATCH_OR_MISMATCH))
+                        .add(new CigarElement(5, CigarOperator.DELETION))
+                        .add(new CigarElement(40, CigarOperator.MATCH_OR_MISMATCH))
+                        .add(new CigarElement(5, CigarOperator.SOFT_CLIP)), 10, false},
+        };
+    }
+
+    @Test(dataProvider= "testCheckIfClippedData")
+    public void testCheckIfClipped(final CigarBuilder cigar, final int minSoftClipLength, final boolean expected) {
+        final GATKRead read = new SAMRecordToGATKReadAdapter(new SAMRecord(new SAMFileHeader()));
+        read.setName("test_read");
+        read.setCigar(cigar.make());
+
+        // Check soft-clip detection is working
+        final boolean result = RealignSoftClippedReads.isValidSoftClip(read, minSoftClipLength);
+        Assert.assertEquals(result, expected);
+
+        // Check that the read name gets added to the set if it's a valid clip
+        final Set<String> names = new HashSet<>();
+        RealignSoftClippedReads.checkIfClipped(read, names, minSoftClipLength);
+        if (result) {
+            Assert.assertEquals(names.size(), 1);
+            Assert.assertTrue(names.contains(read.getName()));
+        } else {
+            Assert.assertTrue(names.isEmpty());
+        }
+
+        // Supplementary read always false
+        final GATKRead supplementary = read.copy();
+        supplementary.setIsSupplementaryAlignment(true);
+        names.clear();
+        Assert.assertFalse(RealignSoftClippedReads.isValidSoftClip(supplementary, minSoftClipLength));
+        RealignSoftClippedReads.checkIfClipped(supplementary, names, minSoftClipLength);
+        Assert.assertTrue(names.isEmpty());
+
+        // Secondary read always false
+        final GATKRead secondary = read.copy();
+        secondary.setIsSecondaryAlignment(true);
+        Assert.assertFalse(RealignSoftClippedReads.isValidSoftClip(secondary, minSoftClipLength));
+        RealignSoftClippedReads.checkIfClipped(secondary, names, minSoftClipLength);
+        Assert.assertTrue(names.isEmpty());
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/softcliprealignment/SubsettingRealignmentEngineTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/softcliprealignment/SubsettingRealignmentEngineTest.java
@@ -1,0 +1,173 @@
+package org.broadinstitute.hellbender.tools.walkers.softcliprealignment;
+
+import com.google.api.client.util.Lists;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
+import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Iterator;
+import java.util.List;
+
+public class SubsettingRealignmentEngineTest extends CommandLineProgramTest {
+
+    @Override
+    public String getTestedClassName() {
+        return SubsettingRealignmentEngine.class.getSimpleName();
+    }
+
+    public static final String TEST_DATA_DIR = "src/test/resources/large/SubsettingRealignmentEngine";
+    public static final String BWA_IMAGE_PATH = TEST_DATA_DIR + "/hg38_chr22_test.fasta.img";
+    public static final String BAM_FILE = TEST_DATA_DIR + "/test.bam";
+
+    private static SubsettingRealignmentEngine getDefaultEngine(final SAMFileHeader header) {
+        return new SubsettingRealignmentEngine(BWA_IMAGE_PATH, header, 10, 1, false);
+    }
+
+    private static boolean alwaysTrue(final GATKRead read) {
+        return true;
+    }
+
+    @Test
+    public void testSmall() {
+        final SamReader reader = SamReaderFactory.make().open(new File(BAM_FILE));
+        final SAMFileHeader inputHeader = reader.getFileHeader();
+        try (final SubsettingRealignmentEngine engine = getDefaultEngine(inputHeader)) {
+            final Iterator<SAMRecord> iter = reader.iterator();
+            engine.addRead(new SAMRecordToGATKReadAdapter(iter.next()), SubsettingRealignmentEngineTest::alwaysTrue);
+            engine.addRead(new SAMRecordToGATKReadAdapter(iter.next()), r -> false);
+            final List<GATKRead> output = Lists.newArrayList(engine.alignAndMerge());
+
+            Assert.assertEquals(engine.getSelectedReadsCount(), 1);
+            Assert.assertEquals(engine.getNonselectedReadsCount(), 1);
+            Assert.assertEquals(engine.getPairedAlignmentReadsCount(), 0);
+            Assert.assertEquals(engine.getUnpairedAlignmentReadsCount(), 1);
+
+            final long realignedOutput = output.stream().filter(SubsettingRealignmentEngine::readIsRealigned).count();
+            Assert.assertEquals(realignedOutput, 1);
+
+            final long notRealignedOutput = output.stream().filter(r -> !SubsettingRealignmentEngine.readIsRealigned(r)).count();
+            Assert.assertEquals(notRealignedOutput, 1);
+
+            Assert.assertFalse(output.stream().anyMatch(GATKRead::isUnmapped));
+            Assert.assertTrue(output.stream().anyMatch(SubsettingRealignmentEngine::readIsRealigned));
+            Assert.assertTrue(output.stream().anyMatch(r -> SubsettingRealignmentEngine.readIsRealigned(r)));
+        }
+    }
+
+    @Test
+    public void testFull() {
+        final SamReader reader = SamReaderFactory.make().open(new File(BAM_FILE));
+        final SAMFileHeader inputHeader = reader.getFileHeader();
+        try (final SubsettingRealignmentEngine engine = getDefaultEngine(inputHeader)) {
+            final Iterator<SAMRecord> iter = reader.iterator();
+            while (iter.hasNext()) {
+                final GATKRead read = new SAMRecordToGATKReadAdapter(iter.next());
+                engine.addRead(read, r -> r.getMappingQuality() < 50);
+            }
+            final List<GATKRead> output = Lists.newArrayList(engine.alignAndMerge());
+
+            Assert.assertEquals(engine.getSelectedReadsCount(), 10);
+            Assert.assertEquals(engine.getNonselectedReadsCount(), 684);
+            Assert.assertEquals(engine.getPairedAlignmentReadsCount(), 6);
+            Assert.assertEquals(engine.getUnpairedAlignmentReadsCount(), 4);
+
+            final long realignedOutput = output.stream().filter(SubsettingRealignmentEngine::readIsRealigned).count();
+            Assert.assertEquals(realignedOutput, 10);
+
+            final long notRealignedOutput = output.stream().filter(r -> !SubsettingRealignmentEngine.readIsRealigned(r)).count();
+            Assert.assertEquals(notRealignedOutput, 684);
+
+            final long properlyPairedOutput = output.stream().filter(GATKRead::isProperlyPaired).count();
+            Assert.assertEquals(properlyPairedOutput, 671);
+
+            final long hasReadGroupOutput = output.stream().map(GATKRead::getReadGroup).filter(rg -> rg != null).count();
+            Assert.assertEquals(hasReadGroupOutput, output.size());
+        }
+    }
+    @Test
+    public void testRetainDuplicateFlag() {
+        final SamReader reader = SamReaderFactory.make().open(new File(BAM_FILE));
+        final SAMFileHeader inputHeader = reader.getFileHeader();
+        try (final SubsettingRealignmentEngine keepDuplicateEngine = new SubsettingRealignmentEngine(BWA_IMAGE_PATH, inputHeader, 10, 1, true);
+             final SubsettingRealignmentEngine notKeepDuplicateEngine = new SubsettingRealignmentEngine(BWA_IMAGE_PATH, inputHeader, 10, 1, false)) {
+            final Iterator<SAMRecord> iter = reader.iterator();
+            final GATKRead duplicate = new SAMRecordToGATKReadAdapter(iter.next());
+            duplicate.setIsDuplicate(true);
+            final GATKRead nonDuplicate = new SAMRecordToGATKReadAdapter(iter.next());
+            nonDuplicate.setIsDuplicate(false);
+
+            keepDuplicateEngine.addRead(duplicate, SubsettingRealignmentEngineTest::alwaysTrue);
+            keepDuplicateEngine.addRead(nonDuplicate, SubsettingRealignmentEngineTest::alwaysTrue);
+            final List<GATKRead> keepDuplicateOutput = Lists.newArrayList(keepDuplicateEngine.alignAndMerge());
+            Assert.assertEquals(keepDuplicateOutput.size(), 2);
+            Assert.assertEquals(keepDuplicateOutput.stream().filter(GATKRead::isDuplicate).count(), 1);
+
+            notKeepDuplicateEngine.addRead(duplicate, SubsettingRealignmentEngineTest::alwaysTrue);
+            notKeepDuplicateEngine.addRead(nonDuplicate, SubsettingRealignmentEngineTest::alwaysTrue);
+            final List<GATKRead> notKeepDuplicateOutput = Lists.newArrayList(notKeepDuplicateEngine.alignAndMerge());
+            Assert.assertEquals(notKeepDuplicateOutput.size(), 2);
+            Assert.assertEquals(notKeepDuplicateOutput.stream().filter(GATKRead::isDuplicate).count(), 0);
+        }
+    }
+
+    @Test
+    public void testEmptyInput() {
+        final SamReader reader = SamReaderFactory.make().open(new File(BAM_FILE));
+        final SAMFileHeader inputHeader = reader.getFileHeader();
+        try (final SubsettingRealignmentEngine engine = getDefaultEngine(inputHeader)) {
+            final List<GATKRead> output = Lists.newArrayList(engine.alignAndMerge());
+            Assert.assertEquals(output.size(), 0);
+            Assert.assertEquals(engine.getSelectedReadsCount(), 0);
+            Assert.assertEquals(engine.getNonselectedReadsCount(), 0);
+            Assert.assertEquals(engine.getPairedAlignmentReadsCount(), 0);
+            Assert.assertEquals(engine.getUnpairedAlignmentReadsCount(), 0);
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testAddingReadAfterAlignment() {
+        final SamReader reader = SamReaderFactory.make().open(new File(BAM_FILE));
+        final SAMFileHeader inputHeader = reader.getFileHeader();
+        try (final SubsettingRealignmentEngine engine = getDefaultEngine(inputHeader)) {
+            engine.alignAndMerge();
+            engine.addRead(new SAMRecordToGATKReadAdapter(reader.iterator().next()), SubsettingRealignmentEngineTest::alwaysTrue);
+        }
+    }
+
+    @Test(expectedExceptions = UserException.class)
+    public void testWrongSortType() {
+        final SamReader reader = SamReaderFactory.make().open(new File(BAM_FILE));
+        final SAMFileHeader inputHeader = reader.getFileHeader();
+        // Must be coordinate sorted
+        inputHeader.setSortOrder(SAMFileHeader.SortOrder.queryname);
+        getDefaultEngine(inputHeader);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testClosed1() {
+        final SamReader reader = SamReaderFactory.make().open(new File(BAM_FILE));
+        final SAMFileHeader inputHeader = reader.getFileHeader();
+        final SubsettingRealignmentEngine engine = getDefaultEngine(inputHeader);
+        engine.close();
+        engine.addRead(new SAMRecordToGATKReadAdapter(reader.iterator().next()), SubsettingRealignmentEngineTest::alwaysTrue);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testClosed2() {
+        final SamReader reader = SamReaderFactory.make().open(new File(BAM_FILE));
+        final SAMFileHeader inputHeader = reader.getFileHeader();
+        final SubsettingRealignmentEngine engine = getDefaultEngine(inputHeader);
+        engine.addRead(new SAMRecordToGATKReadAdapter(reader.iterator().next()), SubsettingRealignmentEngineTest::alwaysTrue);
+        engine.close();
+        engine.alignAndMerge();
+    }
+
+}

--- a/src/test/resources/large/SubsettingRealignmentEngine/hg38_chr22_test.fasta
+++ b/src/test/resources/large/SubsettingRealignmentEngine/hg38_chr22_test.fasta
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8b060d3b92b6cdfdd7580384685d6b880b08b8dba16a99e2a1b8244e7d3da49
+size 58007

--- a/src/test/resources/large/SubsettingRealignmentEngine/hg38_chr22_test.fasta.fai
+++ b/src/test/resources/large/SubsettingRealignmentEngine/hg38_chr22_test.fasta.fai
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db799e37ee6234bf16979fce41992efa52cd7967758c2dc4e395b5a4e5bac9a9
+size 24

--- a/src/test/resources/large/SubsettingRealignmentEngine/hg38_chr22_test.fasta.img
+++ b/src/test/resources/large/SubsettingRealignmentEngine/hg38_chr22_test.fasta.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b48f0d78eebdbafb6e0573755f30bfdaeb499570292560c5099368c8b189ae1
+size 100733

--- a/src/test/resources/large/SubsettingRealignmentEngine/test.bam
+++ b/src/test/resources/large/SubsettingRealignmentEngine/test.bam
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc26dbd3e6cc15ddf352761395209967c8635a741c4ae7c9add980d382cb4dbd
+size 46192

--- a/src/test/resources/large/SubsettingRealignmentEngine/test.bam.bai
+++ b/src/test/resources/large/SubsettingRealignmentEngine/test.bam.bai
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14a17d1f16717b1ad896f025aad2ab797fbf02cb395d25f4323047f71a9d6be2
+size 112

--- a/src/test/resources/large/SubsettingRealignmentEngine/test.expected.bai
+++ b/src/test/resources/large/SubsettingRealignmentEngine/test.expected.bai
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c83d840403f893998e8e61721f8d7692a3af4df7bce73262e82e59d9ae526e1
+size 200

--- a/src/test/resources/large/SubsettingRealignmentEngine/test.expected.bam
+++ b/src/test/resources/large/SubsettingRealignmentEngine/test.expected.bam
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2795260703faf17163a881a3b29da649bdb07088cc7b87fb36d345378cf90d6
+size 46077


### PR DESCRIPTION
Adds a new ReadWalker tool, `RealignSoftClippedReads`, that realigns soft-clipped fragments using BWA.

This tool is motivated by a specific artifact produced by Illumina DRAGEN v3.7.8 in which reads containing small indels are erroneously soft-clipped, often within mobile element contexts (LINE, SINE, ALU, SVA, etc). This is particularly problematic for mobile element insertion callers such as [Scramble](https://github.com/GeneDx/scramble) that rely on soft-clips for identifying potential insertion sites but do not perform a local assembly. In some cases, these soft-clipped reads are aligned to the incorrect region (confirmed by BLAT query and comparison to BWA alignments). An example of a false positive site produced by Scramble is shown below.

<img width="1008" alt="Screenshot 2023-11-16 at 2 09 45 PM" src="https://github.com/broadinstitute/gatk/assets/5686877/9d2c1dfd-9673-49f0-9372-c4c9cf6ffd9f">

This PR includes the new tool and unit/integration tests and some minor refactoring to expose non-Spark BWA read mapping. This tool should be considered experimental until thorough benchmarking and analysis can be performed.
