### PR TITLE
added --inverted-read-filter argument to allow for selecting reads failing read filters from the command line easily

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/DefaultGATKReadFilterArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/DefaultGATKReadFilterArgumentCollection.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.cmdline.GATKPlugin;
 
+import com.google.common.collect.Lists;
 import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.hellbender.cmdline.ReadFilterArgumentDefinitions;
@@ -23,6 +24,11 @@ public class DefaultGATKReadFilterArgumentCollection extends GATKReadFilterArgum
             doc="Read filters to be applied before analysis", optional=true, common = true)
     public final List<String> userEnabledReadFilterNames = new ArrayList<>(); // preserve order
 
+    @Argument(fullName = ReadFilterArgumentDefinitions.INVERTED_READ_FILTER_LONG_NAME,
+            shortName = ReadFilterArgumentDefinitions.INVERTED_READ_FILTER_SHORT_NAME,
+            doc="Inverted (with flipped acceptance/failure conditions) read filters applied before analysis (after regular read filters).", optional=true, common = true)
+    public final List<String> userEnabledInvertedReadFilterNames = new ArrayList<>(); // preserve order
+
     @Argument(fullName = ReadFilterArgumentDefinitions.DISABLE_READ_FILTER_LONG_NAME,
             shortName = ReadFilterArgumentDefinitions.DISABLE_READ_FILTER_SHORT_NAME,
             doc="Read filters to be disabled before analysis", optional=true, common = true)
@@ -34,10 +40,26 @@ public class DefaultGATKReadFilterArgumentCollection extends GATKReadFilterArgum
             doc = "Disable all tool default read filters (WARNING: many tools will not function correctly without their default read filters on)", common = true, optional = true)
     public boolean disableToolDefaultReadFilters = false;
 
+    private List<String> fullUserEnabledReadFilterNames = new ArrayList<>();
+    /** Returns the list with the read filters provided by the user, preserving the order. */
+    public List<String> getAllUserEnabledReadFilterNames() {
+        if (fullUserEnabledReadFilterNames.isEmpty()) {
+            fullUserEnabledReadFilterNames.addAll(userEnabledReadFilterNames);
+            fullUserEnabledReadFilterNames.addAll(userEnabledInvertedReadFilterNames);
+        }
+        return fullUserEnabledReadFilterNames;
+    }
+
     /** Returns the list with the read filters provided by the user, preserving the order. */
     @Override
     public List<String> getUserEnabledReadFilterNames() {
         return userEnabledReadFilterNames;
+    }
+
+    /** Returns the list with the read filters provided by the user, preserving the order. */
+    @Override
+    public List<String> getUserEnabledInvertedReadFilterNames() {
+        return userEnabledInvertedReadFilterNames;
     }
 
     /** Returns the set of filters disabled by the user. */

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/DefaultGATKReadFilterArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/DefaultGATKReadFilterArgumentCollection.java
@@ -41,7 +41,7 @@ public class DefaultGATKReadFilterArgumentCollection extends GATKReadFilterArgum
     public boolean disableToolDefaultReadFilters = false;
 
     private List<String> fullUserEnabledReadFilterNames = new ArrayList<>();
