### PR TITLE
Fix GT header in PostprocessGermlineCNVCalls's --output-genotyped-intervals output

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/gcnv/GermlineCNVIntervalVariantComposer.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/gcnv/GermlineCNVIntervalVariantComposer.java
@@ -95,7 +95,7 @@ public final class GermlineCNVIntervalVariantComposer extends GermlineCNVVariant
 
         /* header lines related to genotype formatting */
         result.addMetaDataLine(new VCFFormatHeaderLine(VCFConstants.GENOTYPE_KEY, 1,
-                VCFHeaderLineType.Integer, "Genotype"));
+                VCFHeaderLineType.String, "Genotype"));
         result.addMetaDataLine(new VCFFormatHeaderLine(CN, 1,
                 VCFHeaderLineType.Integer, "Copy number maximum a posteriori value"));
         result.addMetaDataLine(new VCFFormatHeaderLine(CNLP, VCFHeaderLineCount.UNBOUNDED,

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/ReblockGVCFUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantutils/ReblockGVCFUnitTest.java
@@ -408,16 +408,16 @@ public class ReblockGVCFUnitTest extends CommandLineProgramTest {
         result.setSequenceDictionary(dict);
         result.addMetaDataLine(new VCFFormatHeaderLine(VCFConstants.GENOTYPE_KEY, 1,
                 VCFHeaderLineType.String,  "genotype"));
-        result.addMetaDataLine(new VCFFormatHeaderLine(VCFConstants.GENOTYPE_ALLELE_DEPTHS, 1,
-                VCFHeaderLineType.String, "Allele depth"));
+        result.addMetaDataLine(new VCFFormatHeaderLine(VCFConstants.GENOTYPE_ALLELE_DEPTHS, VCFHeaderLineCount.R,
+                VCFHeaderLineType.Integer, "Allele depth"));
         result.addMetaDataLine(new VCFFormatHeaderLine(VCFConstants.DEPTH_KEY, 1,
-                VCFHeaderLineType.String, " depth"));
+                VCFHeaderLineType.Integer, " depth"));
         result.addMetaDataLine(new VCFInfoHeaderLine(VCFConstants.DEPTH_KEY, 1,
-                VCFHeaderLineType.String, " depth"));
+                VCFHeaderLineType.Integer, " depth"));
         result.addMetaDataLine(new VCFFormatHeaderLine(VCFConstants.GENOTYPE_QUALITY_KEY, 1,
-                VCFHeaderLineType.String, "Genotype quality"));
-        result.addMetaDataLine(new VCFFormatHeaderLine(VCFConstants.GENOTYPE_PL_KEY, 1,
-                VCFHeaderLineType.String, "Phred-scaled likelihoods"));
+                VCFHeaderLineType.Integer, "Genotype quality"));
+        result.addMetaDataLine(new VCFFormatHeaderLine(VCFConstants.GENOTYPE_PL_KEY, VCFHeaderLineCount.G,
+                VCFHeaderLineType.Integer, "Phred-scaled likelihoods"));
         gvcfWriter.writeHeader(result);
         return gvcfWriter;
     }


### PR DESCRIPTION
PostprocessGermlineCNVCalls produces a GT header like this in one of its output files:

```
##FORMAT=<ID=GT,Number=1,Type=Integer,Description="Genotype">
```

which should have been `Type=String`. Incorrectly writing this as `Type=Integer` produces invalid VCF files and in particular causes bcftools to misparse records' genotype fields.

I searched for other similar problems and noted the inconsistencies in _ReblockGVCFUnitTest.java_. However this probably isn't causing any actual problems, so you may wish to include only the first commit — which very much is causing production problems.