### PR TITLE
DRAGEN Joint Detection DO NOT MERGE

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/DRAGENGenotypesModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/DRAGENGenotypesModel.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.walkers.genotyper;
 
+import htsjdk.samtools.util.Locatable;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.GenotypeLikelihoods;
 import org.broadinstitute.hellbender.exceptions.GATKException;
@@ -70,14 +71,18 @@ public class DRAGENGenotypesModel implements GenotypingModel {
     @Override
     public <A extends Allele> GenotypingLikelihoods<A> calculateLikelihoods(final AlleleList<A> genotypingAlleles, final GenotypingData<A> data,
                                                                             byte[] paddedReference, int offsetForRefIntoEvent,
-                                                                            final DragstrReferenceAnalyzer dragstrs) {
-        return calculateLikelihoods(genotypingAlleles, data, paddedReference, offsetForRefIntoEvent, dragstrs, Optional.empty(), Optional.empty());
+                                                                            final DragstrReferenceAnalyzer dragstrs,
+                                                                            final Locatable eventLocus) {
+        return calculateLikelihoods(genotypingAlleles, data, paddedReference, offsetForRefIntoEvent, dragstrs, Optional.empty(), Optional.empty(), eventLocus);
     }
 
     @Override
     public <A extends Allele> GenotypingLikelihoods<A> calculateLikelihoods(final AlleleList<A> genotypingAlleles, final GenotypingData<A> data,
                                                                             byte[] paddedReference, int offsetForRefIntoEvent,
-                                                                            final DragstrReferenceAnalyzer dragstrs, Optional<GenotypingLikelihoods<A>> genotypeLikelihoodsOverride, Optional<GenotypingLikelihoods<A>> genotypePosteriorsOverride) {
+                                                                            final DragstrReferenceAnalyzer dragstrs,
+                                                                            Optional<GenotypingLikelihoods<A>> genotypeLikelihoodsOverride,
+                                                                            Optional<GenotypingLikelihoods<A>> genotypePosteriorsOverride,
+                                                                            final Locatable eventLocus) {
         Utils.nonNull(genotypingAlleles, "the allele cannot be null");
         Utils.nonNull(data, "the genotyping data cannot be null");
 
@@ -104,7 +109,7 @@ public class DRAGENGenotypesModel implements GenotypingModel {
         final int sampleCount = data.numberOfSamples();
         final PloidyModel ploidyModel = data.ploidyModel();
         final List<GenotypeLikelihoods> genotypeLikelihoods = new ArrayList<>(sampleCount);
-        final int variantOffset = data.readLikelihoods().getVariantCallingSubsetApplied().getStart() + allelePadding;
+        final int variantOffset = eventLocus.getStart() + allelePadding;
 
         for (int sampleIndex = 0; sampleIndex < sampleCount; sampleIndex++) {
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/DRAGENGenotypesModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/DRAGENGenotypesModel.java
@@ -42,24 +42,22 @@ public class DRAGENGenotypesModel implements GenotypingModel {
 
     private final boolean computeBQD;
     private final boolean computeFRD;
-    private final int allelePadding;
     private final int maxEffectiveDepthAdjustment;
     private final DragstrParams dragstrParams;
 
-    public DRAGENGenotypesModel(final boolean useBQDModel, final boolean useFRDModel, final int allelePadding,
+    public DRAGENGenotypesModel(final boolean useBQDModel, final boolean useFRDModel,
                                 final int maxEffectiveDepthAdjustment, final DragstrParams dragstrParams) {
         this(DEFAULT_CACHE_PLOIDY_CAPACITY, DEFAULT_CACHE_ALLELE_CAPACITY,
-                useBQDModel, useFRDModel, allelePadding, maxEffectiveDepthAdjustment,  dragstrParams); }
+                useBQDModel, useFRDModel, maxEffectiveDepthAdjustment,  dragstrParams); }
 
     /*
      *  Initialize model with given maximum allele count and ploidy for caching
      */
     public DRAGENGenotypesModel(final int calculatorCachePloidyCapacity, final int calculatorCacheAlleleCapacity,
-                                final boolean useBQDModel, final boolean useFRDModel, final int allelePadding,
+                                final boolean useBQDModel, final boolean useFRDModel,
                                 final int maxEffectiveDepthAdjustment, final DragstrParams dragstrParams) {
         this.computeBQD = useBQDModel;
         this.computeFRD = useFRDModel;
-        this.allelePadding = allelePadding;
         this.maxEffectiveDepthAdjustment = maxEffectiveDepthAdjustment;
         this.dragstrParams = dragstrParams;
 
@@ -109,7 +107,7 @@ public class DRAGENGenotypesModel implements GenotypingModel {
         final int sampleCount = data.numberOfSamples();
         final PloidyModel ploidyModel = data.ploidyModel();
         final List<GenotypeLikelihoods> genotypeLikelihoods = new ArrayList<>(sampleCount);
-        final int variantOffset = eventLocus.getStart() + allelePadding;
+        final int variantOffset = eventLocus.getStart();
 
         for (int sampleIndex = 0; sampleIndex < sampleCount; sampleIndex++) {
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/DRAGENGenotypesModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/DRAGENGenotypesModel.java
@@ -71,15 +71,6 @@ public class DRAGENGenotypesModel implements GenotypingModel {
                                                                             byte[] paddedReference, int offsetForRefIntoEvent,
                                                                             final DragstrReferenceAnalyzer dragstrs,
                                                                             final Locatable eventLocus) {
-        return calculateLikelihoods(genotypingAlleles, data, paddedReference, offsetForRefIntoEvent, dragstrs, Optional.empty(), eventLocus);
-    }
-
-    @Override
-    public <A extends Allele> GenotypingLikelihoods<A> calculateLikelihoods(final AlleleList<A> genotypingAlleles, final GenotypingData<A> data,
-                                                                            byte[] paddedReference, int offsetForRefIntoEvent,
-                                                                            final DragstrReferenceAnalyzer dragstrs,
-                                                                            Optional<HaploGenotypingResult> haploGenotypingResult,
-                                                                            final Locatable eventLocus) {
         Utils.nonNull(genotypingAlleles, "the allele cannot be null");
         Utils.nonNull(data, "the genotyping data cannot be null");
 
@@ -167,7 +158,7 @@ public class DRAGENGenotypesModel implements GenotypingModel {
 
             // go over all homozygous genotypes and find how close they are to the maximum likelihood after the FRD/BQD
             // correction.  Then use this difference to truncate the equivalent different in the corrected GLs.
-            final double[] correctedGLs = (genotypeLikelihoodsOverride.isEmpty() ? ploidyModelGLs : genotypeLikelihoodsOverride.get().sampleLikelihoods(sampleIndex).getAsVector()).clone();
+            final double[] correctedGLs = ploidyModelGLs;
             final double maxPloidyModelCorrectedGL = MathUtils.arrayMax(ploidyModelGLsCorrected);
             final double maxCorrectedGL = MathUtils.arrayMax(correctedGLs);
 
@@ -178,15 +169,6 @@ public class DRAGENGenotypesModel implements GenotypingModel {
                     // if this hom GL is farther from the max GL than the BQD/FRD-corrected ploidy model GLs have it, move it closer
                     correctedGLs[idx] = Math.max(correctedGLs[idx], maxCorrectedGL + ploidyModelGLsCorrected[idx] - maxPloidyModelCorrectedGL);
                 }
-            }
-
-            // approximate the priors' effect on the BQD/FRD-corrected likelihoods as being equal the their effect
-            // on non-corrected likelihoods
-            if (genotypePosteriorsOverride.isPresent()) {
-                final double[] post = MathUtils.normalizeLog10(genotypePosteriorsOverride.get().sampleLikelihoods(sampleIndex).getAsVector());
-                final double[] like = MathUtils.normalizeLog10(genotypeLikelihoodsOverride.get().sampleLikelihoods(sampleIndex).getAsVector());
-                final double[] effectOfPrior = MathArrays.ebeSubtract(post, like);
-                MathUtils.addToArrayInPlace(correctedGLs, effectOfPrior);
             }
 
             // this is what the work actually is, after we have computed a few things

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/DRAGENGenotypesModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/DRAGENGenotypesModel.java
@@ -71,15 +71,14 @@ public class DRAGENGenotypesModel implements GenotypingModel {
                                                                             byte[] paddedReference, int offsetForRefIntoEvent,
                                                                             final DragstrReferenceAnalyzer dragstrs,
                                                                             final Locatable eventLocus) {
-        return calculateLikelihoods(genotypingAlleles, data, paddedReference, offsetForRefIntoEvent, dragstrs, Optional.empty(), Optional.empty(), eventLocus);
+        return calculateLikelihoods(genotypingAlleles, data, paddedReference, offsetForRefIntoEvent, dragstrs, Optional.empty(), eventLocus);
     }
 
     @Override
     public <A extends Allele> GenotypingLikelihoods<A> calculateLikelihoods(final AlleleList<A> genotypingAlleles, final GenotypingData<A> data,
                                                                             byte[] paddedReference, int offsetForRefIntoEvent,
                                                                             final DragstrReferenceAnalyzer dragstrs,
-                                                                            Optional<GenotypingLikelihoods<A>> genotypeLikelihoodsOverride,
-                                                                            Optional<GenotypingLikelihoods<A>> genotypePosteriorsOverride,
+                                                                            Optional<HaploGenotypingResult> haploGenotypingResult,
                                                                             final Locatable eventLocus) {
         Utils.nonNull(genotypingAlleles, "the allele cannot be null");
         Utils.nonNull(data, "the genotyping data cannot be null");

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/DRAGENGenotypesModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/DRAGENGenotypesModel.java
@@ -181,8 +181,8 @@ public class DRAGENGenotypesModel implements GenotypingModel {
             // approximate the priors' effect on the BQD/FRD-corrected likelihoods as being equal the their effect
             // on non-corrected likelihoods
             if (genotypePosteriorsOverride.isPresent()) {
-                final double[] post = genotypePosteriorsOverride.get().sampleLikelihoods(sampleIndex).getAsVector();
-                final double[] like = genotypeLikelihoodsOverride.get().sampleLikelihoods(sampleIndex).getAsVector();
+                final double[] post = MathUtils.normalizeLog10(genotypePosteriorsOverride.get().sampleLikelihoods(sampleIndex).getAsVector());
+                final double[] like = MathUtils.normalizeLog10(genotypeLikelihoodsOverride.get().sampleLikelihoods(sampleIndex).getAsVector());
                 final double[] effectOfPrior = MathArrays.ebeSubtract(post, like);
                 MathUtils.addToArrayInPlace(correctedGLs, effectOfPrior);
             }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/DRAGENGenotypesModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/DRAGENGenotypesModel.java
@@ -165,7 +165,7 @@ public class DRAGENGenotypesModel implements GenotypingModel {
 
             // go over all homozygous genotypes and find how close they are to the maximum likelihood after the FRD/BQD
             // correction.  Then use this difference to truncate the equivalent different in the corrected GLs.
-            final double[] correctedGLs = genotypeLikelihoodsOverride.isEmpty() ? ploidyModelGLs : genotypeLikelihoodsOverride.get().sampleLikelihoods(sampleIndex).getAsVector();
+            final double[] correctedGLs = (genotypeLikelihoodsOverride.isEmpty() ? ploidyModelGLs : genotypeLikelihoodsOverride.get().sampleLikelihoods(sampleIndex).getAsVector()).clone();
             final double maxPloidyModelCorrectedGL = MathUtils.arrayMax(ploidyModelGLsCorrected);
             final double maxCorrectedGL = MathUtils.arrayMax(correctedGLs);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/DRAGENGenotypesModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/DRAGENGenotypesModel.java
@@ -71,13 +71,13 @@ public class DRAGENGenotypesModel implements GenotypingModel {
     public <A extends Allele> GenotypingLikelihoods<A> calculateLikelihoods(final AlleleList<A> genotypingAlleles, final GenotypingData<A> data,
                                                                             byte[] paddedReference, int offsetForRefIntoEvent,
                                                                             final DragstrReferenceAnalyzer dragstrs) {
-        return calculateLikelihoods(genotypingAlleles, data, paddedReference, offsetForRefIntoEvent, dragstrs, Optional.empty());
+        return calculateLikelihoods(genotypingAlleles, data, paddedReference, offsetForRefIntoEvent, dragstrs, Optional.empty(), Optional.empty());
     }
 
     @Override
     public <A extends Allele> GenotypingLikelihoods<A> calculateLikelihoods(final AlleleList<A> genotypingAlleles, final GenotypingData<A> data,
                                                                             byte[] paddedReference, int offsetForRefIntoEvent,
-                                                                            final DragstrReferenceAnalyzer dragstrs, Optional<GenotypingLikelihoods<A>> glsOverride) {
+                                                                            final DragstrReferenceAnalyzer dragstrs, Optional<GenotypingLikelihoods<A>> genotypeLikelihoodsOverride, Optional<GenotypingLikelihoods<A>> genotypePosteriorsOverride) {
         Utils.nonNull(genotypingAlleles, "the allele cannot be null");
         Utils.nonNull(data, "the genotyping data cannot be null");
 
@@ -163,13 +163,9 @@ public class DRAGENGenotypesModel implements GenotypingModel {
                                 FLAT_SNP_HET_PRIOR, api, maxEffectiveDepthAdjustment));
             }
 
-            final double[] glAdditiveCorrection = MathArrays.ebeSubtract(ploidyModelGLsCorrected, ploidyModelGLs);
-
-
-
             // go over all homozygous genotypes and find how close they are to the maximum likelihood after the FRD/BQD
             // correction.  Then use this difference to truncate the equivalent different in the corrected GLs.
-            final double[] correctedGLs = glsOverride.isEmpty() ? ploidyModelGLs : glsOverride.get().sampleLikelihoods(sampleIndex).getAsVector();
+            final double[] correctedGLs = genotypeLikelihoodsOverride.isEmpty() ? ploidyModelGLs : genotypeLikelihoodsOverride.get().sampleLikelihoods(sampleIndex).getAsVector();
             final double maxPloidyModelCorrectedGL = MathUtils.arrayMax(ploidyModelGLsCorrected);
             final double maxCorrectedGL = MathUtils.arrayMax(correctedGLs);
 
@@ -180,6 +176,15 @@ public class DRAGENGenotypesModel implements GenotypingModel {
                     // if this hom GL is farther from the max GL than the BQD/FRD-corrected ploidy model GLs have it, move it closer
                     correctedGLs[idx] = Math.max(correctedGLs[idx], maxCorrectedGL + ploidyModelGLsCorrected[idx] - maxPloidyModelCorrectedGL);
                 }
+            }
+
+            // approximate the priors' effect on the BQD/FRD-corrected likelihoods as being equal the their effect
+            // on non-corrected likelihoods
+            if (genotypePosteriorsOverride.isPresent()) {
+                final double[] post = genotypePosteriorsOverride.get().sampleLikelihoods(sampleIndex).getAsVector();
+                final double[] like = genotypeLikelihoodsOverride.get().sampleLikelihoods(sampleIndex).getAsVector();
+                final double[] effectOfPrior = MathArrays.ebeSubtract(post, like);
+                MathUtils.addToArrayInPlace(correctedGLs, effectOfPrior);
             }
 
             // this is what the work actually is, after we have computed a few things

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingEngine.java
@@ -187,6 +187,7 @@ public abstract class GenotypingEngine<Config extends StandardCallerArgumentColl
 
         // create the genotypes
         //TODO: omit subsetting if output alleles is not a proper subset of vc.getAlleles
+        //TODO: however, this can't be done naively because the subsetting alleles method also applies priors to get posteriors!
         final GenotypesContext genotypes = outputAlleles.size() == 1 ? GATKVariantContextUtils.subsetToRefOnly(vc, defaultPloidy) :
                 AlleleSubsettingUtils.subsetAlleles(vc.getGenotypes(), defaultPloidy, vc.getAlleles(), outputAlleles, gpc, configuration.genotypeArgs.genotypeAssignmentMethod);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingLikelihoods.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingLikelihoods.java
@@ -34,7 +34,7 @@ public final class GenotypingLikelihoods<A extends Allele> implements SampleList
      * @throws IllegalArgumentException if any argument is {@code null}, or the number of samples in {@code ploidyModel}
      *  does not correspond with the number of likelihoods arrays in {@code likelihoods}
      */
-    GenotypingLikelihoods(final AlleleList<A> alleles, final PloidyModel ploidyModel, final List<GenotypeLikelihoods> likelihoods) {
+    public GenotypingLikelihoods(final AlleleList<A> alleles, final PloidyModel ploidyModel, final List<GenotypeLikelihoods> likelihoods) {
         Utils.validateArg (ploidyModel.numberOfSamples() ==  likelihoods.size(), "there must be exactly one likelihood set for each sample");
         this.likelihoods = Utils.nonNull(likelihoods, "the likelihood collection cannot be null").toArray(new GenotypeLikelihoods[likelihoods.size()]);
         Utils.containsNoNull(likelihoods, "no genotype likelihood is allowed to be null");

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingModel.java
@@ -15,8 +15,9 @@ public interface GenotypingModel {
         final byte[] paddedReference, final int offsetForRefIntoEvent, final DragstrReferenceAnalyzer dragstrs);
 
     default <A extends Allele> GenotypingLikelihoods<A> calculateLikelihoods(AlleleList<A> genotypingAlleles, GenotypingData<A> data,
-        final byte[] paddedReference, final int offsetForRefIntoEvent, final DragstrReferenceAnalyzer dragstrs, Optional<GenotypingLikelihoods<A>> glsOverride) {
-        if (glsOverride.isEmpty()) {
+        final byte[] paddedReference, final int offsetForRefIntoEvent, final DragstrReferenceAnalyzer dragstrs,
+        Optional<GenotypingLikelihoods<A>> genotypeLikelihoodsOverride, Optional<GenotypingLikelihoods<A>> genotypePosteriorsOverride) {
+        if (genotypeLikelihoodsOverride.isEmpty()) {
             return calculateLikelihoods(genotypingAlleles, data, paddedReference, offsetForRefIntoEvent, dragstrs);
         } else {
             throw new UnsupportedOperationException("This GenotypingModel class does not implement a GL-override mode.");

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingModel.java
@@ -14,15 +14,4 @@ public interface GenotypingModel {
     @SuppressWarnings({"unchecked", "rawtypes"})
     public <A extends Allele> GenotypingLikelihoods<A> calculateLikelihoods(AlleleList<A> genotypingAlleles, GenotypingData<A> data,
         final byte[] paddedReference, final int offsetForRefIntoEvent, final DragstrReferenceAnalyzer dragstrs, final Locatable eventLocus);
-
-    default <A extends Allele> GenotypingLikelihoods<A> calculateLikelihoods(AlleleList<A> genotypingAlleles, GenotypingData<A> data,
-        final byte[] paddedReference, final int offsetForRefIntoEvent, final DragstrReferenceAnalyzer dragstrs,
-                                                                             Optional<HaploGenotypingResult> haploGenotypingResult,
-                                                                             final Locatable eventLocus) {
-        if (haploGenotypingResult.isEmpty()) {
-            return calculateLikelihoods(genotypingAlleles, data, paddedReference, offsetForRefIntoEvent, dragstrs, eventLocus);
-        } else {
-            throw new UnsupportedOperationException("This GenotypingModel class does not implement a GL-override mode.");
-        }
-    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingModel.java
@@ -4,11 +4,22 @@ import htsjdk.variant.variantcontext.Allele;
 import org.broadinstitute.hellbender.utils.genotyper.AlleleList;
 import org.broadinstitute.hellbender.utils.dragstr.DragstrReferenceAnalyzer;
 
+import java.util.Optional;
+
 /**
  * A wrapping interface between the various versions of genotypers so as to keep them interchangeable.
  */
 public interface GenotypingModel {
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public <A extends Allele> GenotypingLikelihoods<A> calculateLikelihoods(AlleleList<A> genotypingAlleles, GenotypingData<A> data, final byte[] paddedReference, final int offsetForRefIntoEvent, final DragstrReferenceAnalyzer dragstrs);
+    public <A extends Allele> GenotypingLikelihoods<A> calculateLikelihoods(AlleleList<A> genotypingAlleles, GenotypingData<A> data,
+        final byte[] paddedReference, final int offsetForRefIntoEvent, final DragstrReferenceAnalyzer dragstrs);
 
+    default <A extends Allele> GenotypingLikelihoods<A> calculateLikelihoods(AlleleList<A> genotypingAlleles, GenotypingData<A> data,
+        final byte[] paddedReference, final int offsetForRefIntoEvent, final DragstrReferenceAnalyzer dragstrs, Optional<GenotypingLikelihoods<A>> glsOverride) {
+        if (glsOverride.isEmpty()) {
+            return calculateLikelihoods(genotypingAlleles, data, paddedReference, offsetForRefIntoEvent, dragstrs);
+        } else {
+            throw new UnsupportedOperationException("This GenotypingModel class does not implement a GL-override mode.");
+        }
+    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingModel.java
@@ -17,9 +17,9 @@ public interface GenotypingModel {
 
     default <A extends Allele> GenotypingLikelihoods<A> calculateLikelihoods(AlleleList<A> genotypingAlleles, GenotypingData<A> data,
         final byte[] paddedReference, final int offsetForRefIntoEvent, final DragstrReferenceAnalyzer dragstrs,
-        Optional<GenotypingLikelihoods<A>> genotypeLikelihoodsOverride, Optional<GenotypingLikelihoods<A>> genotypePosteriorsOverride,
+                                                                             Optional<HaploGenotypingResult> haploGenotypingResult,
                                                                              final Locatable eventLocus) {
-        if (genotypeLikelihoodsOverride.isEmpty()) {
+        if (haploGenotypingResult.isEmpty()) {
             return calculateLikelihoods(genotypingAlleles, data, paddedReference, offsetForRefIntoEvent, dragstrs, eventLocus);
         } else {
             throw new UnsupportedOperationException("This GenotypingModel class does not implement a GL-override mode.");

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/GenotypingModel.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.walkers.genotyper;
 
+import htsjdk.samtools.util.Locatable;
 import htsjdk.variant.variantcontext.Allele;
 import org.broadinstitute.hellbender.utils.genotyper.AlleleList;
 import org.broadinstitute.hellbender.utils.dragstr.DragstrReferenceAnalyzer;
@@ -12,13 +13,14 @@ import java.util.Optional;
 public interface GenotypingModel {
     @SuppressWarnings({"unchecked", "rawtypes"})
     public <A extends Allele> GenotypingLikelihoods<A> calculateLikelihoods(AlleleList<A> genotypingAlleles, GenotypingData<A> data,
-        final byte[] paddedReference, final int offsetForRefIntoEvent, final DragstrReferenceAnalyzer dragstrs);
+        final byte[] paddedReference, final int offsetForRefIntoEvent, final DragstrReferenceAnalyzer dragstrs, final Locatable eventLocus);
 
     default <A extends Allele> GenotypingLikelihoods<A> calculateLikelihoods(AlleleList<A> genotypingAlleles, GenotypingData<A> data,
         final byte[] paddedReference, final int offsetForRefIntoEvent, final DragstrReferenceAnalyzer dragstrs,
-        Optional<GenotypingLikelihoods<A>> genotypeLikelihoodsOverride, Optional<GenotypingLikelihoods<A>> genotypePosteriorsOverride) {
+        Optional<GenotypingLikelihoods<A>> genotypeLikelihoodsOverride, Optional<GenotypingLikelihoods<A>> genotypePosteriorsOverride,
+                                                                             final Locatable eventLocus) {
         if (genotypeLikelihoodsOverride.isEmpty()) {
-            return calculateLikelihoods(genotypingAlleles, data, paddedReference, offsetForRefIntoEvent, dragstrs);
+            return calculateLikelihoods(genotypingAlleles, data, paddedReference, offsetForRefIntoEvent, dragstrs, eventLocus);
         } else {
             throw new UnsupportedOperationException("This GenotypingModel class does not implement a GL-override mode.");
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/HaploGenotypingResult.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/HaploGenotypingResult.java
@@ -1,0 +1,45 @@
+package org.broadinstitute.hellbender.tools.walkers.genotyper;
+
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
+
+public class HaploGenotypingResult {
+
+    // all fields are log10, the posteriors are normalized
+    private final GenotypingLikelihoods<Haplotype> haploGenotypeLikelihoods;
+    private final GenotypingLikelihoods<Haplotype> haploGenotypePriors;
+    private final GenotypingLikelihoods<Haplotype> haploGenotypePosteriors;
+
+    public HaploGenotypingResult(final GenotypingLikelihoods<Haplotype> haploGenotypeLikelihoods,
+                                 final GenotypingLikelihoods<Haplotype> haploGenotypePriors,
+                                 final GenotypingLikelihoods<Haplotype> haploGenotypePosteriors) {
+        this.haploGenotypeLikelihoods = haploGenotypeLikelihoods;
+        this.haploGenotypePriors = haploGenotypePriors;
+        this.haploGenotypePosteriors = haploGenotypePosteriors;
+
+        Utils.validateArg(haploGenotypeLikelihoods.asListOfSamples().equals(haploGenotypePriors.asListOfSamples()), () -> "inconsistent samples");
+        Utils.validateArg(haploGenotypeLikelihoods.asListOfSamples().equals(haploGenotypePosteriors.asListOfSamples()), () -> "inconsistent samples");
+
+        Utils.validateArg(haploGenotypeLikelihoods.asListOfAlleles().equals(haploGenotypePriors.asListOfAlleles()), () -> "inconsistent haplotypes");
+        Utils.validateArg(haploGenotypeLikelihoods.asListOfAlleles().equals(haploGenotypePosteriors.asListOfAlleles()), () -> "inconsistent haplotypes");
+
+        for (int sampleIndex = 0; sampleIndex < haploGenotypeLikelihoods.numberOfSamples(); sampleIndex++) {
+            Utils.validateArg(haploGenotypeLikelihoods.samplePloidy(sampleIndex) == haploGenotypePriors.samplePloidy(sampleIndex), () -> "inconsistent ploidies");
+            Utils.validateArg(haploGenotypeLikelihoods.samplePloidy(sampleIndex) == haploGenotypePosteriors.samplePloidy(sampleIndex), () -> "inconsistent ploidies");
+        }
+    }
+
+    public GenotypingLikelihoods<Haplotype> getLikelihoods() {
+        return haploGenotypeLikelihoods;
+    }
+
+    public GenotypingLikelihoods<Haplotype> getPriors() {
+        return haploGenotypePriors;
+    }
+
+    public GenotypingLikelihoods<Haplotype> getPosteriors() {
+        return haploGenotypePosteriors;
+    }
+
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/IndependentSampleGenotypesModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/genotyper/IndependentSampleGenotypesModel.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.walkers.genotyper;
 
+import htsjdk.samtools.util.Locatable;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.GenotypeLikelihoods;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -19,11 +20,13 @@ import java.util.List;
 public final class IndependentSampleGenotypesModel implements GenotypingModel {
     public IndependentSampleGenotypesModel() { }
 
+    @Override
     public <A extends Allele> GenotypingLikelihoods<A> calculateLikelihoods(final AlleleList<A> genotypingAlleles,
                                                                             final GenotypingData<A> data,
                                                                             final byte[] paddedReference,
                                                                             final int offsetForRefIntoEvent,
-                                                                            final DragstrReferenceAnalyzer dragstrs) {
+                                                                            final DragstrReferenceAnalyzer dragstrs,
+                                                                            final Locatable eventLocus) {
         Utils.nonNull(genotypingAlleles, "the allele cannot be null");
         Utils.nonNull(data, "the genotyping data cannot be null");
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AlleleFilteringHC.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AlleleFilteringHC.java
@@ -56,7 +56,7 @@ public class AlleleFilteringHC extends AlleleFiltering {
         AlleleList<Allele> alleleList = new IndexedAlleleList<>(Arrays.asList(notAllele, allele));
 
         final GenotypingLikelihoods<Allele> genotypingLikelihoods = genotypesModel.calculateLikelihoods(alleleList,
-                genotypingData, null, 0, null);
+                genotypingData, null, 0, null, null);
         AFCalculationResult af = afCalc.fastCalculateDiploidBasedOnGLs(genotypingLikelihoods, genotypingEngine.getPloidyModel().totalPloidy());
         final double log10Confidence = af.log10ProbOnlyRefAlleleExists();
         final double phredScaledConfidence = (10.0 * log10Confidence) + 0.0;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
@@ -656,10 +656,11 @@ public final class AssemblyBasedCallerUtils {
         //in eventsAtThisLoc, when in mergedVC it would yield AAA* AA A
         mergedVC.getAlternateAlleles().stream().filter(a -> !a.isSymbolic()).forEach(a -> result.put(a, new ArrayList<>()));
 
+        final Locatable locus = new SimpleInterval(mergedVC.getContig(), loc, loc);
         for (final Haplotype h : haplotypes) {
 
             // Partially determined haplotypes know at what position they are determined, only determined position haps should be considered for genotyping
-            if (h.isPartiallyDetermined() && ((PartiallyDeterminedHaplotype) h).getDeterminedPosition() != loc) {
+            if (h.isPartiallyDetermined() && ((PartiallyDeterminedHaplotype) h).getDeterminedSpan().overlaps(locus)) {
                 continue;
             }
             final List<Event> overlappingEvents = h.getEventMap().getOverlappingEvents(loc);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
@@ -660,7 +660,7 @@ public final class AssemblyBasedCallerUtils {
         for (final Haplotype h : haplotypes) {
 
             // Partially determined haplotypes know at what position they are determined, only determined position haps should be considered for genotyping
-            if (h.isPartiallyDetermined() && ((PartiallyDeterminedHaplotype) h).getDeterminedSpan().overlaps(locus)) {
+            if (h.isPartiallyDetermined() && !((PartiallyDeterminedHaplotype) h).getDeterminedSpan().overlaps(locus)) {
                 continue;
             }
             final List<Event> overlappingEvents = h.getEventMap().getOverlappingEvents(loc);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
@@ -191,6 +191,23 @@ public class HaplotypeCallerGenotypingEngine extends GenotypingEngine<StandardCa
 
             int mergedAllelesListSizeBeforePossibleTrimming = mergedVC.getAlleles().size();
 
+            // use joint detection haplo-genotype posteriors if available
+            final List<GenotypingLikelihoods<Haplotype>> haploGenotypePosteriors = new ArrayList<>(haploGenotypePosteriorOverlapDetector.getOverlaps(mergedVC));
+            if (!haploGenotypePosteriors.isEmpty()) {
+                Utils.validate(haploGenotypePosteriors.size() == 1, "Only one set of haplotype genotype posteriors should overlap this variant.");
+                final GenotypingLikelihoods<Haplotype> haplotypePosteriors = haploGenotypePosteriors.get(0);
+
+                final List<Haplotype> determinedHaplotypes = haplotypePosteriors.asListOfAlleles(); // this only contains haplotypes whose determined span contains this locus
+
+                final Map<Allele, List<Haplotype>> alleleMapper = AssemblyBasedCallerUtils.createAlleleMapper(mergedVC, loc, determinedHaplotypes, !hcArgs.disableSpanningEventGenotyping);
+
+
+                // TODO: we have a mapping between alleles and haplotypes.  Now we need a corresponding mapping between
+                // TODO: allele-genotypes and haplo-genotypes in the canonical PL order.
+
+
+            }
+
             // TODO: can we use this as-is for the mapping between joint detection PD haplotypes and merged VC alleles?  I think so...
             final Map<Allele, List<Haplotype>> alleleMapper = AssemblyBasedCallerUtils.createAlleleMapper(mergedVC, loc, haplotypes, !hcArgs.disableSpanningEventGenotyping);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
@@ -279,11 +279,9 @@ public class HaplotypeCallerGenotypingEngine extends GenotypingEngine<StandardCa
             // these genotypes have the PLs calculated and filled out but are otherwise empty (no-call alleles, no annotations)
             final GenotypesContext genotypes = calculateGLsForThisEvent(readAlleleLikelihoods, mergedVC, noCallAlleles, ref, loc - refLoc.getStart(), dragstrs, glsOverride);
 
-            // at this point joint detection and non-joint detection code paths meet up again
-
-            // TODO: look into this genotype prior calculator because in joint detection we have already accounted for
-            // TODO: haplotype priors, no need to double-count priors here!
-            final GenotypePriorCalculator gpc = resolveGenotypePriorCalculator(dragstrs, loc - refLoc.getStart() + 1, snpHeterozygosity, indelHeterozygosity);
+            // In joint detection we have already accounted for *haplotype* priors, no need to double-count priors here!
+            final GenotypePriorCalculator gpc = glsOverride.isPresent() ? GenotypePriorCalculator.flatPrior() :
+                    resolveGenotypePriorCalculator(dragstrs, loc - refLoc.getStart() + 1, snpHeterozygosity, indelHeterozygosity);
             final VariantContext call = calculateGenotypes(new VariantContextBuilder(mergedVC).genotypes(genotypes).make(), gpc, givenAlleles);
 
             // TODO: looks like even in joint detection we will need the read-allele likelihoods for annotations

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
@@ -445,6 +445,9 @@ public class HaplotypeCallerGenotypingEngine extends GenotypingEngine<StandardCa
                         .toList();
 
                 GenotypingLikelihoods<Haplotype> log10HaploGenotypePosteriors = new GenotypingLikelihoods<>(log10HaploGenotypeLikelihoods, ploidyModel, log10HaploGenotypePosteriorsInSampleOrder);
+                if (haploGenotypePosteriorOverlapDetector.overlapsAny(jdInterval)) {
+                    int DEBUG = 90;
+                }
                 haploGenotypePosteriorOverlapDetector.addLhs(log10HaploGenotypePosteriors, jdInterval);
             }
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
@@ -81,7 +81,7 @@ public class HaplotypeCallerGenotypingEngine extends GenotypingEngine<StandardCa
         ploidyModel = new HomogeneousPloidyModel(samples,configuration.standardArgs.genotypeArgs.samplePloidy);
         dragstrParams = DragstrParamUtils.parse(configuration.likelihoodArgs.dragstrParams);
         genotypingModel = hcArgs.applyBQD || hcArgs.applyFRD ?
-                new DRAGENGenotypesModel(applyBQD, hcArgs.applyFRD, hcArgs.informativeReadOverlapMargin, hcArgs.maxEffectiveDepthAdjustment, dragstrParams) :
+                new DRAGENGenotypesModel(applyBQD, hcArgs.applyFRD, hcArgs.maxEffectiveDepthAdjustment, dragstrParams) :
                 new IndependentSampleGenotypesModel();
         maxGenotypeCountToEnumerate = configuration.standardArgs.genotypeArgs.maxGenotypeCount;
         referenceConfidenceMode = configuration.emitReferenceConfidence;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
@@ -395,7 +395,7 @@ public class HaplotypeCallerGenotypingEngine extends GenotypingEngine<StandardCa
                 final List<Event> allEvents = jdHaplotypes.stream().flatMap(haplotype -> haplotype.getEventMap().getEvents().stream()).distinct().toList();
                 final Map<Event, Double> log10EventHetPriors = new HashMap<>();
                 for (final Event event : allEvents) {
-                    final double log10SNPHetPrior = Math.log10(snpHeterozygosity);
+                    final double log10SNPHetPrior = Math.log10(snpHeterozygosity) - GenotypePriorCalculator.LOG10_SNP_NORMALIZATION_CONSTANT;
                     if (event.isSNP()) {
                         log10EventHetPriors.put(event, log10SNPHetPrior);
                     } else {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
@@ -722,8 +722,13 @@ public class HaplotypeCallerGenotypingEngine extends GenotypingEngine<StandardCa
         Utils.nonNull(mergedVC, "mergedVC");
         final List<Allele> vcAlleles = mergedVC.getAlleles();
         final AlleleList<Allele> alleleList = readLikelihoods.numberOfAlleles() == vcAlleles.size() ? readLikelihoods : new IndexedAlleleList<>(vcAlleles);
+
+        // this includes BQD/FRD but does not include priors or the effect of joint detection
         final GenotypingLikelihoods<Allele> likelihoods = genotypingModel.calculateLikelihoods(alleleList,new GenotypingData<>(ploidyModel,readLikelihoods),
-                paddedReference, offsetForRefIntoEvent, dragstrs, haploGenotypingResult, mergedVC);
+                paddedReference, offsetForRefIntoEvent, dragstrs, mergedVC);
+        // TODO: apply joint detection
+
+
         final int sampleCount = samples.numberOfSamples();
         final GenotypesContext result = GenotypesContext.create(sampleCount);
         for (int s = 0; s < sampleCount; s++) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
@@ -207,7 +207,6 @@ public class HaplotypeCallerGenotypingEngine extends GenotypingEngine<StandardCa
             final SAMSequenceDictionary sequenceDictionary = header.getSequenceDictionary();
             final SimpleInterval variantCallingRelevantOverlap = new SimpleInterval(mergedVC).expandWithinContig(hcArgs.informativeReadOverlapMargin, sequenceDictionary);
             readAlleleLikelihoods.retainEvidence(read -> readQualifiesForGenotypingPredicate.test(read, variantCallingRelevantOverlap));
-            readAlleleLikelihoods.setVariantCallingSubsetUsed(variantCallingRelevantOverlap);
 
             if (configuration.isSampleContaminationPresent()) {
                 // This warrants future evaluation as to the best way to handle disqualified reads
@@ -390,7 +389,7 @@ public class HaplotypeCallerGenotypingEngine extends GenotypingEngine<StandardCa
                 // NOTE: we do not want the DRAGEN genotypes model here because it includes FRD and BQD, which only apply once
                 // we have genotypes based on alleles, not haplotypes
                 final GenotypingLikelihoods<Haplotype> log10HaploGenotypeLikelihoods = new IndependentSampleGenotypesModel().calculateLikelihoods(jdReadLikelihoods,
-                        new GenotypingData<>(ploidyModel, jdReadLikelihoods), ref, jdInterval.getStart() - refLoc.getStart(), dragstrs);
+                        new GenotypingData<>(ploidyModel, jdReadLikelihoods), ref, jdInterval.getStart() - refLoc.getStart(), dragstrs, jdInterval);
 
                 // calculate heterozygosity for each event
                 final List<Event> allEvents = jdHaplotypes.stream().flatMap(haplotype -> haplotype.getEventMap().getEvents().stream()).distinct().toList();
@@ -718,7 +717,7 @@ public class HaplotypeCallerGenotypingEngine extends GenotypingEngine<StandardCa
         final List<Allele> vcAlleles = mergedVC.getAlleles();
         final AlleleList<Allele> alleleList = readLikelihoods.numberOfAlleles() == vcAlleles.size() ? readLikelihoods : new IndexedAlleleList<>(vcAlleles);
         final GenotypingLikelihoods<Allele> likelihoods = genotypingModel.calculateLikelihoods(alleleList,new GenotypingData<>(ploidyModel,readLikelihoods),
-                paddedReference, offsetForRefIntoEvent, dragstrs, genotypeLikelihoodsOverride, genotypePosteriorsOverride);
+                paddedReference, offsetForRefIntoEvent, dragstrs, genotypeLikelihoodsOverride, genotypePosteriorsOverride, mergedVC);
         final int sampleCount = samples.numberOfSamples();
         final GenotypesContext result = GenotypesContext.create(sampleCount);
         for (int s = 0; s < sampleCount; s++) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
@@ -276,7 +276,6 @@ public class HaplotypeCallerGenotypingEngine extends GenotypingEngine<StandardCa
             final Optional<GenotypingLikelihoods<Allele>> glsOverride = (haploGTPosteriors.size() == 1 && ploidy == 2) ?
                     Optional.of(computeAlleleGenotypesFromHaploGenotypes(ploidy, noCallAlleles, loc, mergedVC, haploGTPosteriors.get(0))) : Optional.empty();
 
-            // TODO: the code below needs to optionally take in the genotypesOverride as a flag to skip GL computation
             // these genotypes have the PLs calculated and filled out but are otherwise empty (no-call alleles, no annotations)
             final GenotypesContext genotypes = calculateGLsForThisEvent(readAlleleLikelihoods, mergedVC, noCallAlleles, ref, loc - refLoc.getStart(), dragstrs, glsOverride);
 
@@ -713,7 +712,7 @@ public class HaplotypeCallerGenotypingEngine extends GenotypingEngine<StandardCa
         Utils.nonNull(mergedVC, "mergedVC");
         final List<Allele> vcAlleles = mergedVC.getAlleles();
         final AlleleList<Allele> alleleList = readLikelihoods.numberOfAlleles() == vcAlleles.size() ? readLikelihoods : new IndexedAlleleList<>(vcAlleles);
-        final GenotypingLikelihoods<Allele> likelihoods = genotypingModel.calculateLikelihoods(alleleList,new GenotypingData<>(ploidyModel,readLikelihoods), paddedReference, offsetForRefIntoEvent, dragstrs);
+        final GenotypingLikelihoods<Allele> likelihoods = genotypingModel.calculateLikelihoods(alleleList,new GenotypingData<>(ploidyModel,readLikelihoods), paddedReference, offsetForRefIntoEvent, dragstrs, glsOverride);
         final int sampleCount = samples.numberOfSamples();
         final GenotypesContext result = GenotypesContext.create(sampleCount);
         for (int s = 0; s < sampleCount; s++) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
@@ -413,11 +413,14 @@ public class HaplotypeCallerGenotypingEngine extends GenotypingEngine<StandardCa
                 final Map<Haplotype, Double> log10HaplotypeHetPriors = jdHaplotypes.stream().collect(Collectors.toMap(h->h,
                         h -> h.getEventMap().getEvents().stream().mapToDouble(log10EventHetPriors::get).sum()));
 
-                // TODO: likewise: we are calculating this for the ref haplotype. . .
                 // note that DRAGEN's prior for homozygosity is NOT the same as Hardy-Weinberg equilibrium!
                 // TODO: should the DRAGEN het-hom ratio for haplotypes be the same as for alleles?
                 final Map<Haplotype, Double> log10HaplotypeHomPriors = jdHaplotypes.stream().collect(Collectors.toMap(h->h,
                         h -> log10HaplotypeHetPriors.get(h) - Math.log10(hcArgs.likelihoodArgs.dragstrHetHomRatio)));
+
+                // set hom ref to 0
+                jdHaplotypes.stream().filter(h -> h.getEventMap().size() == 0)
+                        .forEach(h -> log10HaplotypeHomPriors.put(h, 0.0));
 
                 // calculate diploid haplotype-based genotype priors
                 final double[] log10HaploGenotypePriors = new double[GenotypeIndexCalculator.genotypeCount(ploidy, log10HaploGenotypeLikelihoods.numberOfAlleles())];

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerGenotypingEngine.java
@@ -341,7 +341,7 @@ public class HaplotypeCallerGenotypingEngine extends GenotypingEngine<StandardCa
             // TODO: haplotype priors, no need to double-count priors here!
             final GenotypePriorCalculator gpc = resolveGenotypePriorCalculator(dragstrs, loc - refLoc.getStart() + 1, snpHeterozygosity, indelHeterozygosity);
             final VariantContext call = calculateGenotypes(new VariantContextBuilder(mergedVC).genotypes(genotypes).make(), gpc, givenAlleles);
-            
+
             // TODO: looks like even in joint detection we will need the read-allele likelihoods for annotations
             if( call != null ) {
                 readAlleleLikelihoods = prepareReadAlleleLikelihoodsForAnnotation(readLikelihoods, perSampleFilteredReadList,
@@ -409,7 +409,8 @@ public class HaplotypeCallerGenotypingEngine extends GenotypingEngine<StandardCa
                     if (event.isSNP()) {
                         log10EventHetPriors.put(event, log10SNPHetPrior);
                     } else {
-                        final int pos = event.getStart();
+                        // TODO: is this right?
+                        final int pos = event.getStart() - refLoc.getStart() + 1;
                         final boolean noDragstr = hcArgs.likelihoodArgs.dragstrParams == null || hcArgs.standardArgs.genotypeArgs.dontUseDragstrPriors || dragstrs == null;
                         final double log10IndelHetPrior = noDragstr ? Math.log10(indelHeterozygosity) :
                                 -.1 * dragstrParams.api(dragstrs.period(pos), dragstrs.repeatLength(pos));

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngine.java
@@ -102,7 +102,7 @@ public class PartiallyDeterminedHaplotypeComputationEngine {
         if (outputHaplotypes == null) {
             return sourceSet;
         }
-        
+
         sourceSet.storeAssemblyHaplotypes();
 
         // TODO: Sorting haplotypes is unnecessary but makes debugging against previous versions much easier.

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngine.java
@@ -421,6 +421,9 @@ public class PartiallyDeterminedHaplotypeComputationEngine {
                     eventIndex++;
                 }
                 if (!eventsInSpan.isEmpty()) {  // the interval could be an STR with no Events within
+                    if (eventsInSpan.size() > MAX_VAR_IN_EVENT_GROUP) {
+                        return null;
+                    }
                     try {
                         eventGroups.add(new EventGroup(eventsInSpan, swMutexes, overlapMutexes));
                     } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngine.java
@@ -422,7 +422,20 @@ public class PartiallyDeterminedHaplotypeComputationEngine {
                     eventIndex++;
                 }
                 if (!eventsInSpan.isEmpty()) {  // the interval could be an STR with no Events within
-                    eventGroups.add(new EventGroup(eventsInSpan, swMutexes, overlapMutexes));
+                    try {
+                        eventGroups.add(new EventGroup(eventsInSpan, swMutexes, overlapMutexes));
+                    } catch (Exception e) {
+                        System.out.println("The exception was: " + e);
+                        System.out.println("Events in order: " + eventsInOrder);
+                        System.out.println("Events in DRAGEN order: " + eventsInDragenOrder);
+                        System.out.println("Event groups found so far: " + eventGroups);
+                        System.out.println("All intervals in order: " + allIntervals);
+                        System.out.println("current span: " + span);
+                        System.out.println("Events in the current span: " + eventsInSpan);
+                        System.out.println("All SW mutexes here: " + swMutexes);
+                        System.out.println("All STR intervals here: " + strIntervals);
+                        throw e;
+                    }
                 }
 
                 start = interval.getMinimumDouble();

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngine.java
@@ -140,12 +140,12 @@ public class PartiallyDeterminedHaplotypeComputationEngine {
                 Utils.printIf(debug, () -> "Found too many branches, aborting and falling back to Assembly Variants!");
                 return sourceSet;
             }
-            
+
             // by default, the whole event group is the determined span, but we can optionally revert to pre-joint detection behavior
             // where only one event at a time is determined and the rest of the event group is undetermined
-            final List<Pair<Set<Event>, SimpleInterval>> eventSetsAndDeterminedSpans = true ?
-                    determinedEventGroup.determinedEventSets().stream().map(s -> Pair.of(s, determinedEventGroup.getSpan())).toList() :
-                    determinedEventGroup.determinedUndeterminedHybridSets();
+            final List<Pair<Set<Event>, SimpleInterval>> eventSetsAndDeterminedSpans = pileupArgs.disableJointDetection ? determinedEventGroup.determinedUndeterminedHybridSets() :
+                    determinedEventGroup.determinedEventSets().stream().map(s -> Pair.of(s, determinedEventGroup.getSpan())).toList();
+                    ;
 
             for (final Pair<Set<Event>, SimpleInterval> eventSetAndDeterminedSpan : eventSetsAndDeterminedSpans) {
                 final Set<Event> eventsFromDeterminedGroup = eventSetAndDeterminedSpan.getLeft();

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngine.java
@@ -111,7 +111,8 @@ public class PartiallyDeterminedHaplotypeComputationEngine {
         List<List<Event>> disallowedCombinations = smithWatermanRealignPairsOfVariantsForEquivalentEvents(referenceHaplotype, aligner, args.getHaplotypeToReferenceSWParameters(), debug, eventsInOrder);
         dragenDisallowedGroupsMessage(referenceHaplotype.getStart(), debug, disallowedCombinations);
 
-        final List<EventGroup> eventGroups = getEventGroupClusters(eventsInOrder, disallowedCombinations);
+        // TODO: add in command line argument to activate joint detection and only use the STR overlap detector if joint detection is turned on
+        final List<EventGroup> eventGroups = getEventGroupClusters(eventsInOrder, disallowedCombinations, Optional.of(strOverlapDetector));
         // if any of our merged event groups is too large, abort.
         if (eventGroups == null) {
             Utils.printIf(debug, () -> "Found event group with too many variants! Aborting haplotype building");
@@ -369,28 +370,54 @@ public class PartiallyDeterminedHaplotypeComputationEngine {
      *                                simplifying via Smith Waterman yields other events
      */
     @VisibleForTesting
-    static List<EventGroup> getEventGroupClusters(List<Event> eventsInOrder, List<List<Event>> swForbiddenPairsAndTrios) {
+    static List<EventGroup> getEventGroupClusters(List<Event> eventsInOrder, List<List<Event>> swForbiddenPairsAndTrios, Optional<OverlapDetector<SimpleInterval>> strIntervals) {
         final List<List<Event>> allMutexes = new ArrayList<>(swForbiddenPairsAndTrios);
 
         // edges due to overlapping position
+        // if STR intervals are given, two events that intersect the same STR are treated as overlapping for the purpose of DRAGEN joint detection
         for (int e1 = 0; e1 < eventsInOrder.size(); e1++) {
             final Event event1 = eventsInOrder.get(e1);
             for (int e2 = e1 + 1; e2 < eventsInOrder.size() && eventsInOrder.get(e2).getStart() <= event1.getEnd() + 1; e2++) {
                 final Event event2 = eventsInOrder.get(e2);
+
                 if (eventsOverlapForPDHapsCode(event1, event2)) {
                     allMutexes.add(List.of(event1, event2));
                 }
             }
         }
 
+
         // for each mutex, add edges 0-1, 1-2. . . to put all mutex events in one connected component
         final Graph<Event, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
         eventsInOrder.forEach(graph::addVertex);
-        allMutexes.forEach(mutex -> new IndexRange(0, mutex.size() - 1).forEach(n -> graph.addEdge(mutex.get(n), mutex.get(n+1))));
+        allMutexes.forEach(mutex -> connectVertices(graph, mutex));
 
+        // STR extended overlap is used to cluster by EventGroups but is *not* a mutex.
+        strIntervals.ifPresent(strs -> {
+            // we're going to fill a map from STR intervals to the events they contain, then add graph edges to ensure that
+            // all events incident on the same STR belong to one connected component
+            final Multimap<SimpleInterval, Event> eventsBySTRInterval = MultimapBuilder.hashKeys().arrayListValues().build();
+            for (final Event event : eventsInOrder) {
+                strs.getOverlaps(event).forEach(str -> eventsBySTRInterval.put(str, event));
+            }
+
+            eventsBySTRInterval.asMap().values().forEach(eventsInSTR -> connectVertices(graph, List.copyOf(eventsInSTR)));
+        });
+        
         final List<Set<Event>> components = new ConnectivityInspector<>(graph).connectedSets();
         return components.stream().anyMatch(comp -> comp.size() > MAX_VAR_IN_EVENT_GROUP) ? null :
                 components.stream().map(component -> new EventGroup(component, allMutexes)).toList();
+    }
+
+    // helper method to ensure that all elements of a list of vertices end up in one connected component of a graph
+    private static <T> void connectVertices(final Graph<T, DefaultEdge> graph, final List<T> verticesToConnect) {
+        new IndexRange(0, verticesToConnect.size() - 1).forEach(n -> graph.addEdge(verticesToConnect.get(n), verticesToConnect.get(n+1)));
+    }
+
+    // same as above without the STR overlap detector
+    @VisibleForTesting
+    static List<EventGroup> getEventGroupClusters(List<Event> eventsInOrder, List<List<Event>> swForbiddenPairsAndTrios) {
+        return getEventGroupClusters(eventsInOrder, swForbiddenPairsAndTrios, Optional.empty());
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PileupDetectionArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PileupDetectionArgumentCollection.java
@@ -41,6 +41,7 @@ public final class PileupDetectionArgumentCollection {
 
     public static final String GENERATE_PARTIALLY_DETERMINED_HAPLOTYPES_LONG_NAME = "use-pdhmm";
     public static final String DETERMINE_PD_HAPS = "make-determined-haps-from-pd-code";
+    public static final String DISABLE_JOINT_DETECTION = "disable-joint-detection";
     public static final String DEBUG_PILEUPCALLING_ARG = "print-pileupcalling-status";
     public static final String FALLBACK_TO_ALT_HAP_CONSTRUCITON_IF_ABORTED = "fallback-gga-if-pdhmm-fails";
     public static final String PDHMM_READ_OVERLAP_OPTIMIZATION = "use-pdhmm-overlap-optimization";
@@ -78,6 +79,8 @@ public final class PileupDetectionArgumentCollection {
     @Hidden
     @Argument(fullName= DETERMINE_PD_HAPS, doc = "PDHMM: As an alternative to using the PDHMM, run all of the haplotype branching/determination code and instead of using the PDHMM use the old HMM with determined haplotypes. NOTE: this often fails and fallsback to other code due to combinatorial expansion. (Requires '--"+GENERATE_PARTIALLY_DETERMINED_HAPLOTYPES_LONG_NAME+"' argument)", optional = true)
     public boolean useDeterminedHaplotypesDespitePdhmmMode = false;
+    @Argument(fullName= DISABLE_JOINT_DETECTION, doc = "PDHMM: Disable joint detection; that is, make partially-determined haplotypes with at most one determined event. (Requires '--"+GENERATE_PARTIALLY_DETERMINED_HAPLOTYPES_LONG_NAME+"' argument)", optional = true)
+    public boolean disableJointDetection = false;
     @Hidden
     @Argument(fullName= DEBUG_PILEUPCALLING_ARG, doc = "PDHMM: If set, print to stdout a prodigious amount of debugging information about each of the steps involved in artificial haplotype construction and filtering. (Requires '--"+GENERATE_PARTIALLY_DETERMINED_HAPLOTYPES_LONG_NAME+"' argument)", optional = true)
     public boolean debugPileupStdout = false;

--- a/src/main/java/org/broadinstitute/hellbender/utils/SmallBitSet.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/SmallBitSet.java
@@ -123,8 +123,9 @@ public class SmallBitSet {
         bits &= ~(elementIndex(element));
     }
 
-    public void flip(final int element) {
+    public SmallBitSet flip(final int element) {
         bits ^= elementIndex(element);
+        return this;
     }
 
     public boolean get(final int element) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/SmallBitSet.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/SmallBitSet.java
@@ -138,7 +138,7 @@ public class SmallBitSet {
 
     public boolean isEmpty() { return bits == 0; }
 
-    public boolean hasElementGreaterThan(final int element) { return bits >= 1 << element; }
+    public boolean hasElementGreaterThan(final int element) { return bits >= 1 << (element + 1); }
 
     private static int elementIndex(final int element) {
         return 1 << element;

--- a/src/main/java/org/broadinstitute/hellbender/utils/SmallBitSet.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/SmallBitSet.java
@@ -6,6 +6,9 @@ import org.broadinstitute.hellbender.utils.param.ParamUtils;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
@@ -100,6 +103,12 @@ public class SmallBitSet {
         final SmallBitSet result = new SmallBitSet();
         result.bits = this.bits | other.bits;
         return result;
+    }
+
+    // convert this Bitset of integer indices into a set of objects by indexing into some list
+    public <T> Set<T> asSet(final List<T> elements) {
+        Utils.validateArg(!hasElementGreaterThan(elements.size()-1), "this bitset contains indices too big for the given list");
+        return stream(elements.size()).mapToObj(elements::get).collect(Collectors.toSet());
     }
 
     public boolean contains(final SmallBitSet other) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/SmallBitSet.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/SmallBitSet.java
@@ -73,6 +73,10 @@ public class SmallBitSet {
         return result;
     }
 
+    public static SmallBitSet emptySet() {
+        return new SmallBitSet();
+    }
+
     // convert to the next bitset in the canonical ordering, which conveniently is just adding 1 to the underlying int.
     // Useful for iterating over all possible subsets in order from empty to full.
     // Calling code is responsible for starting iteration at 0 (empty bitset) and stopping iteration at 2^n - 1 for a full bitset of n elements.

--- a/src/main/java/org/broadinstitute/hellbender/utils/genotyper/AlleleLikelihoods.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/genotyper/AlleleLikelihoods.java
@@ -40,7 +40,6 @@ public class AlleleLikelihoods<EVIDENCE extends Locatable, A extends Allele> imp
     private static final Logger logger = LogManager.getLogger(AlleleLikelihoods.class);
 
     private boolean isNaturalLog = false;
-    private SimpleInterval subsettedGenomicLoc;
     private int filteredHaplotypeCount = 0;
 
     public boolean isNaturalLog() {
@@ -1205,17 +1204,6 @@ public class AlleleLikelihoods<EVIDENCE extends Locatable, A extends Allele> imp
             }
         }
         return result;
-    }
-
-    public void setVariantCallingSubsetUsed(final SimpleInterval loc) {
-        this.subsettedGenomicLoc = loc;
-    }
-
-    /**
-     * Returns the location used for subsetting. May be null.
-     */
-    public SimpleInterval getVariantCallingSubsetApplied() {
-        return subsettedGenomicLoc;
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/genotyper/GenotypePriorCalculator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/genotyper/GenotypePriorCalculator.java
@@ -39,7 +39,7 @@ public final class GenotypePriorCalculator {
 
     // A snp can go to 3 different bases (standard-nucs - 1), so we normalize SNP lks accordingly. Here is the
     // log10 constant used for that:
-    private static final double LOG10_SNP_NORMALIZATION_CONSTANT =
+    public static final double LOG10_SNP_NORMALIZATION_CONSTANT =
             Math.log10(Nucleotide.STANDARD_BASES.size() - 1);
 
     private final double[] hetValues;

--- a/src/main/java/org/broadinstitute/hellbender/utils/genotyper/GenotypePriorCalculator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/genotyper/GenotypePriorCalculator.java
@@ -46,6 +46,17 @@ public final class GenotypePriorCalculator {
     private final double[] homValues;
     private final double[] diffValues;
 
+    // constructor for flat prior
+    private GenotypePriorCalculator() {
+        hetValues = new double[NUMBER_OF_ALLELE_TYPES];
+        homValues = new double[NUMBER_OF_ALLELE_TYPES];
+        diffValues = new double[NUMBER_OF_ALLELE_TYPES];
+    }
+
+    public static GenotypePriorCalculator flatPrior() {
+        return new GenotypePriorCalculator();
+    }
+
     private GenotypePriorCalculator(final double snpHet, final double snpHom,
                                           final double indelHet, final double indelHom,
                                           final double otherHet, final double otherHom) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/genotyper/GenotypePriorCalculator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/genotyper/GenotypePriorCalculator.java
@@ -149,6 +149,7 @@ public final class GenotypePriorCalculator {
 
         for (final GenotypeAlleleCounts gac : GenotypeAlleleCounts.iterable(ploidy, alleles.size())) {
             // implied = result[0] = 0.0;
+            // TODO: shouldn't this be "count == ploidy ? homValues. . ." ?
             if (gac.index() > 0) {
                 result[gac.index()] = gac.sumOverAlleleIndicesAndCounts((allele, count) -> count == 2 ? homValues[alleleTypes[allele]]
                         : hetValues[alleleTypes[allele]] + diffValues[alleleTypes[allele]] * (count - 1));

--- a/src/main/java/org/broadinstitute/hellbender/utils/haplotype/PartiallyDeterminedHaplotype.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/haplotype/PartiallyDeterminedHaplotype.java
@@ -72,8 +72,6 @@ public final class  PartiallyDeterminedHaplotype extends Haplotype {
 
     private final byte[] alternateBases;
     private final List<Event> constituentBuiltEvents;
-
-    //TODO Eventually these will have to be refactored to support multiple determined alleles per PDHaplotype
     private final Set<Event> determinedEvents; // NOTE this must be a subset (possibly empty if the determined allele is ref) of both of the previous lists
 
     // NOTE: we need all of the events at the determined site (all of which are determined in *some* PD haplotype) for the purposes

--- a/src/main/java/org/broadinstitute/hellbender/utils/haplotype/PartiallyDeterminedHaplotype.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/haplotype/PartiallyDeterminedHaplotype.java
@@ -71,7 +71,7 @@ public final class  PartiallyDeterminedHaplotype extends Haplotype {
     }
 
     private final byte[] alternateBases;
-    private final List<Event> constituentBuiltEvents;
+    private final List<Event> constituentEvents;
     private final Set<Event> determinedEvents; // NOTE this must be a subset (possibly empty if the determined allele is ref) of both of the previous lists
 
     // NOTE: we need all of the events at the determined site (all of which are determined in *some* PD haplotype) for the purposes
@@ -96,7 +96,7 @@ public final class  PartiallyDeterminedHaplotype extends Haplotype {
         Utils.validateArg(base.length() == pdBytes.length, "pdBytes array must have same length as base haplotype.");
         this.setGenomeLocation(base.getGenomeLocation());
         this.alternateBases = pdBytes;
-        this.constituentBuiltEvents = constituentEvents;
+        this.constituentEvents = constituentEvents;
         // TODO: this needs to generalize to a set of determined events or empty if ref is determined
         this.determinedEvents = determinedEvents;
 
@@ -119,7 +119,7 @@ public final class  PartiallyDeterminedHaplotype extends Haplotype {
     public String toString() {
         String output = "HapLen:"+length() +", "+new String(getDisplayBases());
         output = output + "\nUnresolved Bases["+alternateBases.length+"] "+Arrays.toString(alternateBases);
-        return output + "\n"+getCigar().toString()+" "+ constituentBuiltEvents.stream()
+        return output + "\n"+getCigar().toString()+" "+ constituentEvents.stream()
                 .map(v ->(determinedEvents.contains(v) ?"*":"")+ getDRAGENDebugEventString( getStart()).apply(v) )
                 .collect(Collectors.joining("->"));
     }
@@ -149,6 +149,8 @@ public final class  PartiallyDeterminedHaplotype extends Haplotype {
     public Set<Event> getDeterminedEvents() {
         return determinedEvents;
     }
+
+    public List<Event> getConstituentEvents() { return constituentEvents; }
 
     //NOTE: we never want the genotyper to handle reads that were not HMM scored, caching this extent helps keep us safe from messy sites
     public SimpleInterval getDeterminedSpan() {

--- a/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/PDPairHMM.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/PDPairHMM.java
@@ -8,13 +8,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.gatk.nativebindings.pairhmm.PairHMMNativeArguments;
 import org.broadinstitute.hellbender.exceptions.GATKException;
-import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.PDPairHMMLikelihoodCalculationEngine;
 import org.broadinstitute.hellbender.utils.MathUtils;
-import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.genotyper.LikelihoodMatrix;
-import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
 import org.broadinstitute.hellbender.utils.haplotype.PartiallyDeterminedHaplotype;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
@@ -191,7 +188,9 @@ public abstract class PDPairHMM implements Closeable{
                 final byte[] nextAlleleBases = a == alleles.size() - 1 ? null : alleles.get(a + 1).getBases();
                 final byte[] nextAllelePDBases = a == alleles.size() - 1 ? null : alleles.get(a + 1).getBases();
                 // if we aren't apply the optimization (range == -1) or if the read overlaps the determined region for calling:
-                if (rangeForReadOverlapToDeterminedBases < 0 || allele.getMaximumExtentOfSiteDeterminedAlleles()
+                // TODO: with joint detection a read can overlap the determined span of a PD haplotype without overlapping any of the
+                // TODO: actual determined alleles.  Does the logic here need to change?
+                if (rangeForReadOverlapToDeterminedBases < 0 || allele.getDeterminedSpan()
                         .overlapsWithMargin((Locatable) read.getTransientAttribute(PDPairHMMLikelihoodCalculationEngine.UNCLIPPED_ORIGINAL_SPAN_ATTR), rangeForReadOverlapToDeterminedBases + 1)) { // the +1 here is us erring on the side of caution
                     lk = computeReadLikelihoodGivenHaplotypeLog10(alleleBases, allele.getAlternateBases(),
                             readBases, readQuals, readInsQuals, readDelQuals, overallGCP, isFirstHaplotype, nextAlleleBases, nextAllelePDBases);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/IndependentSampleGenotypesModelUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/genotyper/IndependentSampleGenotypesModelUnitTest.java
@@ -26,7 +26,7 @@ public final class IndependentSampleGenotypesModelUnitTest {
         final PloidyModel ploidyModel = new HeterogeneousPloidyModel(sampleList,ploidies);
         final GenotypingData<Allele> data = new GenotypingData<>(ploidyModel,likelihoods);
         final GenotypingModel model = new IndependentSampleGenotypesModel();
-        final GenotypingLikelihoods<Allele> gLikelihoods = model.calculateLikelihoods(genotypingAlleleList,data,null, 0, null);
+        final GenotypingLikelihoods<Allele> gLikelihoods = model.calculateLikelihoods(genotypingAlleleList,data,null, 0, null, null);
         Assert.assertNotNull(gLikelihoods);
         AlleleListUnitTester.assertAlleleList(gLikelihoods, genotypingAlleleList.asListOfAlleles());
         SampleListUnitTester.assertSampleList(gLikelihoods,sampleList.asListOfSamples());

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
@@ -2025,7 +2025,6 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-L", "20:10000000-10100000",
                 "-O", outputPath,
                 "--dragen-378-concordance-mode",
-                "--disable-joint-detection",
                 "--dragstr-params-path", TEST_FILES_DIR+"example.dragstr-params.txt",
 
                 "--" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE, "false",

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
@@ -2025,6 +2025,7 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-L", "20:10000000-10100000",
                 "-O", outputPath,
                 "--dragen-378-concordance-mode",
+                "--disable-joint-detection",
                 "--dragstr-params-path", TEST_FILES_DIR+"example.dragstr-params.txt",
 
                 "--" + StandardArgumentDefinitions.ADD_OUTPUT_VCF_COMMANDLINE, "false",

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngineUnitTest.java
@@ -317,7 +317,6 @@ public class PartiallyDeterminedHaplotypeComputationEngineUnitTest extends GATKB
         public int hashCode() {
             return Objects.hash(determinedSpan.hashCode(), determinedEvents.hashCode(), undeterminedEvents.hashCode());
         }
-
     }
 
     @DataProvider

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngineUnitTest.java
@@ -363,10 +363,12 @@ public class PartiallyDeterminedHaplotypeComputationEngineUnitTest extends GATKB
 
         final List<Event> allEventsAtDeterminedLocus = events.stream().filter(event -> event.getStart() == determinedLocus).toList();
 
-        PartiallyDeterminedHaplotype result = PartiallyDeterminedHaplotypeComputationEngine.createNewPDHaplotypeFromEvents(ref, determinedEvents, determinedLocus, events, allEventsAtDeterminedLocus);
+        PartiallyDeterminedHaplotype result = PartiallyDeterminedHaplotypeComputationEngine.createNewPDHaplotypeFromEvents(ref, determinedEvents, determinedLocus, events);
         Assert.assertEquals(new String(result.getBases()), expectedBases);
         Assert.assertEquals(result.getAlternateBases(), expectedAltArray);
         Assert.assertEquals(result.getCigar(), TextCigarCodec.decode(expectedCigar));
+
+        // TODO: replace with determinedSpan
         Assert.assertEquals(result.getDeterminedPosition(), determinedLocus);
     }
 
@@ -381,10 +383,12 @@ public class PartiallyDeterminedHaplotypeComputationEngineUnitTest extends GATKB
         Haplotype ref = new Haplotype("AAAAAAAAAA".getBytes(), true, 500, TextCigarCodec.decode("10M"));
         ref.setGenomeLocation(new SimpleInterval("20", 100, 110));
 
-        PartiallyDeterminedHaplotype result = PartiallyDeterminedHaplotypeComputationEngine.createNewPDHaplotypeFromEvents(ref, Set.of(), 105, List.of(DEL_AAAAAAA_102, DEL_AA_105), List.of(DEL_AA_105));
+        PartiallyDeterminedHaplotype result = PartiallyDeterminedHaplotypeComputationEngine.createNewPDHaplotypeFromEvents(ref, Set.of(), 105, List.of(DEL_AAAAAAA_102, DEL_AA_105));
         Assert.assertEquals(new String(result.getBases()), "AAAAAAAAAA");
         Assert.assertEquals(result.getAlternateBases(), new byte[]{0,0,0,2,0,0,0,0,4,0});
         Assert.assertEquals(result.getCigar(), TextCigarCodec.decode("10M"));
+
+        // TODO: replace with determined span
         Assert.assertEquals(result.getDeterminedPosition(), DEL_AA_105.getStart());
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngineUnitTest.java
@@ -7,7 +7,6 @@ import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.haplotype.Event;
 import org.broadinstitute.hellbender.utils.haplotype.EventMap;
 import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
-import org.broadinstitute.hellbender.utils.haplotype.PartiallyDeterminedHaplotype;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -81,9 +80,12 @@ public class PartiallyDeterminedHaplotypeComputationEngineUnitTest extends GATKB
                 // Smith-Waterman pair mutex joining event groups that would otherwise be independent
                 { List.of(SNP_C_90, SNP_C_100), List.of(List.of(0,1)), List.of(List.of(0,1))},
                 { List.of(SNP_C_90, SNP_C_100, SNP_C_105), List.of(List.of(0,1)), List.of(List.of(0,1), List.of(2))},
-                { List.of(SNP_C_90, SNP_C_100, SNP_C_105), List.of(List.of(0,2)), List.of(List.of(0,2), List.of(1))},    // this example is unrealistic
                 { List.of(DEL_AA_100, SNP_G_101, DEL_AA_105, SNP_C_106), List.of(List.of(1,2)), List.of(List.of(0,1,2,3))},
                 { List.of(DEL_AA_100, SNP_G_101, DEL_AA_105, SNP_C_106, SNP_C_120), List.of(List.of(1,2)), List.of(List.of(0,1, 2,3), List.of(4))},
+
+                // this example is unrealistic. but illustrates that the mutex between the outer SNPs forces the inner SNPinto the same EventGroup
+                { List.of(SNP_C_90, SNP_C_100, SNP_C_105), List.of(List.of(0,2)), List.of(List.of(0,1,2))},
+
 
                 // two Smith-Waterman pair mutexes transitively combining three event groups
                 { List.of(DEL_AA_100, SNP_G_101, DEL_AA_105, SNP_C_106, SNP_C_120), List.of(List.of(1,2), List.of(3,4)), List.of(List.of(0,1, 2, 3, 4))},
@@ -209,14 +211,15 @@ public class PartiallyDeterminedHaplotypeComputationEngineUnitTest extends GATKB
 
         final List<Event> allEventsAtDeterminedLocus = eventsInOrder.stream().filter(event -> event.getStart() == determinedLocus).toList();
 
-        final Set<Set<Event>> actualBranches = PartiallyDeterminedHaplotypeComputationEngine.computeUndeterminedBranches(eventGroups, determinedEvents, allEventsAtDeterminedLocus)
+        // TODO: fix all this
+        /*final Set<Set<Event>> actualBranches = PartiallyDeterminedHaplotypeComputationEngine.computeUndeterminedBranches(eventGroups, determinedEvents, allEventsAtDeterminedLocus)
                         .stream().collect(Collectors.toSet());
 
         final Set<Set<Event>> expectedBranches = expectedBranchIndices.stream()
                         .map(indexSet -> indexSet.stream().map(eventsInOrder::get).collect(Collectors.toSet()))
                                 .collect(Collectors.toSet());
 
-        Assert.assertEquals(actualBranches, expectedBranches);
+        Assert.assertEquals(actualBranches, expectedBranches);*/
     }
 
     @DataProvider
@@ -363,13 +366,14 @@ public class PartiallyDeterminedHaplotypeComputationEngineUnitTest extends GATKB
 
         final List<Event> allEventsAtDeterminedLocus = events.stream().filter(event -> event.getStart() == determinedLocus).toList();
 
-        PartiallyDeterminedHaplotype result = PartiallyDeterminedHaplotypeComputationEngine.createNewPDHaplotypeFromEvents(ref, determinedEvents, determinedLocus, events);
+        // TODO: fix all this
+        /*PartiallyDeterminedHaplotype result = PartiallyDeterminedHaplotypeComputationEngine.createNewPDHaplotypeFromEvents(ref, determinedEvents, determinedLocus, events);
         Assert.assertEquals(new String(result.getBases()), expectedBases);
         Assert.assertEquals(result.getAlternateBases(), expectedAltArray);
-        Assert.assertEquals(result.getCigar(), TextCigarCodec.decode(expectedCigar));
+        Assert.assertEquals(result.getCigar(), TextCigarCodec.decode(expectedCigar));*/
 
         // TODO: replace with determinedSpan
-        Assert.assertEquals(result.getDeterminedPosition(), determinedLocus);
+        //Assert.assertEquals(result.getDeterminedPosition(), determinedLocus);
     }
 
     // NOTE: This is an enforcement of a behavior that I consider to be a bug in DRAGEN. Specifically my assumption that we needn't ever concern
@@ -383,13 +387,14 @@ public class PartiallyDeterminedHaplotypeComputationEngineUnitTest extends GATKB
         Haplotype ref = new Haplotype("AAAAAAAAAA".getBytes(), true, 500, TextCigarCodec.decode("10M"));
         ref.setGenomeLocation(new SimpleInterval("20", 100, 110));
 
-        PartiallyDeterminedHaplotype result = PartiallyDeterminedHaplotypeComputationEngine.createNewPDHaplotypeFromEvents(ref, Set.of(), 105, List.of(DEL_AAAAAAA_102, DEL_AA_105));
+        // TODO: fix all this
+        /*PartiallyDeterminedHaplotype result = PartiallyDeterminedHaplotypeComputationEngine.createNewPDHaplotypeFromEvents(ref, Set.of(), 105, List.of(DEL_AAAAAAA_102, DEL_AA_105));
         Assert.assertEquals(new String(result.getBases()), "AAAAAAAAAA");
         Assert.assertEquals(result.getAlternateBases(), new byte[]{0,0,0,2,0,0,0,0,4,0});
         Assert.assertEquals(result.getCigar(), TextCigarCodec.decode("10M"));
 
         // TODO: replace with determined span
-        Assert.assertEquals(result.getDeterminedPosition(), DEL_AA_105.getStart());
+        Assert.assertEquals(result.getDeterminedPosition(), DEL_AA_105.getStart());*/
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngineUnitTest.java
@@ -341,6 +341,29 @@ public class PartiallyDeterminedHaplotypeComputationEngineUnitTest extends GATKB
                                 Triple.of(List.of(0), List.of(1), new SimpleInterval("20", 105, 105)),   // first SNP haplotype, 2nd SNP undetermined
                                 Triple.of(List.of(), List.of(0), new SimpleInterval("20", 107, 107)),   // ref haplotype (2nd SNP's determined span), 1st SNP undetermined
                                 Triple.of(List.of(1), List.of(0), new SimpleInterval("20", 107, 107)))},  // second SNP haplotype, 1st SNP undetermined
+                {"CTTGAAGACTGAG".getBytes(), List.of(SNP_C_105, SNP_G_105, SNP_C_107), List.of(),      // two overlapping SNPs and one other SNP
+                        Set.of(Triple.of(List.of(), List.of(2), new SimpleInterval("20", 105, 105)),
+                                Triple.of(List.of(0), List.of(2), new SimpleInterval("20", 105, 105)),
+                                Triple.of(List.of(1), List.of(2), new SimpleInterval("20", 105, 105)),
+                                Triple.of(List.of(), List.of(0,1), new SimpleInterval("20", 107, 107)),
+                                Triple.of(List.of(2), List.of(0,1), new SimpleInterval("20", 107, 107)))},
+                {"CTAAAAGACTGAG".getBytes(), List.of(DEL_AAA_102, SNP_G_102, SNP_C_104), List.of(),      // deletion spanning two non-overlapping SNPs
+                        Set.of(Triple.of(List.of(), List.of(), new SimpleInterval("20", 102, 104)),
+                                Triple.of(List.of(0), List.of(), new SimpleInterval("20", 102, 104)),
+                                Triple.of(List.of(1), List.of(), new SimpleInterval("20", 102, 104)),
+                                Triple.of(List.of(2), List.of(), new SimpleInterval("20", 102, 104)),
+                                Triple.of(List.of(1,2), List.of(), new SimpleInterval("20", 102, 104)))},
+                {"CTAAAAAAAAAAA".getBytes(), List.of(DEL_AAA_102, SNP_G_102, SNP_C_104, SNP_C_107), List.of(),      // deletion spanning two non-overlapping SNPs; one other SNP; everything shares an event group due to the STR
+                        Set.of(Triple.of(List.of(), List.of(), new SimpleInterval("20", 102, 107)),
+                                Triple.of(List.of(0), List.of(), new SimpleInterval("20", 102, 107)),
+                                Triple.of(List.of(1), List.of(), new SimpleInterval("20", 102, 107)),
+                                Triple.of(List.of(2), List.of(), new SimpleInterval("20", 102, 107)),
+                                Triple.of(List.of(3), List.of(), new SimpleInterval("20", 102, 107)),
+                                Triple.of(List.of(0,3), List.of(), new SimpleInterval("20", 102, 107)),
+                                Triple.of(List.of(1,2), List.of(), new SimpleInterval("20", 102, 107)),
+                                Triple.of(List.of(1,3), List.of(), new SimpleInterval("20", 102, 107)),
+                                Triple.of(List.of(2,3), List.of(), new SimpleInterval("20", 102, 107)),
+                                Triple.of(List.of(1,2,3), List.of(), new SimpleInterval("20", 102, 107)))}
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngineUnitTest.java
@@ -423,4 +423,19 @@ public class PartiallyDeterminedHaplotypeComputationEngineUnitTest extends GATKB
         Assert.assertTrue(overlaps.test(DEL_AAAAAAA_102, INS_GGG_106));
         Assert.assertTrue(overlaps.test(INS_TT_103, DEL_AAA_102));
     }
+
+    @Test
+    public void testFindSTRs() {
+        final String contig = "CONTIG";
+        final int refStart = 100;
+        // 4 units of AC (8 bases), 9 bases of nothing, 10-base T homopolymer, 6 bases of nothing
+        final String refBases = "ACACACAC" + "GTAGGTACG" + "TTTTTTTTTT" + "ACGCTG";
+        final Haplotype refHaplotype = new Haplotype(refBases.getBytes(), new SimpleInterval(contig, refStart, refStart + refBases.length()));
+
+        final List<SimpleInterval> strs = PartiallyDeterminedHaplotypeComputationEngine.findSTRs(refHaplotype);
+
+        final List<SimpleInterval> expected = List.of(new SimpleInterval(contig, refStart + 0, refStart + 8),
+                new SimpleInterval(contig, refStart + 8 + 9, refStart + 8 + 9 + 10));
+        Assert.assertEquals(strs, expected);
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PartiallyDeterminedHaplotypeComputationEngineUnitTest.java
@@ -190,6 +190,8 @@ public class PartiallyDeterminedHaplotypeComputationEngineUnitTest extends GATKB
         };
     }
 
+    // TODO: update this test: previously the method computed the entire branch, both determined and undetermined
+    // TODO: now the method computes only the event sets for the undetermined part of PD haplotypes
     @Test(dataProvider = "makeBranchesDataProvider")
     public void testMakeBranches(List<Event> eventsInOrder, List<List<Integer>> swMutexes, final int determinedLocus, final OptionalInt determinedEvent,
                                  final List<Set<Integer>> expectedBranchIndices) {
@@ -207,7 +209,7 @@ public class PartiallyDeterminedHaplotypeComputationEngineUnitTest extends GATKB
 
         final List<Event> allEventsAtDeterminedLocus = eventsInOrder.stream().filter(event -> event.getStart() == determinedLocus).toList();
 
-        final Set<Set<Event>> actualBranches = PartiallyDeterminedHaplotypeComputationEngine.computeBranches(eventGroups, determinedEvents, allEventsAtDeterminedLocus)
+        final Set<Set<Event>> actualBranches = PartiallyDeterminedHaplotypeComputationEngine.computeUndeterminedBranches(eventGroups, determinedEvents, allEventsAtDeterminedLocus)
                         .stream().collect(Collectors.toSet());
 
         final Set<Set<Event>> expectedBranches = expectedBranchIndices.stream()


### PR DESCRIPTION
Initial implementation of DRAGEN joint detection.  Functional equivalence with respect to DRAGEN joint detection is actually worse than before due to many outstanding questions.  

We currently have no idea how joint detection is supposed to interaction with BQD and FRD.  I have tried a few guesses and none have worked (see below for functional equivalence results of the particular guess used in this PR).  The interplay of joint detection with BQD and FRD is complicated for several reasons.

Naively one would simply define the BDQ and FRD likelihoods on entire haplotypes rather than alleles at one locus.  Unresolved difficulties with this include:

- BQD and FRD are defined with respect to one particular variant position.  How would we define them for a haplotype that has no particular locus?
- BQD involves the base qualities at one particular variant locus, how would this be defined for an entire haplotype?
- The above is especially thorny for haplotypes that exhibit multiple variants.
- The FRD prior is only defined for individual events, not haplotypes.
- The BQD and FRD models use reads that overlap a variant site, but it is not clear how to use reads that only partially intersect a haplotype.
- BQD and FRD likelihoods are only defined for homozygous haplotypes, but heterozygous combinations of _haplotypes_ contribute to homozygous genotypes all loci where the distinct haplotypes agree.

Clearly, generalizing BQD and FRD to entire haplotypes is not straightforward.  Nor does it suffice to produce "raw" genotype likelihoods using the joint detection approach and then apply BQD and FRD on variant loci afterwards.  Some difficulties with this include:

- BQD and FRD require the read-allele likelihoods matrix.  Where are these likelihoods supposed to come from?  The pre-joint-detection unrigorous "marginalization" where to each allele we assign the maximum likelihood over all haplotypes supporting that allele?  Some read-allele likelihoods matrix derived from the read-haplotype likelihoods matrix?
- The drawbacks of the faulty "marginalization" actually become more severe with joint detection since genotyping multiple alleles together in a single determined span produces more haplotypes, which in turn increases the risk of the read-allele likelihoods cherry-picking from too many different haplotypes for different reads.
- The BQD and FRD models produce likelihoods on an absolute scale that is only meaningful relative to genotyping likelihoods from the pre-joint-detection approach.  They do not inherently "play nicely" with the posterior probabilities produced by joint detection.
- BQD and FRD as currently implemented in the GATK modify likelihoods _before_ applying a prior, whereas joint detection yields posterior probabilities.  Are we supposed to somehow un-apply the prior to joint detection likelihoods, apply BQD and FRD, then re-apply the prior?  It is not clear.