### PR TITLE
Reduce SVConcordance memory footprint

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/SVCallRecord.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/SVCallRecord.java
@@ -132,8 +132,12 @@ public class SVCallRecord implements SVLocatable {
         Utils.nonNull(dictionary);
         validatePosition(contigA, positionA, dictionary);
         validatePosition(contigB, positionB, dictionary);
-        Utils.validateArg(IntervalUtils.compareLocatables(getPositionAInterval(), getPositionBInterval(), dictionary) <= 0,
-                "End coordinate cannot precede start");
+        // CPX types may have position B precede A, such as dispersed duplications where A is the insertion point and
+        // B references the source sequence.
+        if (type != GATKSVVCFConstants.StructuralVariantAnnotationType.CPX) {
+            Utils.validateArg(IntervalUtils.compareLocatables(getPositionAInterval(), getPositionBInterval(), dictionary) <= 0,
+                    "End coordinate cannot precede start");
+        }
     }
 
     private static void validatePosition(final String contig, final int position, final SAMSequenceDictionary dictionary) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVConcordance.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVConcordance.java
@@ -148,6 +148,9 @@ public final class SVConcordance extends AbstractConcordanceWalker {
         final SVConcordanceAnnotator collapser = new SVConcordanceAnnotator(commonSamples);
         engine = new ClosestSVFinder(linkage, collapser::annotate, !doNotSort, dictionary);
 
+        if (doNotSort) {
+            createOutputVariantIndex = false;
+        }
         writer = createVCFWriter(outputFile);
         writer.writeHeader(createHeader(getEvalHeader()));
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVConcordance.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVConcordance.java
@@ -52,7 +52,7 @@ import java.util.stream.Collectors;
  * of the specific fields. For multi-allelic CNVs, only a copy state concordance metric is
  * annotated. Allele frequencies will be recalculated automatically if unavailable in the provided VCFs.
  *
- * Note that the output is unsorted.
+ * For large inputs, users may enable the --do-not-sort flag to reduce memory usage.
  *
  * <h3>Inputs</h3>
  *
@@ -69,7 +69,7 @@ import java.util.stream.Collectors;
  *
  * <ul>
  *     <li>
- *         The evaluation VCF annotated with genotype concordance metrics (unsorted)
+ *         The evaluation VCF annotated with genotype concordance metrics
  *     </li>
  * </ul>
  *

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVConcordanceIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVConcordanceIntegrationTest.java
@@ -38,7 +38,7 @@ public class SVConcordanceIntegrationTest extends CommandLineProgramTest {
 
     @Test
     public void testRefPanel() {
-        final File output = createTempFile("concord", ".vcf");
+        final File output = createTempFile("concord", ".vcf.gz");
         final String evalVcfPath = getToolTestDataDir() + "ref_panel_1kg.cleaned.gatk.chr22_chrY.vcf.gz";
         /**
          * Test file produced from raw standardized VCFs from manta, melt, wham, and cnv callers with SVCluster parameters:
@@ -171,7 +171,7 @@ public class SVConcordanceIntegrationTest extends CommandLineProgramTest {
 
         // Run a vcf against itself and check that every variant matched itself
 
-        final File output = createTempFile("concord", ".vcf");
+        final File output = createTempFile("concord", ".vcf.gz");
         final String vcfPath = getToolTestDataDir() + "ref_panel_1kg.cleaned.gatk.chr22_chrY.vcf.gz";
 
         final ArgumentsBuilder args = new ArgumentsBuilder()
@@ -260,7 +260,7 @@ public class SVConcordanceIntegrationTest extends CommandLineProgramTest {
 
         // Run a vcf against itself but with extra samples and variants
 
-        final File output = createTempFile("concord", ".vcf");
+        final File output = createTempFile("concord", ".vcf.gz");
         final String evalVcfPath = getToolTestDataDir() + "ref_panel_1kg.cleaned.gatk.chr22_chrY.sample_subset.vcf.gz";
         final String truthVcfPath = getToolTestDataDir() + "ref_panel_1kg.cleaned.gatk.chr22_chrY.vcf.gz";
 
@@ -322,7 +322,7 @@ public class SVConcordanceIntegrationTest extends CommandLineProgramTest {
 
     @Test
     public void testSitesOnly() {
-        final File output = createTempFile("concord_sites_only", ".vcf");
+        final File output = createTempFile("concord_sites_only", ".vcf.gz");
         final String evalVcfPath = getToolTestDataDir() + "ref_panel_1kg.cleaned.gatk.chr22_chrY.sites_only.vcf.gz";
         final String truthVcfPath = getToolTestDataDir() + "ref_panel_1kg.raw_calls.chr22_chrY.sites_only.vcf.gz";
 
@@ -358,7 +358,7 @@ public class SVConcordanceIntegrationTest extends CommandLineProgramTest {
 
     @Test(expectedExceptions = UserException.IncompatibleSequenceDictionaries.class)
     public void testHeaderContigsOutOfOrder() {
-        final File output = createTempFile("concord_sites_only", ".vcf");
+        final File output = createTempFile("concord_sites_only", ".vcf.gz");
         final String evalVcfPath = getToolTestDataDir() + "ref_panel_1kg.cleaned.gatk.chr22_chrY.vcf.gz";
         final String truthVcfPath = getToolTestDataDir() + "ref_panel_1kg.cleaned.gatk.chr22_chrY.contigs_out_of_order.vcf.gz";
 
@@ -372,13 +372,13 @@ public class SVConcordanceIntegrationTest extends CommandLineProgramTest {
     }
 
     @Test
-    public void testSelfTruthSubsetUnsorted() {
+    public void testSelfUnsorted() {
 
-        // Run a vcf against itself but subsetted to fewer samples and variants
+        // Run a vcf against itself but don't sort the output
 
         final File output = createTempFile("concord", ".vcf");
         final String evalVcfPath = getToolTestDataDir() + "ref_panel_1kg.cleaned.gatk.chr22_chrY.vcf.gz";
-        final String truthVcfPath = getToolTestDataDir() + "ref_panel_1kg.cleaned.gatk.chr22_chrY.sample_subset.vcf.gz";
+        final String truthVcfPath = getToolTestDataDir() + "ref_panel_1kg.cleaned.gatk.chr22_chrY.vcf.gz";
 
         final ArgumentsBuilder args = new ArgumentsBuilder()
                 .addOutput(output)

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVConcordanceIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVConcordanceIntegrationTest.java
@@ -370,4 +370,24 @@ public class SVConcordanceIntegrationTest extends CommandLineProgramTest {
 
         runCommandLine(args, SVConcordance.class.getSimpleName());
     }
+
+    @Test
+    public void testSelfTruthSubsetUnsorted() {
+
+        // Run a vcf against itself but subsetted to fewer samples and variants
+
+        final File output = createTempFile("concord", ".vcf");
+        final String evalVcfPath = getToolTestDataDir() + "ref_panel_1kg.cleaned.gatk.chr22_chrY.vcf.gz";
+        final String truthVcfPath = getToolTestDataDir() + "ref_panel_1kg.cleaned.gatk.chr22_chrY.sample_subset.vcf.gz";
+
+        final ArgumentsBuilder args = new ArgumentsBuilder()
+                .addOutput(output)
+                .add(StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, GATKBaseTest.FULL_HG38_DICT)
+                .add(AbstractConcordanceWalker.EVAL_VARIANTS_LONG_NAME, evalVcfPath)
+                .add(AbstractConcordanceWalker.TRUTH_VARIANTS_LONG_NAME, truthVcfPath)
+                .add(SVConcordance.UNSORTED_OUTPUT_LONG_NAME, true);
+
+        runCommandLine(args, SVConcordance.class.getSimpleName());
+        assertPerfectConcordance(output, evalVcfPath);
+    }
 }


### PR DESCRIPTION
The SVConcordance tool is currently too inefficient in terms of memory usage, requiring several 100's of GB of heap space on ~100K samples. This PR aims to reduce memory usage in two ways:

1. Truth VCF records are stripped of all genotype fields except `GT` and `CN`, which are necessary and sufficient for concordance computations.
2. A new option `--do-not-sort` is introduced to skip output record sorting. A major source of heap usage is the output buffer in the `ClosestSVFinder` class, which ensures records are emitted in coordinate-sorted order. This buffer quickly fills, however, when there is at least one record being actively clustered that spans a large interval because the buffer cannot be flushed until a variant beyond the maximal clusterable coordinate of that large variant is encountered. This option will allow users to substantially reduce max heap usage on larger call sets (a single SVRecord can consume ~100MB with 100K samples).

Includes an integration test to cover the `--do-not-sort` functionality.