### PR TITLE
Retain all source IDs on VariantContext merge

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
@@ -1217,7 +1217,10 @@ public final class GATKVariantContextUtils {
 
         final String ID = rsIDs.isEmpty() ? VCFConstants.EMPTY_ID_FIELD : Utils.join(",", rsIDs);
 
-        final VariantContextBuilder builder = new VariantContextBuilder().source(name).id(ID);
+        // This preserves the GATK3-like behavior of reporting all sources, delimited with hyphen:
+        final String allSources = variantSources.isEmpty() ? name : variantSources.stream().sorted().collect(Collectors.joining("-"));
+
+        final VariantContextBuilder builder = new VariantContextBuilder().source(allSources).id(ID);
         builder.loc(longestVC.getContig(), longestVC.getStart(), longestVC.getEnd());
         builder.alleles(alleles);
         builder.genotypes(genotypes);


### PR DESCRIPTION
In GATK3, when merging variants, the IDs of all the source VCFs were retained. This code path seems like it intended that, since the variantSources set is generated, but it doesnt get used for anything. This PR will use that set to set the source of the resulting merged VC.

Note: i dont think I can kick off the test suite. It is possible this change would result in tests breaking, and those would need updates.