### PR TITLE
Adds option to write sample names in variantCounts

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/AnalyzeSaturationMutagenesis.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/AnalyzeSaturationMutagenesis.java
@@ -1955,10 +1955,6 @@ public final class AnalyzeSaturationMutagenesis extends GATKTool {
                 final ReadReport combinedReport = new ReadReport(report1, report2);
                 final ReportType reportType = combinedReport.updateCounts(codonTracker, variationCounts, reference);
                 disjointPairCounts.bumpCount(reportType);
-                if ( reportType.attributeValue != null && rejectedReadsBAMWriter != null ) {
-                    read1.setAttribute(ReportType.REPORT_TYPE_ATTRIBUTE_KEY, reportType.attributeValue);
-                    read2.setAttribute(ReportType.REPORT_TYPE_ATTRIBUTE_KEY, reportType.attributeValue);
-                }
             } else { // mates are disjoint, use the first one
                 final ReportType ignoredMate = ReportType.IGNORED_MATE;
                 if ( read1.isFirstOfPair() ) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/AnalyzeSaturationMutagenesis.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/AnalyzeSaturationMutagenesis.java
@@ -1970,7 +1970,7 @@ public final class AnalyzeSaturationMutagenesis extends GATKTool {
                         rejectedReadsBAMWriter.addRead(read1);
                     }
                 }
-                disjointPairCounts.bumpCount(reportType);
+                disjointPairCounts.bumpCount(ignoredMate);
             }
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/AnalyzeSaturationMutagenesis.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/AnalyzeSaturationMutagenesis.java
@@ -131,8 +131,8 @@ public final class AnalyzeSaturationMutagenesis extends GATKTool {
     @Argument(doc = "paired mode evaluation of variants (combine mates, when possible)", fullName = "paired-mode")
     private static boolean pairedMode = true;
 
-    @Argument(doc = "don't discard disjoint mates (combine variants from both reads)", fullName = "dont-ignore")
-    private static boolean noIgnore = false;
+    @Argument(doc = "don't discard disjoint mates (i.e., combine variants from both reads)", fullName = "dont-ignore-disjoint-pairs")
+    private static boolean noIgnoreDisjointPairs = false;
 
     @Argument(doc = "write BAM of rejected reads", fullName = "write-rejected-reads")
     private static boolean writeRejectedReads = false;
@@ -1951,15 +1951,13 @@ public final class AnalyzeSaturationMutagenesis extends GATKTool {
                     read2.setAttribute(ReportType.REPORT_TYPE_ATTRIBUTE_KEY, reportType.attributeValue);
                     rejectedReadsBAMWriter.addRead(read2);
                 }
-            } else if (noIgnore) { // mates are disjoint, process both
+            } else if (noIgnoreDisjointPairs) { // mates are disjoint, process both
                 final ReadReport combinedReport = new ReadReport(report1, report2);
                 final ReportType reportType = combinedReport.updateCounts(codonTracker, variationCounts, reference);
                 disjointPairCounts.bumpCount(reportType);
                 if ( reportType.attributeValue != null && rejectedReadsBAMWriter != null ) {
                     read1.setAttribute(ReportType.REPORT_TYPE_ATTRIBUTE_KEY, reportType.attributeValue);
-                    rejectedReadsBAMWriter.addRead(read1);
                     read2.setAttribute(ReportType.REPORT_TYPE_ATTRIBUTE_KEY, reportType.attributeValue);
-                    rejectedReadsBAMWriter.addRead(read2);
                 }
             } else { // mates are disjoint, use the first one
                 final ReportType ignoredMate = ReportType.IGNORED_MATE;
@@ -1976,6 +1974,7 @@ public final class AnalyzeSaturationMutagenesis extends GATKTool {
                         rejectedReadsBAMWriter.addRead(read1);
                     }
                 }
+                disjointPairCounts.bumpCount(reportType);
             }
         }
     }


### PR DESCRIPTION
In some cases it may be useful to know what reads are giving rise to which specific variants. I have run into several cases while debugging some strange results where this would be useful to know, and also there is a QC workflow we would like to implement where this would be essential information. This is unlikely to be generally useful, however.

This PR adds a flag, `--write-qnames`, which will, for each variant, write the list of qnames in the bam that give rise to that variant as a comma separated list in the final column.

This PR also makes synonymous variants (with no protein-level consequence) write an empty value rather than nothing, in order to keep column order.

This seems to work with SE reads, but hasn't been tested much with PE reads.

This should also probably not parse read names by default, but only if write-qnames is set.