### PR TITLE
normal artifact lod is now defined without the extra minus sign

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
@@ -176,7 +176,7 @@ public class SomaticGenotypingEngine implements AutoCloseable {
 
             if (hasNormal) {
                 callVcb.attribute(GATKVCFConstants.NORMAL_ARTIFACT_LOG_10_ODDS_KEY,
-                        Arrays.stream(normalArtifactLogOdds.asDoubleArray(tumorAltAlleles)).map(x->-MathUtils.logToLog10(x)).toArray());
+                        Arrays.stream(normalArtifactLogOdds.asDoubleArray(tumorAltAlleles)).map(x->MathUtils.logToLog10(x)).toArray());
                 callVcb.attribute(GATKVCFConstants.NORMAL_LOG_10_ODDS_KEY,
                         Arrays.stream(normalLogOdds.asDoubleArray(tumorAltAlleles)).map(MathUtils::logToLog10).toArray());
             }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/filtering/NormalArtifactFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/filtering/NormalArtifactFilter.java
@@ -45,7 +45,7 @@ public class NormalArtifactFilter extends Mutect2VariantFilter {
             return 0.0;
         }
 
-        final double[] normalArtifactNegativeLogOdds = MathUtils.applyToArrayInPlace(VariantContextGetters.getAttributeAsDoubleArray(vc, GATKVCFConstants.NORMAL_ARTIFACT_LOG_10_ODDS_KEY), MathUtils::log10ToLog);
+        final double[] normalArtifactNegativeLogOdds = MathUtils.applyToArrayInPlace(VariantContextGetters.getAttributeAsDoubleArray(vc, GATKVCFConstants.NORMAL_ARTIFACT_LOG_10_ODDS_KEY), x -> -MathUtils.log10ToLog(x));
         final double normalArtifactProbability = filteringEngine.posteriorProbabilityOfNormalArtifact(normalArtifactNegativeLogOdds[indexOfMaxTumorLod]);
 
         // the normal artifact log odds misses artifacts whose support in the normal consists entirely of low base quality reads

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFHeaderLines.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVCFHeaderLines.java
@@ -235,7 +235,7 @@ public class GATKVCFHeaderLines {
         addInfoLine(new VCFInfoHeaderLine(STRAND_QUAL_KEY, 1, VCFHeaderLineType.Integer, "Phred-scaled quality of strand bias artifact"));
         addInfoLine(new VCFInfoHeaderLine(CONTAMINATION_QUAL_KEY, 1, VCFHeaderLineType.Float, "Phred-scaled qualities that alt allele are not due to contamination"));
         addInfoLine(new VCFInfoHeaderLine(READ_ORIENTATION_QUAL_KEY, 1, VCFHeaderLineType.Float, "Phred-scaled qualities that alt allele are not due to read orientation artifact"));
-        addInfoLine(new VCFInfoHeaderLine(NORMAL_ARTIFACT_LOG_10_ODDS_KEY, VCFHeaderLineCount.A, VCFHeaderLineType.Float, "Negative log 10 odds of artifact in normal with same allele fraction as tumor"));
+        addInfoLine(new VCFInfoHeaderLine(NORMAL_ARTIFACT_LOG_10_ODDS_KEY, VCFHeaderLineCount.A, VCFHeaderLineType.Float, "Log 10 odds of artifact in normal with same allele fraction as tumor"));
         addInfoLine(new VCFInfoHeaderLine(ORIGINAL_CONTIG_MISMATCH_KEY, 1, VCFHeaderLineType.Integer, "Number of alt reads whose original alignment doesn't match the current contig."));
         addInfoLine(new VCFInfoHeaderLine(N_COUNT_KEY, 1, VCFHeaderLineType.Integer, "Count of N bases in the pileup"));
         addInfoLine(new VCFInfoHeaderLine(AS_UNIQUE_ALT_READ_SET_COUNT_KEY, VCFHeaderLineCount.A, VCFHeaderLineType.Integer, "Number of reads with unique start and mate end positions for each alt at a variant site"));

--- a/src/test/resources/org/broadinstitute/hellbender/tools/mutect/expected.testExposureOfSmithWatermanParameters.M2.gatk4.vcf
+++ b/src/test/resources/org/broadinstitute/hellbender/tools/mutect/expected.testExposureOfSmithWatermanParameters.M2.gatk4.vcf
@@ -22,7 +22,7 @@
 ##INFO=<ID=MFRL,Number=R,Type=Integer,Description="median fragment length by allele">
 ##INFO=<ID=MMQ,Number=R,Type=Integer,Description="median mapping quality by allele">
 ##INFO=<ID=MPOS,Number=A,Type=Integer,Description="median distance from end of read">
-##INFO=<ID=NALOD,Number=A,Type=Float,Description="Negative log 10 odds of artifact in normal with same allele fraction as tumor">
+##INFO=<ID=NALOD,Number=A,Type=Float,Description="Log 10 odds of artifact in normal with same allele fraction as tumor">
 ##INFO=<ID=NCount,Number=1,Type=Integer,Description="Count of N bases in the pileup">
 ##INFO=<ID=NLOD,Number=A,Type=Float,Description="Normal log 10 likelihood ratio of diploid het or hom alt genotypes">
 ##INFO=<ID=OCM,Number=1,Type=Integer,Description="Number of alt reads whose original alignment doesn't match the current contig.">


### PR DESCRIPTION
This fixes a small math error in Permutect that was harming precision in tumor-normal mode.