### PR TITLE
VS-623 Exclude AS_YNG from Extract VCF

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -290,7 +290,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_VS-623_ExcludeAsYNGFromVcfAhVarStore
          tags:
              - /.*/
    - name: GvsQuickstartHailIntegration
@@ -300,7 +299,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_VS-623_ExcludeAsYNGFromVcfAhVarStore
          tags:
              - /.*/
    - name: GvsQuickstartIntegration
@@ -311,7 +309,6 @@ workflows:
              - master
              - ah_var_store
              - rsa_vs_1245
-             - gg_VS-623_ExcludeAsYNGFromVcfAhVarStore
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -290,6 +290,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_VS-623_ExcludeAsYNGFromVcfAhVarStore
          tags:
              - /.*/
    - name: GvsQuickstartHailIntegration
@@ -299,6 +300,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_VS-623_ExcludeAsYNGFromVcfAhVarStore
          tags:
              - /.*/
    - name: GvsQuickstartIntegration
@@ -309,6 +311,7 @@ workflows:
              - master
              - ah_var_store
              - rsa_vs_1245
+             - gg_VS-623_ExcludeAsYNGFromVcfAhVarStore
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
@@ -32,7 +32,7 @@ workflow GvsQuickstartIntegration {
 
     File full_wgs_interval_list = "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.noCentromeres.noTelomeres.interval_list"
     File full_exome_interval_list = "gs://gcp-public-data--broad-references/hg38/v0/bge_exome_calling_regions.v1.1.interval_list"
-    File expected_output_prefix = "gs://gvs-internal-quickstart/integration/2024-01-18/"
+    File expected_output_prefix = "gs://gvs-internal-quickstart/integration/2024-03-13/"
 
     # WDL 1.0 trick to set a variable ('none') to be undefined.
     if (false) {

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -73,7 +73,7 @@ task GetToolVersions {
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
     String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2024-02-14-alpine-40124cdc5"
-    String gatk_docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2024_02_16_78c53a6"
+    String gatk_docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2024_03_12_ee216c89aabaf2f85178b40a784a81764148a4c7"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"
     String gotc_imputation_docker = "us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.5-1.10.2-0.1.16-1649948623"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -73,7 +73,7 @@ task GetToolVersions {
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
     String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2024-02-14-alpine-40124cdc5"
-    String gatk_docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2024_03_12_ee216c89aabaf2f85178b40a784a81764148a4c7"
+    String gatk_docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2024_03_15_ddc537dc8"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"
     String gotc_imputation_docker = "us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.5-1.10.2-0.1.16-1649948623"

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
@@ -238,7 +238,6 @@ public abstract class ExtractCohort extends ExtractTool {
                 VCFConstants.GENOTYPE_QUALITY_KEY
         );
         headerLines.add(GATKVCFHeaderLines.getFormatLine(GATKVCFConstants.REFERENCE_GENOTYPE_QUALITY));
-        headerLines.add(GATKVCFHeaderLines.getInfoLine(GATKVCFConstants.AS_YNG_STATUS_KEY));
 
         headerLines.addAll(extraHeaders);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
@@ -620,8 +620,6 @@ public class ExtractCohortEngine {
         mergedVC.getAlternateAlleles().forEach(key -> Optional.ofNullable(remappedScoreMap.get(key)).ifPresent(value -> relevantScoreMap.put(key, value)));
         final Map<Allele, Double> relevantVQScoreMap = new LinkedHashMap<>();
         mergedVC.getAlternateAlleles().forEach(key -> Optional.ofNullable(remappedVQScoreMap.get(key)).ifPresent(value -> relevantVQScoreMap.put(key, value)));
-        final Map<Allele, String> relevantYngMap = new LinkedHashMap<>();
-        mergedVC.getAlternateAlleles().forEach(key -> Optional.ofNullable(remappedYngMap.get(key)).ifPresent(value -> relevantYngMap.put(key, value)));
 
         final VariantContextBuilder builder = new VariantContextBuilder(mergedVC);
 
@@ -629,7 +627,6 @@ public class ExtractCohortEngine {
             builder.attribute(getScoreKey(), relevantScoreMap.values().stream().map(val -> val.equals(Double.NaN) ? VCFConstants.EMPTY_INFO_FIELD : val.toString()).collect(Collectors.toList()));
         }
         builder.attribute(getAlleleSpecificVQSScoreKey(), relevantVQScoreMap.values().stream().map(val -> val.equals(Double.NaN) ? VCFConstants.EMPTY_INFO_FIELD : val.toString()).collect(Collectors.toList()));
-        builder.attribute(GATKVCFConstants.AS_YNG_STATUS_KEY, new ArrayList<>(relevantYngMap.values()));
 
         if (vqScoreFilteringType.equals(ExtractCohort.VQScoreFilteringType.SITES)) { // Note that these filters are not used with Genotype VQSLOD/Sensitivity Filtering
             int refLength = mergedVC.getReference().length();


### PR DESCRIPTION
Exclude the field AS_YNG from VCFs extracted from GVS.
This is the merge into ah_var_store to match the one into EchoCallset
Integration tests [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration/job_history/5b513630-203f-4e4c-a14c-7423f300645e) - one failure for unrelated reasons.
Note that I had to update the truth data (since the contents of the VCFs had changed, and that there is one failure, but it's due to a slight cost difference - which is presumably in the noise.