-    /** Returns the list with the read filters provided by the user, preserving the order. */
+    /** Returns the list with the union of inverted and non-inverted read filters provided by the user, preserving the order. */
     public List<String> getAllUserEnabledReadFilterNames() {
         if (fullUserEnabledReadFilterNames.isEmpty()) {
             fullUserEnabledReadFilterNames.addAll(userEnabledReadFilterNames);
@@ -56,7 +56,7 @@ public class DefaultGATKReadFilterArgumentCollection extends GATKReadFilterArgum
         return userEnabledReadFilterNames;
     }
 
-    /** Returns the list with the read filters provided by the user, preserving the order. */
+    /** Returns the list with the inverted read filters provided by the user, preserving the order. */
     @Override
     public List<String> getUserEnabledInvertedReadFilterNames() {
         return userEnabledInvertedReadFilterNames;

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/DefaultGATKReadFilterArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/DefaultGATKReadFilterArgumentCollection.java
@@ -41,7 +41,7 @@ public class DefaultGATKReadFilterArgumentCollection extends GATKReadFilterArgum
     public boolean disableToolDefaultReadFilters = false;
 
     private List<String> fullUserEnabledReadFilterNames = new ArrayList<>();
-    /** Returns the list with the union of inverted and non-inverted read filters provided by the user, preserving the order. */
+    /** Returns the list with the union of inverted and non-inverted read filters provided by the user. Includes user default filters followed by the user inverted filters.  */
     public List<String> getAllUserEnabledReadFilterNames() {
         if (fullUserEnabledReadFilterNames.isEmpty()) {
             fullUserEnabledReadFilterNames.addAll(userEnabledReadFilterNames);

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterArgumentCollection.java
@@ -20,6 +20,16 @@ public abstract class GATKReadFilterArgumentCollection implements Serializable {
     public abstract List<String> getUserEnabledReadFilterNames();
 
     /**
+     * Returns the inverted enabled read filters. Order should be honored.
+     */
+    public abstract List<String> getUserEnabledInvertedReadFilterNames();
+
+    /**
+     * Returns the union of all of the user enabled read filters and the user enabled inverted read filters.
+     */
+    public abstract List<String> getAllUserEnabledReadFilterNames();
+
+    /**
      * Returns the disabled read filter names. Order should be honored.
      */
     public abstract List<String> getUserDisabledReadFilterNames();

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterArgumentCollection.java
@@ -20,7 +20,7 @@ public abstract class GATKReadFilterArgumentCollection implements Serializable {
     public abstract List<String> getUserEnabledReadFilterNames();
 
     /**
-     * Returns the inverted enabled read filters. Order should be honored.
+     * Returns the inverted enabled read filters. Applied after the regular read filters. Order should be honored.
      */
     public abstract List<String> getUserEnabledInvertedReadFilterNames();
 

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptor.java
@@ -2,7 +2,6 @@ package org.broadinstitute.hellbender.cmdline.GATKPlugin;
 
 import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.filter.InvertFilter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
@@ -333,13 +332,12 @@ public class GATKReadFilterPluginDescriptor extends CommandLinePluginDescriptor<
                 logger.warn(String.format("Redundant enabled filter (%s) is enabled for this tool by default", s));
             });
 
-        // throw if a filter is both default and inverted by the user
-        // TODO this perhaps should be more graceful than a throw...
+        // throw if a filter is both default and inverted by the user as we do not want to inadvertently filter all reads from the input
         final Set<String> redundantInv = new HashSet<>(toolDefaultReadFilters.keySet());
         redundantInv.retainAll(userArgs.getUserEnabledInvertedReadFilterNames());
-        if (redundantInv.size() > 0) {
+        if (!userArgs.getDisableToolDefaultReadFilters() && redundantInv.size() > 0) {
             throw new CommandLineException(
-                    String.format("The read filter(s): %s exist as tool default filters and were inverted, disable tool default read fitlers in order to use this filter", redundantInv));
+                    String.format("The read filter(s): %s exist as tool default filters and were inverted, disable tool default read filters in order to use this filter", redundantInv));
         }
 
         // Throw if args were specified for a filter that was also disabled, or that was not enabled by the

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/ReadFilterArgumentDefinitions.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/ReadFilterArgumentDefinitions.java
@@ -9,9 +9,11 @@ public final class ReadFilterArgumentDefinitions {
     // GATKReadFilterPluginDescriptor arguments
 
     public static final String READ_FILTER_LONG_NAME = "read-filter";
+    public static final String INVERTED_READ_FILTER_LONG_NAME = "inverted-read-filter";
     public static final String DISABLE_READ_FILTER_LONG_NAME = "disable-read-filter";
     public static final String DISABLE_TOOL_DEFAULT_READ_FILTERS = "disable-tool-default-read-filters";
     public static final String READ_FILTER_SHORT_NAME = "RF";
+    public static final String INVERTED_READ_FILTER_SHORT_NAME = "XRF";
     public static final String DISABLE_READ_FILTER_SHORT_NAME = "DF";
 
     // ReadFilter arguments

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/CountingReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/CountingReadFilter.java
@@ -76,7 +76,7 @@ public class CountingReadFilter extends ReadFilter {
         filteredCount = 0;
     }
 
-    public String getName() {return delegateFilter.getClass().getSimpleName();}
+    public String getName() {return delegateFilter.getName();}
 
     // Returns a summary line with filter counts organized by level
     public String getSummaryLine() {return getSummaryLineForLevel(0);}

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadFilter.java
@@ -44,6 +44,11 @@ public abstract class ReadFilter implements Predicate<GATKRead>, Serializable {
         public boolean test( GATKRead read ) {
             return !delegate.test(read);
         }
+
+        @Override
+        public String getName() {
+            return "NOT " + delegate.getName();
+        }
     }
 
     protected abstract static class ReadFilterBinOp extends ReadFilter {
@@ -80,6 +85,11 @@ public abstract class ReadFilter implements Predicate<GATKRead>, Serializable {
 
         @Override
         public boolean test( GATKRead read ) { return lhs.test(read) && rhs.test(read); }
+
+        @Override
+        public String getName() {
+            return lhs.getName() + " AND " + rhs.getName();
+        }
     }
 
     private static class ReadFilterOr extends ReadFilterBinOp {
@@ -89,6 +99,11 @@ public abstract class ReadFilter implements Predicate<GATKRead>, Serializable {
 
         @Override
         public boolean test( GATKRead read ) { return lhs.test(read) || rhs.test(read);}
+
+        @Override
+        public String getName() {
+            return lhs.getName() + " OR " + rhs.getName();
+        }
     }
 
     // It turns out, this is necessary. Please don't remove it.
@@ -144,4 +159,11 @@ public abstract class ReadFilter implements Predicate<GATKRead>, Serializable {
 
     @Override
     public abstract boolean test( GATKRead read );
+
+    /**
+     * Retruns the display name for logs for this filter
+     */
+    String getName() {
+        return this.getClass().getSimpleName();
+    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadFilter.java
@@ -30,7 +30,8 @@ public abstract class ReadFilter implements Predicate<GATKRead>, Serializable {
 
     public void setHeader(SAMFileHeader samHeader) { this.samHeader = samHeader; }
 
-    private static class ReadFilterNegate extends ReadFilter {
+    @VisibleForTesting
+    public static class ReadFilterNegate extends ReadFilter {
         private static final long serialVersionUID = 1L;
 
         private final ReadFilter delegate;

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptorTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/GATKReadFilterPluginDescriptorTest.java
@@ -20,6 +20,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import javax.validation.constraints.AssertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -536,6 +537,23 @@ public class GATKReadFilterPluginDescriptorTest extends GATKBaseTest {
         clp.parseArguments(nullMessageStream, new String[] {
                 "--RF", "GoodCigarReadFilter",
                 "--" + ReadFilterArgumentDefinitions.DISABLE_READ_FILTER_LONG_NAME, "GoodCigarReadFilter"});
+    }
+
+    @Test
+    public void testDisableToolDefaultFiltersWithInvertedFilter() {
+        GATKReadFilterPluginDescriptor rfDesc = new GATKReadFilterPluginDescriptor(
+                Collections.singletonList(new ReadLengthReadFilter(1, 10)));
+        CommandLineParser clp = new CommandLineArgumentParser(
+                new Object(),
+                Collections.singletonList(rfDesc),
+                Collections.emptySet());
+        clp.parseArguments(nullMessageStream, new String[] {
+                "--" + ReadFilterArgumentDefinitions.DISABLE_TOOL_DEFAULT_READ_FILTERS,
+                "--" + ReadFilterArgumentDefinitions.INVERTED_READ_FILTER_LONG_NAME, ReadLengthReadFilter.class.getSimpleName()}
+        );
+        List<ReadFilter> allFilters = rfDesc.getResolvedInstances();
+        Assert.assertEquals(allFilters.size(), 1);
+        Assert.assertEquals(allFilters.get(0).getClass(), ReadFilter.ReadFilterNegate.class);
     }
 
     @Test(expectedExceptions = CommandLineException.class)


### PR DESCRIPTION
A quick and dirty implementation. The on thing that needs extra scrutiny is going to be the various conditions/failure states in the validate method. I think i caught most of the cases but there might be a gap somewhere. 