### PR TITLE
VS-1159 - Enhance GVSWithdrawSamples

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -243,6 +243,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_VS-1159_EnhanceGvsWithdrawSamples
          tags:
              - /.*/
    - name: GvsJointVariantCalling

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -243,7 +243,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_VS-1159_EnhanceGvsWithdrawSamples
          tags:
              - /.*/
    - name: GvsJointVariantCalling

--- a/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
+++ b/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
@@ -57,7 +57,7 @@
    - Run if there are any samples to withdraw from the last callset.
    - When you run the `GvsWithdrawSamples` workflow, you should inspect the output of the workflow.
      - The output `num_samples_withdrawn` indicates the number of samples that have been withdrawn. This number should agree with that which you expect.
-     - The output `samples_not_yet_ingested_file` is a file that contains a list of samples that were found in the list of samples that you provided as input that were NOT found in the sample_info table in the dataset. This (presumably) indicates that these samples need to be ingested.
+     - If the workflow fails, it may have failed if the list of smaples that was supplied to it includes samples that have not yet been ingested. To determine if this is the case, inspect the output (STDOUT) of the workflow and if it includes a list of samples that need to be ingested, then do so (or investigate the discreprancy.)
 1. **TBD Workflow to soft delete samples**
 1. `GvsPopulateAltAllele` workflow
    - **TODO:** needs to be made cumulative so that it can add data to the existing table instead of creating it from scratch on each run (see [VS-52](https://broadworkbench.atlassian.net/browse/VS-52))

--- a/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
+++ b/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
@@ -55,6 +55,9 @@
    - **NOTE** It appears that there is a rawls limit on the size of the input (list of gvcf files and indexes) per workflow run. 25K samples in a list worked for the Intermediate call set, 50K did not.
 1. `GvsWithdrawSamples` workflow
    - Run if there are any samples to withdraw from the last callset.
+   - When you run the `GvsWithdrawSamples` workflow, you should inspect the output of the workflow.
+     - The output `num_samples_withdrawn` indicates the number of samples that have been withdrawn. This number should agree with that which you expect.
+     - The output `samples_not_yet_ingested_file` is a file that contains a list of samples that were found in the list of samples that you provided as input that were NOT found in the sample_info table in the dataset. This (presumably) indicates that these samples need to be ingested.
 1. **TBD Workflow to soft delete samples**
 1. `GvsPopulateAltAllele` workflow
    - **TODO:** needs to be made cumulative so that it can add data to the existing table instead of creating it from scratch on each run (see [VS-52](https://broadworkbench.atlassian.net/browse/VS-52))

--- a/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
+++ b/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
@@ -57,7 +57,7 @@
    - Run if there are any samples to withdraw from the last callset.
    - When you run the `GvsWithdrawSamples` workflow, you should inspect the output of the workflow.
      - The output `num_samples_withdrawn` indicates the number of samples that have been withdrawn. This number should agree with that which you expect.
-     - If the workflow fails, it may have failed if the list of smaples that was supplied to it includes samples that have not yet been ingested. To determine if this is the case, inspect the output (STDOUT) of the workflow and if it includes a list of samples that need to be ingested, then do so (or investigate the discreprancy.)
+     - If the workflow fails, it may have failed if the list of smaples that was supplied to it includes samples that have not yet been ingested. To determine if this is the case, inspect the output (STDOUT) of the workflow and if it includes a list of samples that need to be ingested, then do so (or investigate the discreprancy). Note that there is a boolean variable `allow_uningested_samples` for this workflow that will allow it to pass if this condition occurs.
 1. **TBD Workflow to soft delete samples**
 1. `GvsPopulateAltAllele` workflow
    - **TODO:** needs to be made cumulative so that it can add data to the existing table instead of creating it from scratch on each run (see [VS-52](https://broadworkbench.atlassian.net/browse/VS-52))

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "GvsUtils.wdl" as Utils
 
-# 1
+# 2
 
 workflow GvsWithdrawSamples {
 
@@ -85,14 +85,14 @@ task WithdrawSamples {
 
     # join on the temp table to figure out which samples should be marked as withdrawn
     bq --apilog=false --project_id=~{project_id} query --format=csv --use_legacy_sql=false \
-      "UPDATE \`~{dataset_name}.sample_info\` AS samples SET withdrawn = '~{withdrawn_timestamp}' \
+      'UPDATE `~{dataset_name}.sample_info` AS samples SET withdrawn = "~{withdrawn_timestamp}" \
         WHERE NOT EXISTS \
         (SELECT * \
-        FROM \`~{project_id}.~{dataset_name}.current_callset_samples\` AS callset \
+        FROM '~{project_id}.~{dataset_name}.current_callset_samples' AS callset \
         WHERE \
         samples.sample_name = callset.sample_name) \
         AND NOT samples.is_control \
-        AND withdrawn IS NULL" > log_message.txt
+        AND withdrawn IS NULL' > log_message.txt
 
     cat log_message.txt | sed -e 's/Number of affected rows: //' > rows_updated.txt
   >>>

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -88,7 +88,7 @@ task WithdrawSamples {
       'UPDATE `~{dataset_name}.sample_info` AS samples SET withdrawn = "~{withdrawn_timestamp}" \
         WHERE NOT EXISTS \
         (SELECT * \
-        FROM '~{project_id}.~{dataset_name}.current_callset_samples' AS callset \
+        FROM `~{project_id}.~{dataset_name}.current_callset_samples` AS callset \
         WHERE \
         samples.sample_name = callset.sample_name) \
         AND NOT samples.is_control \

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -97,6 +97,9 @@ task WithdrawSamples {
       echo "ERROR: NO samples have been withdrawn"
       echo " The following samples were found in the uploaded file that have not yet been ingested into the dataset"
       echo " Either ingest the following samples, or remove them from the upload file"
+      echo "---"
+      cat new_samples.txt
+      echo "---"
       exit 1
     fi
 

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "GvsUtils.wdl" as Utils
 
-# 5
+# 6
 
 workflow GvsWithdrawSamples {
 
@@ -93,7 +93,7 @@ task WithdrawSamples {
     bq --apilog=false --project_id=~{project_id} query --format=csv --use_legacy_sql=false \
       'UPDATE `~{dataset_name}.sample_info` AS samples SET withdrawn = "~{withdrawn_timestamp}"
         WHERE NOT EXISTS
-          (SELECT * FROM `~{project_id}`.$TEMP_TABLE_NAME AS callset
+          (SELECT * FROM `~{project_id}.'"${TEMP_TABLE_NAME}"'` AS callset
             WHERE samples.sample_name = callset.sample_name)
         AND NOT samples.is_control
         AND withdrawn IS NULL' > log_message.txt

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -2,8 +2,6 @@ version 1.0
 
 import "GvsUtils.wdl" as Utils
 
-# 8
-
 workflow GvsWithdrawSamples {
 
   input {

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "GvsUtils.wdl" as Utils
 
-# 7
+# 8
 
 workflow GvsWithdrawSamples {
 
@@ -93,7 +93,7 @@ task WithdrawSamples {
     bq --apilog=false --project_id=~{project_id} query --format=csv --use_legacy_sql=false \
       'UPDATE `~{dataset_name}.sample_info` AS samples SET withdrawn = "~{withdrawn_timestamp}"
         WHERE NOT EXISTS
-          (SELECT * FROM \`~{project_id}.${TEMP_TABLE_NAME}\` AS callset
+          (SELECT * FROM `~{project_id}.'"${TEMP_TABLE_NAME}"'` AS callset
             WHERE samples.sample_name = callset.sample_name)
         AND NOT samples.is_control
         AND withdrawn IS NULL' > log_message.txt
@@ -104,7 +104,7 @@ task WithdrawSamples {
     echo "Determining if there are any new samples that should be upladed"
     bq --apilog=false --project_id=gvs-internal query --format=csv --use_legacy_sql=false \
       'SELECT callset.sample_name
-        FROM \`~{project_id}.${TEMP_TABLE_NAME}\` callset
+        FROM `~{project_id}.'"${TEMP_TABLE_NAME}"'` callset
         LEFT JOIN `~{dataset_name}.sample_info` sample_info ON sample_info.sample_name = callset.sample_name
         WHERE sample_info.sample_name IS NULL' > new_samples.txt
 

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -37,8 +37,8 @@ workflow GvsWithdrawSamples {
   }
 
   output {
-    Int num_rows_updated = WithdrawSamples.num_rows_updated
-    File new_samples_file = WithdrawSamples.new_samples_file
+    Int num_samples_withdrawn = WithdrawSamples.num_samples_withdrawn
+    File samples_not_yet_ingested_file = WithdrawSamples.samples_not_yet_ingested_file
     String recorded_git_hash = GetToolVersions.git_hash
   }
 }
@@ -116,8 +116,8 @@ task WithdrawSamples {
     cpu: 1
   }
   output {
-    Int num_rows_updated = read_int("rows_updated.txt")
-    File new_samples_file = "new_samples.txt"
+    Int num_samples_withdrawn = read_int("rows_updated.txt")
+    File samples_not_yet_ingested_file = "new_samples.txt"
   }
 }
 

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -100,7 +100,7 @@ task WithdrawSamples {
 
     # Now, determine if there are any samples in the uploaded list that are NOT in sample_info and report this
     echo "Determining if there are any new samples that should be uploaded"
-    bq --apilog=false --project_id=gvs-internal query --format=csv --use_legacy_sql=false \
+    bq --apilog=false --project_id=~{project_id} query --format=csv --use_legacy_sql=false \
       'SELECT callset.sample_name
         FROM `~{project_id}.'"${TEMP_TABLE_NAME}"'` callset
         LEFT JOIN `~{dataset_name}.sample_info` sample_info ON sample_info.sample_name = callset.sample_name

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -99,7 +99,7 @@ task WithdrawSamples {
     cat log_message.txt | sed -e 's/Number of affected rows: //' > rows_updated.txt
 
     # Now, determine if there are any samples in the uploaded list that are NOT in sample_info and report this
-    echo "Determining if there are any new samples that should be upladed"
+    echo "Determining if there are any new samples that should be uploaded"
     bq --apilog=false --project_id=gvs-internal query --format=csv --use_legacy_sql=false \
       'SELECT callset.sample_name
         FROM `~{project_id}.'"${TEMP_TABLE_NAME}"'` callset

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -85,13 +85,11 @@ task WithdrawSamples {
 
     # join on the temp table to figure out which samples should be marked as withdrawn
     bq --apilog=false --project_id=~{project_id} query --format=csv --use_legacy_sql=false \
-      'UPDATE `~{dataset_name}.sample_info` AS samples SET withdrawn = "~{withdrawn_timestamp}" \
-        WHERE NOT EXISTS \
-        (SELECT * \
-        FROM `~{project_id}.~{dataset_name}.current_callset_samples` AS callset \
-        WHERE \
-        samples.sample_name = callset.sample_name) \
-        AND NOT samples.is_control \
+      'UPDATE `~{dataset_name}.sample_info` AS samples SET withdrawn = "~{withdrawn_timestamp}"
+        WHERE NOT EXISTS
+          (SELECT * FROM `~{project_id}.~{dataset_name}.current_callset_samples` AS callset
+            WHERE samples.sample_name = callset.sample_name)
+        AND NOT samples.is_control
         AND withdrawn IS NULL' > log_message.txt
 
     cat log_message.txt | sed -e 's/Number of affected rows: //' > rows_updated.txt

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "GvsUtils.wdl" as Utils
 
-# 6
+# 7
 
 workflow GvsWithdrawSamples {
 
@@ -93,7 +93,7 @@ task WithdrawSamples {
     bq --apilog=false --project_id=~{project_id} query --format=csv --use_legacy_sql=false \
       'UPDATE `~{dataset_name}.sample_info` AS samples SET withdrawn = "~{withdrawn_timestamp}"
         WHERE NOT EXISTS
-          (SELECT * FROM `~{project_id}.'"${TEMP_TABLE_NAME}"'` AS callset
+          (SELECT * FROM \`~{project_id}.${TEMP_TABLE_NAME}\` AS callset
             WHERE samples.sample_name = callset.sample_name)
         AND NOT samples.is_control
         AND withdrawn IS NULL' > log_message.txt
@@ -104,7 +104,7 @@ task WithdrawSamples {
     echo "Determining if there are any new samples that should be upladed"
     bq --apilog=false --project_id=gvs-internal query --format=csv --use_legacy_sql=false \
       'SELECT callset.sample_name
-        FROM $TEMP_TABLE_NAME callset
+        FROM \`~{project_id}.${TEMP_TABLE_NAME}\` callset
         LEFT JOIN `~{dataset_name}.sample_info` sample_info ON sample_info.sample_name = callset.sample_name
         WHERE sample_info.sample_name IS NULL' > new_samples.txt
 

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "GvsUtils.wdl" as Utils
 
-# 2
+# 3
 
 workflow GvsWithdrawSamples {
 
@@ -40,6 +40,7 @@ workflow GvsWithdrawSamples {
 
   output {
     Int num_rows_updated = WithdrawSamples.num_rows_updated
+    File new_samples_file = WithdrawSamples.new_samples_file
     String recorded_git_hash = GetToolVersions.git_hash
   }
 }
@@ -79,20 +80,36 @@ task WithdrawSamples {
     fi
 
     # create the temp table (expires in 1 day)
-    bq --apilog=false --project_id=~{project_id} mk --expiration=86400 ~{dataset_name}.current_callset_samples "sample_name:STRING"
-    # populate the temp table
-    bq --apilog=false load --project_id=~{project_id} -F "tab" ~{dataset_name}.current_callset_samples sample_names.tsv
+    TEMP_TABLE_NAME="~{dataset_name}.current_call_set_samples_$(date +%s)"
+    echo "Creating Temp Table: $TEMP_TABLE_NAME"
+    bq --apilog=false --project_id=~{project_id} mk --expiration=86400 $TEMP_TABLE_NAME "sample_name:STRING"
 
-    # join on the temp table to figure out which samples should be marked as withdrawn
+    # populate the temp table
+    echo "Populating Temp Table: $TEMP_TABLE_NAME"
+    bq --apilog=false load --project_id=~{project_id} -F "tab" $TEMP_TABLE_NAME sample_names.tsv
+
+    # Update sample_info.withdrawn by joining on the temp table to figure out which samples should be marked as withdrawn
+    echo "Updating samples that should be withdrawn"
     bq --apilog=false --project_id=~{project_id} query --format=csv --use_legacy_sql=false \
       'UPDATE `~{dataset_name}.sample_info` AS samples SET withdrawn = "~{withdrawn_timestamp}"
         WHERE NOT EXISTS
-          (SELECT * FROM `~{project_id}.~{dataset_name}.current_callset_samples` AS callset
+          (SELECT * FROM `~{project_id}.$TEMP_TABLE_NAME` AS callset
             WHERE samples.sample_name = callset.sample_name)
         AND NOT samples.is_control
         AND withdrawn IS NULL' > log_message.txt
 
     cat log_message.txt | sed -e 's/Number of affected rows: //' > rows_updated.txt
+
+    # Now, determine if there are any samples in the uploaded list that are NOT in sample_info and report this
+    echo "Determining if there are any new samples that should be upladed"
+    bq --apilog=false --project_id=gvs-internal query --format=csv --use_legacy_sql=false \
+      'SELECT callset.sample_name
+        FROM `$TEMP_TABLE_NAME` callset
+        LEFT JOIN `~{dataset_name}.sample_info` sample_info ON sample_info.sample_name = callset.sample_name
+        WHERE sample_info.sample_name IS NULL' > new_samples.txt
+
+    echo "The following samples in the uploaded list have NOT been loaded into ~{dataset_name}"
+    cat new_samples.txt
   >>>
   runtime {
     docker: gatk_docker
@@ -102,6 +119,7 @@ task WithdrawSamples {
   }
   output {
     Int num_rows_updated = read_int("rows_updated.txt")
+    File new_samples_file = "new_samples.txt"
   }
 }
 

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "GvsUtils.wdl" as Utils
 
-# 4
+# 5
 
 workflow GvsWithdrawSamples {
 

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "GvsUtils.wdl" as Utils
 
-# 3
+# 4
 
 workflow GvsWithdrawSamples {
 
@@ -93,7 +93,7 @@ task WithdrawSamples {
     bq --apilog=false --project_id=~{project_id} query --format=csv --use_legacy_sql=false \
       'UPDATE `~{dataset_name}.sample_info` AS samples SET withdrawn = "~{withdrawn_timestamp}"
         WHERE NOT EXISTS
-          (SELECT * FROM `~{project_id}.$TEMP_TABLE_NAME` AS callset
+          (SELECT * FROM `~{project_id}`.$TEMP_TABLE_NAME AS callset
             WHERE samples.sample_name = callset.sample_name)
         AND NOT samples.is_control
         AND withdrawn IS NULL' > log_message.txt
@@ -104,7 +104,7 @@ task WithdrawSamples {
     echo "Determining if there are any new samples that should be upladed"
     bq --apilog=false --project_id=gvs-internal query --format=csv --use_legacy_sql=false \
       'SELECT callset.sample_name
-        FROM `$TEMP_TABLE_NAME` callset
+        FROM $TEMP_TABLE_NAME callset
         LEFT JOIN `~{dataset_name}.sample_info` sample_info ON sample_info.sample_name = callset.sample_name
         WHERE sample_info.sample_name IS NULL' > new_samples.txt
 

--- a/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
+++ b/scripts/variantstore/wdl/GvsWithdrawSamples.wdl
@@ -2,6 +2,8 @@ version 1.0
 
 import "GvsUtils.wdl" as Utils
 
+# 1
+
 workflow GvsWithdrawSamples {
 
   input {
@@ -83,14 +85,14 @@ task WithdrawSamples {
 
     # join on the temp table to figure out which samples should be marked as withdrawn
     bq --apilog=false --project_id=~{project_id} query --format=csv --use_legacy_sql=false \
-      'UPDATE `~{dataset_name}.sample_info` AS samples SET withdrawn = "~{withdrawn_timestamp}" \
+      "UPDATE \`~{dataset_name}.sample_info\` AS samples SET withdrawn = '~{withdrawn_timestamp}' \
         WHERE NOT EXISTS \
         (SELECT * \
-        FROM `~{project_id}.~{dataset_name}.current_callset_samples` AS callset \
+        FROM \`~{project_id}.~{dataset_name}.current_callset_samples\` AS callset \
         WHERE \
         samples.sample_name = callset.sample_name) \
         AND NOT samples.is_control \
-        AND withdrawn IS NULL' > log_message.txt
+        AND withdrawn IS NULL" > log_message.txt
 
     cat log_message.txt | sed -e 's/Number of affected rows: //' > rows_updated.txt
   >>>


### PR DESCRIPTION
This PR updates GvsWithdrawSamples to:
1) Use a "true" temporary table (uniquely named, goes away after 24 hours)
2) Check if there are any samples in the uploaded list of samples to withdraw that are NOT in the existing sample_info table. Fail and print out the list of samples if so.
3) Added a boolean flag to allow the user to pass the workflow if condition 2 is true.

A) Example [Run](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/job_history/26482e64-cc22-4191-b88f-f7765b173450) with 0 samples withdrawn and 0 new samples (samples in the withdrawn file that aren't in sample_info)
B) Example [Run](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/job_history/00f17100-18c4-4522-8dee-24630ef291b1) with 1 sample withdrawn and 0 new samples (samples in the withdrawn file that aren't in sample_info)
C) Example [Run](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/job_history/c7dfc547-305c-4b31-aec8-685494b92221) with 1 sample withdrawn and 1 new sample (sample in the withdrawn file that wasn't in sample_info). This run was run with the override flag allowing it to pass
D) Example [Run](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/job_history/c2d2c897-ec1b-47ad-9927-70c6d7eb7e9b) with 1 sample withdrawn and 1 new sample (sample in the withdrawn file that wasn't in sample_info). This run failed (as intended)