### PR TITLE
GatherVcfsCloud is no longer Beta

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/GatherVcfsCloud.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/GatherVcfsCloud.java
@@ -102,7 +102,6 @@ import java.util.stream.Collectors;
         oneLineSummary = "Gathers multiple VCF files from a scatter operation into a single VCF file",
         programGroup = VariantManipulationProgramGroup.class
 )
-@BetaFeature
 public final class GatherVcfsCloud extends CommandLineProgram {
 
     public static final String IGNORE_SAFETY_CHECKS_LONG_NAME = "ignore-safety-checks";


### PR DESCRIPTION
@droazen I noticed we never removed the beta marker from this.  I think it should be considered no longer beta given it's pretty intensive use for the last several years.