### PR TITLE
Make CreateTables volatile [VS-1328]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -97,6 +97,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - rsa_vs_1328
          tags:
              - /.*/
    - name: GvsBenchmarkExtractTask

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -97,7 +97,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - rsa_vs_1328
          tags:
              - /.*/
    - name: GvsBenchmarkExtractTask
@@ -183,6 +182,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - rsa_vs_1328
          tags:
              - /.*/
    - name: GvsPrepareRangesCallset

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -182,7 +182,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - rsa_vs_1245
          tags:
              - /.*/
    - name: GvsPrepareRangesCallset
@@ -279,7 +278,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - rsa_vs_1245
          tags:
              - /.*/
    - name: GvsQuickstartVcfIntegration
@@ -307,6 +305,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - rsa_vs_1328
          tags:
              - /.*/
    - name: GvsIngestTieout
@@ -343,7 +342,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - rsa_vs_1224
          tags:
              - /.*/
    - name: GvsFindHailCruft

--- a/scripts/variantstore/wdl/GvsCreateTables.wdl
+++ b/scripts/variantstore/wdl/GvsCreateTables.wdl
@@ -80,7 +80,8 @@ task CreateTables {
     String clustering_field = "location"
   }
   meta {
-    # Not `volatile: true` since there shouldn't be a need to re-run this if there has already been a successful execution.
+    # set to volatile because if the table already exists, this will not remake it
+    volatile: true
   }
 
   command <<<


### PR DESCRIPTION
Reasoning:
 - task will not recreate/overwrite table if it exists
 - task does not take long, so unnecessary runs are not costly in time or $
 - when not volatile, Beta users need to run with call-caching off if they re-run the pipeline

run where tables already existed: https://app.terra.bio/#workspaces/gvs-dev/RSA%20-%20GVS%20Quickstart%20V2%20/job_history/64782949-33dd-41ef-b3f7-5e88cc5a5dcc

integration run: https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration/job_history/9e79ef7f-9e64-46c7-8749-83909a5d423f (it failed the end tests, but the tables were created/populated as expected)