### PR TITLE
Write variant mt and rename to as_vets

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -306,7 +306,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1187_headers_only_ingest
+             - rc-VS-1282-and-only-write-variant-mt
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -72,7 +72,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
-    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2024-02-14-alpine-40124cdc5"
+    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2024-03-06-alpine-6af272e27"
     String gatk_docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2024_02_16_78c53a6"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -72,7 +72,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
-    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2024-03-06-alpine-6af272e27"
+    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2024-03-06-alpine-0511c645f"
     String gatk_docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2024_02_16_78c53a6"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/extract/import_gvs.py
+++ b/scripts/variantstore/wdl/extract/import_gvs.py
@@ -406,5 +406,6 @@ def import_gvs(refs: 'List[List[str]]',
         vd = vd.annotate_entries(FT=~ft.any_no & (ft.any_yes | ((~ft.any_snp | ft.any_snp_ok) & (~ft.any_indel | ft.any_indel_ok))))
 
         vd = vd.drop('allele_NO', 'allele_YES', 'allele_is_snp', 'allele_OK')
+        vd = vd.rename({'as_vqsr': 'as_vets'})
 
         vd.write(os.path.join(final_path, 'variant_data'), overwrite=True))

--- a/scripts/variantstore/wdl/extract/import_gvs.py
+++ b/scripts/variantstore/wdl/extract/import_gvs.py
@@ -408,4 +408,4 @@ def import_gvs(refs: 'List[List[str]]',
         vd = vd.drop('allele_NO', 'allele_YES', 'allele_is_snp', 'allele_OK')
         vd = vd.rename({'as_vqsr': 'as_vets'})
 
-        vd.write(os.path.join(final_path, 'variant_data'), overwrite=True))
+        vd.write(os.path.join(final_path, 'variant_data'), overwrite=True)

--- a/scripts/variantstore/wdl/extract/import_gvs.py
+++ b/scripts/variantstore/wdl/extract/import_gvs.py
@@ -407,7 +407,4 @@ def import_gvs(refs: 'List[List[str]]',
 
         vd = vd.drop('allele_NO', 'allele_YES', 'allele_is_snp', 'allele_OK')
 
-        hl.vds.VariantDataset(
-            reference_data=rd,
-            variant_data=vd,
-        ).write(final_path, overwrite=True)
+        vd.write(os.path.join(final_path, 'variant_data'), overwrite=True))


### PR DESCRIPTION
The ref matrix table has been rsynced over already and is here:
gs://prod-drc-broad/v8/wgs/vds/aou_srwgs_short_variants_v8.vds/reference_data


variant data still need to be transformed and written. This writes the variant data only and renames the as_vqsr to as_vets