### PR TITLE
Funcotator: suppress a log message about b37 contigs when not doing b37/hg19 conversion

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorEngine.java
@@ -528,7 +528,7 @@ public final class FuncotatorEngine implements AutoCloseable {
         }
 
         // Record whether we need to revert the contigs back to B37 after annotation:
-        if (FuncotatorUtils.isSequenceDictionaryUsingB37Reference(sequenceDictionaryForDrivingVariants) && mustConvertInputContigsToHg19) {
+        if (mustConvertInputContigsToHg19 && FuncotatorUtils.isSequenceDictionaryUsingB37Reference(sequenceDictionaryForDrivingVariants)) {
             this.mustRevertVariantContigsFromHg19ToB37 = true;
         }
 


### PR DESCRIPTION
Don't print the very long and misleading "The following contigs are present in b37 and missing in the input VCF sequence dictionary" log message when we're not even doing b37/hg19 conversion.

Users are getting log messages like this even when they have an hg38 dictionary:

16:21:32.764 INFO  FuncotatorUtils -   The following contigs are present in b37 and missing in the input VCF sequence dictionary:
16:21:32.767 INFO  FuncotatorUtils -     1 (len=249250621,assembly=GRCh37)
16:21:32.767 INFO  FuncotatorUtils -     2 (len=243199373,assembly=GRCh37)
16:21:32.767 INFO  FuncotatorUtils -     3 (len=198022430,assembly=GRCh37)
16:21:32.767 INFO  FuncotatorUtils -     4 (len=191154276,assembly=GRCh37)
16:21:32.767 INFO  FuncotatorUtils -     5 (len=180915260,assembly=GRCh37)
16:21:32.768 INFO  FuncotatorUtils -     6 (len=171115067,assembly=GRCh37)
16:21:32.768 INFO  FuncotatorUtils -     7 (len=159138663,assembly=GRCh37)
16:21:32.768 INFO  FuncotatorUtils -     8 (len=146364022,assembly=GRCh37)
16:21:32.768 INFO  FuncotatorUtils -     9 (len=141213431,assembly=GRCh37)
16:21:32.768 INFO  FuncotatorUtils -     10 (len=135534747,assembly=GRCh37)
16:21:32.768 INFO  FuncotatorUtils -     11 (len=135006516,assembly=GRCh37)
16:21:32.768 INFO  FuncotatorUtils -     12 (len=133851895,assembly=GRCh37)
16:21:32.768 INFO  FuncotatorUtils -     13 (len=115169878,assembly=GRCh37)
16:21:32.768 INFO  FuncotatorUtils -     14 (len=107349540,assembly=GRCh37)
16:21:32.768 INFO  FuncotatorUtils -     15 (len=102531392,assembly=GRCh37)
16:21:32.768 INFO  FuncotatorUtils -     16 (len=90354753,assembly=GRCh37)
16:21:32.768 INFO  FuncotatorUtils -     17 (len=81195210,assembly=GRCh37)
16:21:32.768 INFO  FuncotatorUtils -     18 (len=78077248,assembly=GRCh37)
16:21:32.768 INFO  FuncotatorUtils -     19 (len=59128983,assembly=GRCh37)
16:21:32.768 INFO  FuncotatorUtils -     20 (len=63025520,assembly=GRCh37)
16:21:32.769 INFO  FuncotatorUtils -     21 (len=48129895,assembly=GRCh37)
16:21:32.769 INFO  FuncotatorUtils -     22 (len=51304566,assembly=GRCh37)
.....