### PR TITLE
Use per-group sample info to avoid scanning refs/vets

### DIFF
--- a/scripts/variantstore/wdl/extract/hail_gvs_import.py
+++ b/scripts/variantstore/wdl/extract/hail_gvs_import.py
@@ -36,6 +36,7 @@ def create_vds(argsfn, vds_path, references_path, temp_path, use_classic_vqsr, i
             vets=argsfn('vets'),
             refs=argsfn('refs'),
             sample_mapping=argsfn('sample_mapping'),
+            sample_info=argsfn('sample_info'),
             site_filtering_data=argsfn('site_filtering_data'),
             vqsr_filtering_data=argsfn('vqsr_filtering_data'),
             vqsr_tranche_data=argsfn('vqsr_tranche_data'),
@@ -67,6 +68,7 @@ def gcs_generate_avro_args(bucket, blob_prefix, key):
     * vets (list of lists, one outer list per GVS superpartition of 4000 samples max)
     * refs (list of lists, one outer list per GVS superpartition of 4000 samples max)
     * sample_mapping (list)
+    * sample_info (list)
     * site_filtering_data (list)
     * vqsr_filtering_data (list)
     * vqsr_tranche_data (list)

--- a/scripts/variantstore/wdl/extract/hail_gvs_import.py
+++ b/scripts/variantstore/wdl/extract/hail_gvs_import.py
@@ -36,7 +36,6 @@ def create_vds(argsfn, vds_path, references_path, temp_path, use_classic_vqsr, i
             vets=argsfn('vets'),
             refs=argsfn('refs'),
             sample_mapping=argsfn('sample_mapping'),
-            sample_info=argsfn('sample_info'),
             site_filtering_data=argsfn('site_filtering_data'),
             vqsr_filtering_data=argsfn('vqsr_filtering_data'),
             vqsr_tranche_data=argsfn('vqsr_tranche_data'),
@@ -68,7 +67,6 @@ def gcs_generate_avro_args(bucket, blob_prefix, key):
     * vets (list of lists, one outer list per GVS superpartition of 4000 samples max)
     * refs (list of lists, one outer list per GVS superpartition of 4000 samples max)
     * sample_mapping (list)
-    * sample_info (list)
     * site_filtering_data (list)
     * vqsr_filtering_data (list)
     * vqsr_tranche_data (list)

--- a/scripts/variantstore/wdl/extract/import_gvs.py
+++ b/scripts/variantstore/wdl/extract/import_gvs.py
@@ -209,7 +209,9 @@ def import_gvs(refs: 'List[List[str]]',
     with hl._with_flags(use_new_shuffle='1'):
         for idx in range(len(refs)):
             sample_mapping_group = sample_mapping[idx]
-            assert os.path.basename(sample_mapping_group) == '000000000000.{idx:03}.avro', sample_mapping_group
+            assert os.path.basename(sample_mapping_group) == f'000000000000.{idx:03}.avro', (
+                sample_mapping_group, os.path.basename(sample_mapping_group), f'000000000000.{idx:03}.avro'
+            )
             ref_group = refs[idx]
             var_group = vets[idx]
             path = os.path.join(tmp_dir, f'sample_group_{idx+1}.vds')

--- a/scripts/variantstore/wdl/extract/import_gvs.py
+++ b/scripts/variantstore/wdl/extract/import_gvs.py
@@ -209,8 +209,8 @@ def import_gvs(refs: 'List[List[str]]',
     with hl._with_flags(use_new_shuffle='1'):
         for idx in range(len(refs)):
             sample_mapping_group = sample_mapping[idx]
-            assert os.path.basename(sample_mapping_group) == f'000000000000.{idx:03}.avro', (
-                sample_mapping_group, os.path.basename(sample_mapping_group), f'000000000000.{idx:03}.avro'
+            assert os.path.basename(sample_mapping_group) == f'000000000000.{(idx+1):03}.avro', (
+                sample_mapping_group, os.path.basename(sample_mapping_group), f'000000000000.{(idx+1):03}.avro'
             )
             ref_group = refs[idx]
             var_group = vets[idx]

--- a/scripts/variantstore/wdl/extract/import_gvs.py
+++ b/scripts/variantstore/wdl/extract/import_gvs.py
@@ -231,7 +231,7 @@ def import_gvs(refs: 'List[List[str]]',
             # reference blocks.
             sample_ht = hl.import_avro([sample_mapping_group])
             sample_ht_fields = set(sample_ht.row.keys())
-            assert set('sample_id', 'sample_name').issubset(sample_ht_fields), sample_ht.row
+            assert {'sample_id', 'sample_name}.issubset(sample_ht_fields), sample_ht.row
 
             sample_ids, sample_names = sample_ht.aggregate((
                 hl.agg.collect(sample_ht.sample_id),

--- a/scripts/variantstore/wdl/extract/import_gvs.py
+++ b/scripts/variantstore/wdl/extract/import_gvs.py
@@ -231,7 +231,7 @@ def import_gvs(refs: 'List[List[str]]',
             # reference blocks.
             sample_ht = hl.import_avro([sample_mapping_group])
             sample_ht_fields = set(sample_ht.row.keys())
-            assert {'sample_id', 'sample_name}.issubset(sample_ht_fields), sample_ht.row
+            assert {'sample_id', 'sample_name'}.issubset(sample_ht_fields), sample_ht.row
 
             sample_ids, sample_names = sample_ht.aggregate((
                 hl.agg.collect(sample_ht.sample_id),

--- a/scripts/variantstore/wdl/extract/import_gvs.py
+++ b/scripts/variantstore/wdl/extract/import_gvs.py
@@ -229,7 +229,7 @@ def import_gvs(refs: 'List[List[str]]',
             # GVS generates for us one (sample_id, sample_name) Avro per group. Note that, in
             # theory, a sample nominally in this group *could* have zero variants and/or zero
             # reference blocks.
-            sample_ht = hl.import_avro(sample_mapping_group)
+            sample_ht = hl.import_avro([sample_mapping_group])
             sample_ht_fields = set(sample_ht.row.keys())
             assert set('sample_id', 'sample_name').issubset(sample_ht_fields), sample_ht.row
 


### PR DESCRIPTION
A matrix table is a dense matrix. GVS's refs and vets tables are sparse matrices, specifically using the [coordinate-list
representation](https://en.wikipedia.org/wiki/Sparse_matrix#Coordinate_list_(COO)). For example, the following coordinate-list representation:

```
row, col, value
0, 2, 42.0
0, 3, 48.0
0, 5, 43.0
1, 0, 41.0
1, 1, 45.0
1, 3, 43.0
```

corresponds to this dense representation
```
  NA   NA 42.0 48.0   NA 43.0
41.0 45.0   NA 43.0   NA   NA
```

I must read the entire coordinate-list representation to conclude this matrix has five columns. Moreover, in vets and refs, instead of column indices, we have unique column identifiers [1], so we even lack the index of each column. In a single-threaded, single-machine world, we could assign identifiers to indices as we scanned the refs/vets from top to bottom. However, when processing the refs and vets in parallel, we must know the identifier-to-index mapping before execution.

The current implementation reads the entire refs Avro to discover the present sample identifiers. The new implementation uses a new `sample_info` Avro file which contains one record per sample. This reduces the complexity of assigning samples to indices from $O(N_{SAMPLES} N_{REFS})$ to $O(N_{SAMPLES})$. In practice, this is a substantial reduction because the genomic axis is much larger than 4000, the typical group size.

[1] In practice, currently, the column identifiers are a dense interval of the global column
    indices. Concretely: sample group one contains only the samples 0 through 3999. Sample group two
    contains only the samples 4000 through 7999. We do not use this fact in import_gvs.py.