### PR TITLE
Combining aws-java-nio-spi-for-s3 with GATK.

### DIFF
--- a/gatk
+++ b/gatk
@@ -32,6 +32,7 @@ GATK_RUN_SCRIPT = BUILD_LOCATION + projectName
 GATK_LOCAL_JAR_ENV_VARIABLE = "GATK_LOCAL_JAR"
 GATK_SPARK_JAR_ENV_VARIABLE = "GATK_SPARK_JAR"
 BIN_PATH = script + "/build/libs"
+NIO_SPI_S3_JAR = "src/main/resources/org/broadinstitute/hellbender/tools/aws/nio-spi-for-s3-2.0.0-dev-all.jar"
 
 EXTRA_JAVA_OPTIONS_SPARK= "-DGATK_STACKTRACE_ON_USER_EXCEPTION=true " \
                    "-Dsamjdk.use_async_io_read_samtools=false " \
@@ -121,6 +122,7 @@ def main(args):
             print("   --debug-suspend       sets the Java VM debug agent up so that the run get immediatelly suspended")
             print("                         waiting for a debugger to connect. By default the port number is 5005 but")
             print("                         can be customized using --debug-port")
+            print("   --s3                  (IN DEV) sets up GATK to use Amazon S3 as the default storage backend")
             sys.exit(0)
 
         if len(args) == 1 and args[0] == "--list":
@@ -131,6 +133,10 @@ def main(args):
             dryRun = True
             args.remove("--dry-run")
 
+        aws_s3 = "--s3" in args
+        if aws_s3:
+            aws_s3 = True
+            args.remove("--s3")
 
         debugPort = getValueForArgument(args, "--debug-port")
         if debugPort is not None:
@@ -174,7 +180,7 @@ def main(args):
             del sparkArgs[i] #and its parameter
             gatkArgs += ["--spark-master", sparkMaster]
 
-        runGATK(sparkRunner, sparkSubmitCommand, dryRun, gatkArgs, sparkArgs, javaOptions, debugPort, debugSuspend)
+        runGATK(sparkRunner, sparkSubmitCommand, dryRun, gatkArgs, sparkArgs, javaOptions, debugPort, debugSuspend, aws_s3)
 
     except GATKLaunchException as e:
         sys.stderr.write(str(e)+"\n")
@@ -202,7 +208,7 @@ def getGCloudSubmitCommand(gcloudCmd):
     else:
         return gcloudCmd
 
-def getLocalGatkRunCommand(javaOptions, debugPort, debugSuspend):
+def getLocalGatkRunCommand(javaOptions, debugPort, debugSuspend, aws_s3):
     localJarFromEnv = getJarFromEnv(GATK_LOCAL_JAR_ENV_VARIABLE)
 
     # Add java options to our packaged local jar options
@@ -217,7 +223,7 @@ def getLocalGatkRunCommand(javaOptions, debugPort, debugSuspend):
             
 
     if localJarFromEnv is not None:
-        return formatLocalJarCommand(localJarFromEnv)
+        return formatLocalJarCommand(localJarFromEnv, aws_s3)
 
     wrapperScript = getGatkWrapperScript(throwIfNotFound=False)
     if wrapperScript is not None:
@@ -233,11 +239,15 @@ def getLocalGatkRunCommand(javaOptions, debugPort, debugSuspend):
 
         return [wrapperScript]
     
-    return formatLocalJarCommand(getLocalJar())  # will throw if local jar not found
+    return formatLocalJarCommand(getLocalJar(), aws_s3)  # will throw if local jar not found
 
 
-def formatLocalJarCommand(localJar):
-    return ["java"] + PACKAGED_LOCAL_JAR_OPTIONS + [ "-jar", localJar]
+def formatLocalJarCommand(localJar, aws_s3):
+    if aws_s3:
+        classpath = "{aws_jar}:{local_jar}".format(aws_jar=NIO_SPI_S3_JAR,local_jar=localJar)
+        return ["java"] + PACKAGED_LOCAL_JAR_OPTIONS + ["-classpath", classpath, "org.broadinstitute.hellbender.Main"]
+    else:
+        return ["java"] + PACKAGED_LOCAL_JAR_OPTIONS + [ "-jar", localJar]
 
 def getGatkWrapperScript(throwIfNotFound=True):
     if not os.path.exists(GATK_RUN_SCRIPT):
@@ -354,9 +364,9 @@ def cacheJarOnGCS(jar, dryRun):
             return jar
 
 
-def runGATK(sparkRunner, suppliedSparkSubmitCommand, dryrun, gatkArgs, sparkArgs, javaOptions, debugPort, debugSuspend):
+def runGATK(sparkRunner, suppliedSparkSubmitCommand, dryrun, gatkArgs, sparkArgs, javaOptions, debugPort, debugSuspend, aws_s3):
     if sparkRunner is None or sparkRunner == "LOCAL":
-        cmd = getLocalGatkRunCommand(javaOptions, debugPort, debugSuspend) + gatkArgs + sparkArgs
+        cmd = getLocalGatkRunCommand(javaOptions, debugPort, debugSuspend, aws_s3) + gatkArgs + sparkArgs
         runCommand(cmd, dryrun)
     elif sparkRunner == "SPARK":
         sparkSubmitCmd = getSparkSubmitCommand(suppliedSparkSubmitCommand)


### PR DESCRIPTION
# Introduction
Recently, Amazon has created the tool [aws-java-nio-spi-for-s3](https://github.com/awslabs/aws-java-nio-spi-for-s3) that allows java-based applications to read and/or write to aws without the need for recompilation during runtime. Since then, we've utilised this tool, in conjunction with a locally modified version of gatk, to communicate with aws. Since we had the code that allows for communication with aws anyway, we decided to share it and maybe it can be part of the gatk toolkit in the future.

# How does it work?
The user is able to provide an additional parameter '--s3', adding the nio-spi-for-s3-2.0.0-dev-all.jar file to the java classpath. File locations starting with 's3://' are then able to be provided, resulting of reading/writing of these files to aws. When using this option, however, the aws credentials have to be set correctly, for which you can find more information [here](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html). Currently, I haven't implemented it for --spark due to a lack of need/inexperience with spark.

# Current Issues
We found some issues for which we do not know any solution. If this tool was to be implemented in GATK in the future, these have to be resolved eventually.

## Doesn't work for picard-based tools
First, 'aws-java-nio-spi-for-s3' doesn't seem work for (most) picard tools, since most of them utilise the java.io.File package, which is limited to local filesystem files, as opposed to java.nio.Path (we think).
## Issues reading genome reference files from AWS
Secondy, most tools that require a reference genome (i.e. BaseRecalibrator, HaplotypeCaller..) do not seem function when provided with a reference genome file stored on AWS. The error we receive can be found underneath and is much less clear. We believe that the issue lies in the interaction between the caching of the indexed reference file and 'aws-java-nio-spi-for-s3', since we tested in a custom java script that the package 'htsjdk' works like intended when the reference genome is read from AWS.
Notably, some tools do not have this issue, such as the the vqsr tools (VariantRecalibrator and applyVQSR).
![image](https://github.com/broadinstitute/gatk/assets/149685151/24d16941-b40c-4a5a-b8e6-0dc7415c6b1b)