### PR TITLE
Replace LGT with GT within hail_create_vat_inputs.py [VS-1195]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -146,7 +146,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - VS-1063-bit-pack-ref-ranges-data-into-a-more-efficient-representation
          tags:
              - /.*/
    - name: GvsCreateVDS
@@ -166,7 +165,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1127_extract_oom
          tags:
              - /.*/
    - name: GvsImportGenomes
@@ -196,7 +194,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - rsa_vs_597
          tags:
              - /.*/
    - name: GvsCreateVATfromVDS
@@ -253,7 +250,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - rsa_vs_1146
          tags:
              - /.*/
    - name: GvsBeta
@@ -274,7 +270,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - bulk_ingest_staging
          tags:
              - /.*/
    - name: GvsCalculatePrecisionAndSensitivity
@@ -311,7 +306,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - rsa_vs_1146
+             - rsa_vs_1195
          tags:
              - /.*/
    - name: GvsIngestTieout
@@ -357,7 +352,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1022_vds_cleanup
          tags:
              - /.*/
    - name: HailFromWdl

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -72,7 +72,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
-    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2023-12-14-alpine-2476d080b"
+    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2024-01-17-alpine-8edbc460d"
     String gatk_docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2023_10_31_e7746ce7c38a8226bcac5b89284782de2a4cdda1"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/extract/hail_create_vat_inputs.py
+++ b/scripts/variantstore/wdl/extract/hail_create_vat_inputs.py
@@ -10,7 +10,7 @@ import create_vat_inputs
 # filtering:
 # hard filter bad sites: hard_filter_non_passing_sites()
 # hard filter based on FT flag:
-# get GT, replace_lgt_with_gt(), swap to no-calls: failing_gts_to_no_call(), (no longer need to replace_lgt_with_gt now that lgt is included in the VDS)
+# get GT, replace_lgt_with_gt(), swap to no-calls: failing_gts_to_no_call()
 # track how many sites have more than 50 alt alleles TODO: we currently aren't tracking this, are we?
 # drop 50+ alternate alleles
 # calculate the AC, AN, AF, SC, for the full population and for the subpopulations

--- a/scripts/variantstore/wdl/extract/hail_create_vat_inputs.py
+++ b/scripts/variantstore/wdl/extract/hail_create_vat_inputs.py
@@ -54,7 +54,8 @@ def failing_gts_to_no_call(vds):
      FT is False => GT assigned no-call
      FT is missing => GT keeps its current value
     """
-    vd = vds.variant_data
+    gt_vds = replace_lgt_with_gt(vds)
+    vd = gt_vds.variant_data
     filtered_vd = vd.annotate_entries(GT=hl.or_missing(hl.coalesce(vd.FT, True), vd.GT))
     # GT will not line up with the LGT but this version of the VDS data will be sliced and not fully moved anywhere
     return hl.vds.VariantDataset(vds.reference_data, filtered_vd)

--- a/scripts/variantstore/wdl/extract/hail_create_vat_inputs.py
+++ b/scripts/variantstore/wdl/extract/hail_create_vat_inputs.py
@@ -10,7 +10,7 @@ import create_vat_inputs
 # filtering:
 # hard filter bad sites: hard_filter_non_passing_sites()
 # hard filter based on FT flag:
-# get GT, ~replace_lgt_with_gt()~, swap to no-calls: failing_gts_to_no_call(), (no longer need to replace_lgt_with_gt now that lgt is included in the VDS)
+# get GT, replace_lgt_with_gt(), swap to no-calls: failing_gts_to_no_call(), (no longer need to replace_lgt_with_gt now that lgt is included in the VDS)
 # track how many sites have more than 50 alt alleles TODO: we currently aren't tracking this, are we?
 # drop 50+ alternate alleles
 # calculate the AC, AN, AF, SC, for the full population and for the subpopulations


### PR DESCRIPTION
sites-only VCF created with VDS, ancestry file and `hail_create_vat_inputs.py` script  from this branch here: gs://fc-93670912-8238-4968-a446-efb36e7dfeb5/vat_inputs/quickstart_v2.vcf.gz