### PR TITLE
LearnReadOrientationModel loads tables for one ref context at a time, reducing memory demands 32x

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/readorientation/F1R2CountsCollector.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/readorientation/F1R2CountsCollector.java
@@ -231,4 +231,8 @@ public class F1R2CountsCollector {
     public static List<File> getAltTablesFromExtractedTar(final File extractedTarDir) {
         return Arrays.stream(extractedTarDir.listFiles()).filter(file -> file.getAbsolutePath().endsWith(ALT_TABLE_EXTENSION)).collect(Collectors.toList());
     }
+
+    public static List<File> getAltTablesFromExtractedTar(final File extractedTarDir, final String refContext) {
+        return Arrays.stream(extractedTarDir.listFiles()).filter(file -> file.getAbsolutePath().endsWith(refContext + ALT_TABLE_EXTENSION)).collect(Collectors.toList());
+    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/readorientation/LearnReadOrientationModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/readorientation/LearnReadOrientationModel.java
@@ -159,7 +159,7 @@ public class LearnReadOrientationModel extends CommandLineProgram {
                 final List<AltSiteRecord> altDesignMatrixRevComp = reverseRecordsBySample.getOrDefault(sample, Collections.emptyList());
                 // Warning: the below method will mutate the content of {@link altDesignMatrixRevComp} and append to {@code altDesignMatrix}
                 mergeDesignMatrices(altDesignMatrix, altDesignMatrixRevComp);
-                
+
                 if (combinedRefHistograms.getSumOfValues() == 0 || altDesignMatrix.isEmpty()) {
                     logger.info(String.format("Skipping the reference context %s as we didn't find either the ref or alt table for the context", refContext));
                     continue;

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/readorientation/CollectF1R2CountsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/readorientation/CollectF1R2CountsIntegrationTest.java
@@ -48,7 +48,6 @@ public class CollectF1R2CountsIntegrationTest extends CommandLineProgramTest {
         IOUtils.extractTarGz(outputTarGz.toPath(), extractedDir.toPath());
 
         final File refHistogramFile = F1R2CountsCollector.getRefHistogramsFromExtractedTar(extractedDir).stream().findFirst().get();
-        final File altTableFile = F1R2CountsCollector.getAltTablesFromExtractedTar(extractedDir).stream().findFirst().get();
 
         final MetricsFile<?, Integer> referenceSiteMetrics = new MetricsFile<>();
         final Reader in = IOUtil.openFileForBufferedReading(refHistogramFile);
@@ -56,7 +55,6 @@ public class CollectF1R2CountsIntegrationTest extends CommandLineProgramTest {
         CloserUtil.close(in);
 
         List<Histogram<Integer>> histograms = referenceSiteMetrics.getAllHistograms();
-        List<AltSiteRecord> altDesignMatrix = AltSiteRecord.readAltSiteRecords(altTableFile.toPath()).getRight();
 
         /** Expected result
          *
@@ -85,30 +83,33 @@ public class CollectF1R2CountsIntegrationTest extends CommandLineProgramTest {
          **/
 
         // alt site tests
-        Assert.assertEquals(altDesignMatrix.size(), 4);
-        AltSiteRecord recordCAC = altDesignMatrix.stream().
-                filter(rec -> rec.getReferenceContext().equals("CAC")).findFirst().get();
+        final File altTableFileCAC = F1R2CountsCollector.getAltTablesFromExtractedTar(extractedDir, "CAC").stream().findFirst().get();
+        List<AltSiteRecord> altDesignMatrixCAC = AltSiteRecord.readAltSiteRecords(altTableFileCAC.toPath()).getRight();
+        AltSiteRecord recordCAC = altDesignMatrixCAC.get(0);
         Assert.assertEquals(recordCAC.getRefCount(), 70);
         Assert.assertEquals(recordCAC.getAltCount(), 30);
         Assert.assertEquals(recordCAC.getRefF1R2(), 35);
         Assert.assertEquals(recordCAC.getAltF1R2(), 15);
 
-        AltSiteRecord recordTAA = altDesignMatrix.stream().
-                filter(rec -> rec.getReferenceContext().equals("TAA")).findFirst().get();
+        final File altTableFileTAA = F1R2CountsCollector.getAltTablesFromExtractedTar(extractedDir, "TAA").stream().findFirst().get();
+        List<AltSiteRecord> altDesignMatrixTAA = AltSiteRecord.readAltSiteRecords(altTableFileCAC.toPath()).getRight();
+        AltSiteRecord recordTAA = altDesignMatrixCAC.get(0);
         Assert.assertEquals(recordTAA.getRefCount(), 70);
         Assert.assertEquals(recordTAA.getAltCount(), 30);
         Assert.assertEquals(recordTAA.getRefF1R2(), 35);
         Assert.assertEquals(recordTAA.getAltF1R2(), 15);
 
-        AltSiteRecord recordAGC = altDesignMatrix.stream().
-                filter(rec -> rec.getReferenceContext().equals("AGC")).findFirst().get();
+        final File altTableFileAGC = F1R2CountsCollector.getAltTablesFromExtractedTar(extractedDir, "AGC").stream().findFirst().get();
+        List<AltSiteRecord> altDesignMatrixAGC = AltSiteRecord.readAltSiteRecords(altTableFileCAC.toPath()).getRight();
+        AltSiteRecord recordAGC = altDesignMatrixCAC.get(0);
         Assert.assertEquals(recordAGC.getRefCount(), 70);
         Assert.assertEquals(recordAGC.getAltCount(), 30);
         Assert.assertEquals(recordAGC.getRefF1R2(), 35);
         Assert.assertEquals(recordAGC.getAltF1R2(), 15);
 
-        AltSiteRecord recordACA = altDesignMatrix.stream().
-                filter(rec -> rec.getReferenceContext().equals("ACA")).findFirst().get();
+        final File altTableFileACA = F1R2CountsCollector.getAltTablesFromExtractedTar(extractedDir, "ACA").stream().findFirst().get();
+        List<AltSiteRecord> altDesignMatrixACA = AltSiteRecord.readAltSiteRecords(altTableFileCAC.toPath()).getRight();
+        AltSiteRecord recordACA = altDesignMatrixCAC.get(0);
         Assert.assertEquals(recordACA.getRefCount(), 70);
         Assert.assertEquals(recordACA.getAltCount(), 30);
         Assert.assertEquals(recordACA.getRefF1R2(), 35);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/readorientation/LearnReadOrientationModelUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/readorientation/LearnReadOrientationModelUnitTest.java
@@ -75,12 +75,11 @@ public class LearnReadOrientationModelUnitTest extends CommandLineProgramTest {
 
         final File altHistUnscattered = F1R2CountsCollector.getAltHistogramsFromExtractedTar(extractedDir).get(0);
 
-        final File altTableUnscattered = F1R2CountsCollector.getAltTablesFromExtractedTar(extractedDir).get(0);
+        final List<File> altTablesUnscattered = F1R2CountsCollector.getAltTablesFromExtractedTar(extractedDir);
+        final List<AltSiteRecord> altSitesTruth = LearnReadOrientationModel.gatherAltSiteRecords(altTablesUnscattered).get("SM-CEMAH");
 
         final List<Histogram<Integer>> refTruth = LearnReadOrientationModel.readMetricsFile(refHistUnscattered).getAllHistograms();
         final List<Histogram<Integer>> altTruth = LearnReadOrientationModel.readMetricsFile(altHistUnscattered).getAllHistograms();
-        final List<AltSiteRecord> altSitesTruth = AltSiteRecord.readAltSiteRecords(altTableUnscattered.toPath()).getRight();
-
 
         for (Histogram<Integer> truth : refTruth){
             final Histogram<Integer> eval = ref.stream().filter(h -> h.getValueLabel().equals(truth.getValueLabel())).findAny().get();


### PR DESCRIPTION
Closes #7948 