### PR TITLE
Exclude test folder from codecov scanning

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -25,6 +25,8 @@ coverage:
         branches: null
         informational: true
 
+ignore:
+  - "src/test"
 
 comment:
   layout: "header, diff, changes, sunburst, uncovered, tree"


### PR DESCRIPTION
Codecov seems to be including test files in its coverage calculation, which is probably not ideal because obviously there are no tests for our tests.  This change should exclude them.