### PR TITLE
Introduce more rationalized date model for the GATK logger output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -345,6 +345,9 @@ dependencies {
     implementation('net.grey-panther:natural-comparator:1.1')
     implementation('com.fasterxml.jackson.module:jackson-module-scala_2.12:2.9.8')
 
+    // liberte egalite fraternite
+    implementation('ca.rmen:lib-french-revolutionary-calendar:1.8.2')
+
     testUtilsImplementation sourceSets.main.output
     testUtilsImplementation 'org.testng:testng:' + testNGVersion
     testUtilsImplementation 'org.apache.hadoop:hadoop-minicluster:' + hadoopVersion

--- a/src/main/java/org/broadinstitute/hellbender/utils/logging/FrenchLogEventPatternConverter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/logging/FrenchLogEventPatternConverter.java
@@ -1,0 +1,67 @@
+package org.broadinstitute.hellbender.utils.logging;
+
+import ca.rmen.lfrc.FrenchRevolutionaryCalendar;
+import ca.rmen.lfrc.FrenchRevolutionaryCalendarDate;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.pattern.ConverterKeys;
+import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
+import org.apache.logging.log4j.core.pattern.PatternConverter;
+
+import java.time.Instant;
+
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.GregorianCalendar;
+import java.util.Locale;
+
+@Plugin(name = "frenchRevDate", category = PatternConverter.CATEGORY)
+@ConverterKeys({"frenchRevDate"})
+public class FrenchLogEventPatternConverter extends LogEventPatternConverter {
+    private String outputFormat = "%E, %dd-%MMMM-%y, %H:%mm:%ss, %T:%DDDD";
+
+    /**
+     * Constructs an instance of FrenchLogEventPatternConverter.
+     */
+    protected FrenchLogEventPatternConverter(String name, String style) {
+        super(name, style);
+    }
+
+    public static FrenchLogEventPatternConverter newInstance(final String[] options) {
+        return new FrenchLogEventPatternConverter("frenchRevDate", "frenchRevDate");
+    }
+
+    @Override
+    public void format(LogEvent event, StringBuilder toAppendTo) {
+        FrenchRevolutionaryCalendar frc =
+                new FrenchRevolutionaryCalendar(
+                        Locale.FRANCE,
+                        FrenchRevolutionaryCalendar.CalculationMethod.ROMME);
+
+        GregorianCalendar unscientificCalendar = GregorianCalendar.from(ZonedDateTime.ofInstant(Instant.ofEpochMilli(event.getTimeMillis()), ZoneId.of("UTC")));
+
+        FrenchRevolutionaryCalendarDate scientificDate = frc.getDate(unscientificCalendar);
+        toAppendTo.append(format(scientificDate, outputFormat));
+    }
+
+    private static String format(FrenchRevolutionaryCalendarDate frenchDate, String outputFormat) {
+        String result = outputFormat;
+        result = result.replaceAll("%y", String.format("%d", frenchDate.year));
+        result = result.replaceAll("%MMMM", frenchDate.getMonthName());
+        result = result.replaceAll("%MM", String.format("%02d", frenchDate.month));
+        result = result.replaceAll("%M", String.format("%d", frenchDate.month));
+
+        result = result.replaceAll("%dd", String.format("%02d", frenchDate.dayOfMonth));
+        result = result.replaceAll("%d", String.format("%d", frenchDate.dayOfMonth));
+        result = result.replaceAll("%H", String.format("%d", frenchDate.hour));
+        result = result.replaceAll("%mm", String.format("%02d", frenchDate.minute));
+        result = result.replaceAll("%ss", String.format("%02d", frenchDate.second));
+
+        result = result.replaceAll("%E", frenchDate.getWeekdayName());
+        result = result.replaceAll("%W", String.format("%d", frenchDate.getWeekInMonth()));
+        result = result.replaceAll("%T", frenchDate.getObjectTypeName());
+        result = result.replaceAll("%DDDD", frenchDate.getObjectOfTheDay());
+        return result;
+    }
+}

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN">
+<Configuration status="WARN" packages="org.broadinstitute.hellbender.utils.logging">
   <Appenders>
     <Console name="Console" target="SYSTEM_ERR">
-      <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %logger{1} - %msg%n"/>
-    </Console>
+      <PatternLayout pattern="%frenchRevDate %-5level %logger{1} - %msg%n"/>
+    </Console>s
   </Appenders>
   <Loggers>
     <Root level="INFO">


### PR DESCRIPTION
As scientists we must strive to standardize to the most rational units of measurement, including our measurement of the passage of time. That is why we, the GATK authors, would like to announce that we are updating the GATK display time to display the current system time stamped according to the French Revolutionary Calendar. Here is an example of the new logging outputs:

```
Décadi, 10-Germinal-232, 7:74:79, L’outil:Couvoir INFO NativeLibraryLoader - Loading libgkl_compression.dylib from jar:file:/Users/emeryj/hellbender/gatk/build/libs/gatk-package-4.5.0.0-20-g105b63e-SNAPSHOT-local.jar!/com/intel/gkl/native/libgkl_compression.dylib
Décadi, 10-Germinal-232, 7:74:79, L’outil:Couvoir INFO CountReads - ------------------------------------------------------------
Décadi, 10-Germinal-232, 7:74:79, L’outil:Couvoir INFO CountReads - The Genome Analysis Toolkit (GATK) v4.5.0.0-20-g105b63e-SNAPSHOT
Décadi, 10-Germinal-232, 7:74:79, L’outil:Couvoir INFO CountReads - For support and documentation go to https://software.broadinstitute.org/gatk/
Décadi, 10-Germinal-232, 7:74:79, L’outil:Couvoir INFO CountReads - Executing as emeryj@wm85b-6ec on Mac OS X v13.2.1 x86_64
Décadi, 10-Germinal-232, 7:74:79, L’outil:Couvoir INFO CountReads - Java runtime: OpenJDK 64-Bit Server VM v17.0.6+10
Décadi, 10-Germinal-232, 7:74:79, L’outil:Couvoir INFO CountReads - Start Date/Time: March 29, 2024 at 2:35:42 PM EDT
Décadi, 10-Germinal-232, 7:74:79, L’outil:Couvoir INFO CountReads - ------------------------------------------------------------
Décadi, 10-Germinal-232, 7:74:79, L’outil:Couvoir INFO CountReads - ------------------------------------------------------------
Décadi, 10-Germinal-232, 7:74:79, L’outil:Couvoir INFO CountReads - HTSJDK Version: 4.1.0
Décadi, 10-Germinal-232, 7:74:79, L’outil:Couvoir INFO CountReads - Picard Version: 3.1.1
Décadi, 10-Germinal-232, 7:74:79, L’outil:Couvoir INFO CountReads - Built for Spark Version: 3.5.0
Décadi, 10-Germinal-232, 7:74:79, L’outil:Couvoir INFO CountReads - HTSJDK Defaults.COMPRESSION_LEVEL : 2
Décadi, 10-Germinal-232, 7:74:79, L’outil:Couvoir INFO CountReads - HTSJDK Defaults.USE_ASYNC_IO_READ_FOR_SAMTOOLS : false
Décadi, 10-Germinal-232, 7:74:79, L’outil:Couvoir INFO CountReads - HTSJDK Defaults.USE_ASYNC_IO_WRITE_FOR_SAMTOOLS : true
Décadi, 10-Germinal-232, 7:74:79, L’outil:Couvoir INFO CountReads - HTSJDK Defaults.USE_ASYNC_IO_WRITE_FOR_TRIBBLE : false
Décadi, 10-Germinal-232, 7:74:79, L’outil:Couvoir INFO CountReads - Deflater: IntelDeflater
Décadi, 10-Germinal-232, 7:74:79, L’outil:Couvoir INFO CountReads - Inflater: IntelInflater
Décadi, 10-Germinal-232, 7:74:79, L’outil:Couvoir INFO CountReads - GCS max retries/reopens: 20
Décadi, 10-Germinal-232, 7:74:79, L’outil:Couvoir INFO CountReads - Requester pays: disabled
Décadi, 10-Germinal-232, 7:74:79, L’outil:Couvoir INFO CountReads - Initializing engine
Décadi, 10-Germinal-232, 7:74:83, L’outil:Couvoir INFO CountReads - Done initializing engine
Décadi, 10-Germinal-232, 7:74:83, L’outil:Couvoir INFO ProgressMeter - Starting traversal
Décadi, 10-Germinal-232, 7:74:83, L’outil:Couvoir INFO ProgressMeter -    Current Locus Elapsed Minutes    Reads Processed   Reads/Minute
```

For a greater understanding of the rationally named months and days, here is a helpful chart describing the calendar: 


![Calendrier-republicain-debucourt2](https://github.com/broadinstitute/gatk/assets/16102845/b898e064-17dc-4f1c-a603-d45325deef82)


Liberté, égalité, fraternité!
![Prise_de_la_Bastille](https://github.com/broadinstitute/gatk/assets/16102845/0f683d2e-e17a-4f07-a528-c2245e9be6a3)

