### PR TITLE
Standardize test results directory between normal/docker tests

### DIFF
--- a/.github/actions/upload-gatk-test-results/action.yml
+++ b/.github/actions/upload-gatk-test-results/action.yml
@@ -49,7 +49,7 @@ runs:
       id: uploadreports
       run: |
         gsutil -m cp -z html -z js -z xml -z css -r build/reports/tests gs:/${{ env.HELLBENDER_TEST_LOGS }}${{ inputs.repo-path }}/;
-        VIEW_URL=https://storage.googleapis.com${{ env.HELLBENDER_TEST_LOGS }}${{ inputs.repo-path }}/tests/testOnPackagedReleaseJar/index.html
+        VIEW_URL=https://storage.googleapis.com${{ env.HELLBENDER_TEST_LOGS }}${{ inputs.repo-path }}/tests/test/index.html
         echo "See the test report at ${VIEW_URL}";
         echo view_url="${VIEW_URL}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/gatk-tests.yml
+++ b/.github/workflows/gatk-tests.yml
@@ -230,10 +230,6 @@ jobs:
             bash --init-file /gatk/gatkenv.rc /root/run_unit_tests.sh;
           TEST_EXIT_VALUE=$?;
           $( exit ${TEST_EXIT_VALUE} );
-          sudo chmod -R a+w build/reports/;
-          mkdir build/reports/tests/test \
-           && cp -rp build/reports/tests/testOnPackagedReleaseJar/* build/reports/tests/test \
-           && rm -r build/reports/tests/testOnPackagedReleaseJar;
 
       - uses: ./.github/actions/upload-gatk-test-results
         if: always()

--- a/scripts/docker/dockertest.gradle
+++ b/scripts/docker/dockertest.gradle
@@ -144,6 +144,9 @@ task testOnPackagedReleaseJar(type: Test){
 
     jvmArgs = getJVMArgs(runtimeAddOpens, testAddOpens)
 
+    //Set this to match the name of the normal test output in order to simplify finding / uploading it
+    reports.html.outputLocation = file("$buildDir/reports/tests/test")
+
     classpath = files( gatkJar, testDependencyJar, testClassesJar)
     testClassesDirs = files(testClassesUnpacked)
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
@@ -27,12 +27,6 @@ public final class PrintReadsIntegrationTest extends AbstractPrintReadsIntegrati
         doFileToFile(fileIn, extOut, reference, true);
     }
 
-
-    @Test
-    public void failToTestReporting(){
-        Assert.fail();
-    }
-    
     @Test
     public void testNoConflictPG() throws IOException {
         final File inFile = new File(TEST_DATA_DIR, "print_reads_withPG.sam");

--- a/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
@@ -27,6 +27,12 @@ public final class PrintReadsIntegrationTest extends AbstractPrintReadsIntegrati
         doFileToFile(fileIn, extOut, reference, true);
     }
 
+
+    @Test
+    public void failToTestReporting(){
+        Assert.fail();
+    }
+    
     @Test
     public void testNoConflictPG() throws IOException {
         final File inFile = new File(TEST_DATA_DIR, "print_reads_withPG.sam");


### PR DESCRIPTION
* Changing test results directory for the docker tests to match the test results directory from the non docker test.
* Awkward handling of this seems to have been resulting in different test output paths and causing the reporting bot to sometimes fail to report the correct file location 
