### PR TITLE
Do not delete raw combiner output

### DIFF
--- a/scripts/variantstore/wdl/extract/import_gvs.py
+++ b/scripts/variantstore/wdl/extract/import_gvs.py
@@ -302,7 +302,6 @@ def import_gvs(refs: 'List[List[str]]',
     with hl._with_flags(no_whole_stage_codegen='1'):
 
         merge_tmp = os.path.join(tmp_dir, 'merge_tmp.vds')
-        hl.current_backend().fs.rmtree(merge_tmp)
         info(f'import_gvs: calling Hail VDS combiner for merging {len(vds_paths)} intermediates')
         combiner = hl.vds.new_combiner(output_path=merge_tmp,
                                        vds_paths=vds_paths,


### PR DESCRIPTION
If the combiner finishes, but import_gvs fails, and this script is run again, the combiner output will be deleted and the finished plan will be used causing no new output to be generated causing the script to fail.