### PR TITLE
Use `noAddress` to limit use of external IPs [VS-1323]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -164,6 +164,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - vs_1323_no_address
          tags:
              - /.*/
    - name: GvsImportGenomes
@@ -428,6 +429,7 @@ workflows:
          - master
          - ah_var_store
          - EchoCallset
+         - vs_1323_no_address
    - name: MergePgenHierarchicalWdl
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/MergePgenHierarchical.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -164,7 +164,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1323_no_address
          tags:
              - /.*/
    - name: GvsImportGenomes
@@ -308,7 +307,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1323_no_address
          tags:
              - /.*/
    - name: GvsIngestTieout
@@ -429,7 +427,6 @@ workflows:
          - master
          - ah_var_store
          - EchoCallset
-         - vs_1323_no_address
    - name: MergePgenHierarchicalWdl
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/MergePgenHierarchical.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -308,7 +308,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - rsa_vs_1245
+             - vs_1323_no_address
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -344,6 +344,7 @@ task ExtractFilterTask {
     preemptible: 3
     maxRetries: 3
     cpu: 2
+    noAddress: true
   }
 
   output {

--- a/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
+++ b/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
@@ -373,6 +373,7 @@ task ExtractFromSuperpartitionedTables {
     runtime {
         docker: variants_docker
         disks: "local-disk 500 HDD"
+        noAddress: true
     }
 }
 

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -420,6 +420,7 @@ task ExtractTask {
     preemptible: select_first([extract_preemptible_override, "2"])
     maxRetries: select_first([extract_maxretries_override, "3"])
     cpu: 2
+    noAddress: true
   }
 
   # files sizes are floats instead of ints because they can be larger

--- a/scripts/variantstore/wdl/GvsExtractCallsetPgen.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallsetPgen.wdl
@@ -486,6 +486,7 @@ task PgenExtractTask {
         preemptible: select_first([extract_preemptible_override, "2"])
         maxRetries: select_first([extract_maxretries_override, "3"])
         cpu: 2
+        noAddress: true
     }
 
     # files sizes are floats instead of ints because they can be larger

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -388,6 +388,7 @@ task LoadData {
     disks: "local-disk 50 HDD"
     preemptible: load_data_preemptible
     cpu: 1
+    noAddress: true
   }
   output {
     Boolean done = true

--- a/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
+++ b/scripts/variantstore/wdl/GvsPopulateAltAllele.wdl
@@ -286,6 +286,7 @@ task PopulateAltAlleleTable {
     memory: "3 GB"
     disks: "local-disk 10 HDD"
     cpu: 1
+    noAddress: true
   }
 
   output {

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -1126,6 +1126,7 @@ task SelectVariants {
         disks: "local-disk ${disk_size_gb} HDD"
         bootDiskSizeGb: 15
         preemptible: 3
+        noAddress: true
     }
 
     output {

--- a/scripts/variantstore/wdl/GvsVQSRClassic.wdl
+++ b/scripts/variantstore/wdl/GvsVQSRClassic.wdl
@@ -555,6 +555,7 @@ task SNPsVariantRecalibrator {
     disks: "local-disk " + disk_size + " HDD"
     preemptible: 0
     docker: gatk_docker
+    noAddress: true
   }
 
   output {

--- a/scripts/variantstore/wdl/MergePgenHierarchical.wdl
+++ b/scripts/variantstore/wdl/MergePgenHierarchical.wdl
@@ -145,6 +145,7 @@ task MergePgen {
         disks: "local-disk ${disk_in_gb} HDD"
         bootDiskSizeGb: 15
         cpu: "${cpu}"
+        noAddress: true
     }
 }
 
@@ -201,6 +202,7 @@ task MakeFileLists {
         docker: "ubuntu:22.04"
         memory: "1GB"
         bootDiskSizeGb: 15
+        noAddress: true
     }
 }
 
@@ -281,6 +283,7 @@ task SortFileLists {
         docker: "ubuntu:22.04"
         memory: "1GB"
         bootDiskSizeGb: 15
+        noAddress: true
     }
 }
 
@@ -314,5 +317,6 @@ task SplitFileLists {
         docker: "ubuntu:22.04"
         memory: "1GB"
         bootDiskSizeGb: 15
+        noAddress: true
     }
 }

--- a/scripts/variantstore/wdl/MergePgenHierarchical.wdl
+++ b/scripts/variantstore/wdl/MergePgenHierarchical.wdl
@@ -149,8 +149,6 @@ task MergePgen {
         disks: "local-disk ${disk_in_gb} HDD"
         bootDiskSizeGb: 15
         cpu: "${cpu}"
-        # The PGEN Docker needs to be in GAR or GCR to be able to use noAddress.
-        # noAddress: true
     }
 }
 

--- a/scripts/variantstore/wdl/MergePgenHierarchical.wdl
+++ b/scripts/variantstore/wdl/MergePgenHierarchical.wdl
@@ -149,7 +149,7 @@ task MergePgen {
         disks: "local-disk ${disk_in_gb} HDD"
         bootDiskSizeGb: 15
         cpu: "${cpu}"
-        # The PGEN Docker needs to be in GAR or GCR to be able to use noAddress
+        # The PGEN Docker needs to be in GAR or GCR to be able to use noAddress.
         # noAddress: true
     }
 }


### PR DESCRIPTION
Use Cromwell's [noAddress](https://support.terra.bio/hc/en-us/community/posts/360060020871-noAddress-true-results-in-stalling-jobs) feature to avoid the unnecessary use of external IPs on Cromwell worker VMs on wide scatters that cause us Google quota problems.

For most of the GVS code this only involves adding `noAddress: true` to the existing runtime attributes. In the PGEN code this was slightly more work to change away from `docker: "ubuntu:22.04"` which is implicitly pulled from Docker Hub. Since `noAddress: true` means the VM can only interact with Google services, we have to switch to a GCR-hosted image as Docker Hub has become unreachable.

- [Mostly successful integration test](https://job-manager.dsde-prod.broadinstitute.org/jobs/32b9e2b5-3c56-4bf8-ab5e-66fa72c7cadb), delta some existing issues with cost discrepancies documented in VS-1324.
- [Successful PGEN extract](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration/job_history/1f19bea2-a9b9-4ec5-b741-e9f64bbfa35a)