### PR TITLE
⛔ [DO NOT MERGE] ⛔ Fix partition grouping bug ⛔ 

### DIFF
--- a/scripts/variantstore/wdl/extract/hail_create_vat_inputs.py
+++ b/scripts/variantstore/wdl/extract/hail_create_vat_inputs.py
@@ -190,7 +190,9 @@ def main(vds, ancestry_file_location, sites_only_vcf_path, dry_run_n_parts=None)
         sites_only_vcf_path = sites_only_vcf_path.replace(r".vcf.bgz", f'_dryrun.vcf.bgz')
     else:
         n_rounds = 5
-        parts_per_round = n_parts // n_rounds
+        # Add in 'n_rounds - 1' to include all of the partitions in the set of groups, otherwise we would omit the final
+        # n_parts % n_rounds partitions.
+        parts_per_round = (n_parts + n_rounds - 1) // n_rounds
         ht_paths = [sites_only_vcf_path.replace(r".sites-only.vcf.bgz", f'_{i}.ht') for i in range(n_rounds)]
     for i in range(n_rounds):
         part_range = range(i*parts_per_round, min((i+1)*parts_per_round, n_parts))


### PR DESCRIPTION
⛔ DO NOT MERGE this into the EchoCallset branch ⛔ just yet; it's probably better to address this bug in the current EchoCallset run by adding the two missing partitions to the last group and rerunning the last group only rather than rerunning all the groups with a larger group size.

Add in `n_rounds - 1` to the group size expression to include all of the partitions in the set of groups, otherwise we omit the final `n_parts % n_rounds` partitions.

Concretely for AoU Echo with 145192 total partitions and 5 rounds:

```
>>> 145192 // 5
29038
>>> 29038 * 5
145190
>>> (145192 + 5 - 1) // 5
29039
```