### PR TITLE
VS-1324 Investigate integration test failures

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -288,6 +288,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_VS-1324_IntegrationTestFailures
          tags:
              - /.*/
    - name: GvsQuickstartHailIntegration
@@ -297,6 +298,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_VS-1324_IntegrationTestFailures
          tags:
              - /.*/
    - name: GvsQuickstartIntegration
@@ -307,6 +309,7 @@ workflows:
              - master
              - ah_var_store
              - rsa_vs_1328
+             - gg_VS-1324_IntegrationTestFailures
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/wdl/GvsQuickstartHailIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartHailIntegration.wdl
@@ -70,6 +70,7 @@ workflow GvsQuickstartHailIntegration {
             load_vcf_headers = true,
             dataset_suffix = dataset_suffix,
             use_default_dockers = use_default_dockers,
+            check_expected_cost_and_table_size_outputs = false,
             gatk_override = gatk_override,
             is_wgs = is_wgs,
             interval_list = interval_list,

--- a/scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
@@ -32,7 +32,8 @@ workflow GvsQuickstartIntegration {
 
     File full_wgs_interval_list = "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.noCentromeres.noTelomeres.interval_list"
     File full_exome_interval_list = "gs://gcp-public-data--broad-references/hg38/v0/bge_exome_calling_regions.v1.1.interval_list"
-    File expected_output_prefix = "gs://gvs-internal-quickstart/integration/2024-03-13/"
+    String expected_subdir = if (chr20_X_Y_only) then "/all_chrs/"  else ""
+    File expected_output_prefix = "gs://gvs-internal-quickstart/integration/2024-03-13/" + expected_subdir
 
     # WDL 1.0 trick to set a variable ('none') to be undefined.
     if (false) {

--- a/scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
@@ -32,7 +32,7 @@ workflow GvsQuickstartIntegration {
 
     File full_wgs_interval_list = "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.noCentromeres.noTelomeres.interval_list"
     File full_exome_interval_list = "gs://gcp-public-data--broad-references/hg38/v0/bge_exome_calling_regions.v1.1.interval_list"
-    String expected_subdir = if (!chr20_X_Y_only) then "/all_chrs/"  else ""
+    String expected_subdir = if (!chr20_X_Y_only) then "all_chrs/"  else ""
     File expected_output_prefix = "gs://gvs-internal-quickstart/integration/2024-03-13/" + expected_subdir
 
     # WDL 1.0 trick to set a variable ('none') to be undefined.

--- a/scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
@@ -32,7 +32,7 @@ workflow GvsQuickstartIntegration {
 
     File full_wgs_interval_list = "gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.noCentromeres.noTelomeres.interval_list"
     File full_exome_interval_list = "gs://gcp-public-data--broad-references/hg38/v0/bge_exome_calling_regions.v1.1.interval_list"
-    String expected_subdir = if (chr20_X_Y_only) then "/all_chrs/"  else ""
+    String expected_subdir = if (!chr20_X_Y_only) then "/all_chrs/"  else ""
     File expected_output_prefix = "gs://gvs-internal-quickstart/integration/2024-03-13/" + expected_subdir
 
     # WDL 1.0 trick to set a variable ('none') to be undefined.

--- a/scripts/variantstore/wdl/GvsQuickstartVcfIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartVcfIntegration.wdl
@@ -17,6 +17,7 @@ workflow GvsQuickstartVcfIntegration {
         Boolean is_wgs = true
         File? interval_list
         Boolean use_default_dockers = false
+        Boolean check_expected_cost_and_table_size_outputs = true
         String? basic_docker
         String? cloud_sdk_docker
         String? cloud_sdk_slim_docker
@@ -119,22 +120,24 @@ workflow GvsQuickstartVcfIntegration {
                 cloud_sdk_docker = effective_cloud_sdk_docker,
         }
 
-        call AssertCostIsTrackedAndExpected {
-            input:
-                go = JointVariantCalling.done,
-                dataset_name = CreateDatasetForTest.dataset_name,
-                project_id = project_id,
-                expected_output_csv = expected_prefix + "cost_observability_expected.csv",
-                cloud_sdk_docker = effective_cloud_sdk_docker,
-        }
+        if (check_expected_cost_and_table_size_outputs) {
+            call AssertCostIsTrackedAndExpected {
+                input:
+                    go = JointVariantCalling.done,
+                    dataset_name = CreateDatasetForTest.dataset_name,
+                    project_id = project_id,
+                    expected_output_csv = expected_prefix + "cost_observability_expected.csv",
+                    cloud_sdk_docker = effective_cloud_sdk_docker,
+            }
 
-        call AssertTableSizesAreExpected {
-            input:
-                go = JointVariantCalling.done,
-                dataset_name = CreateDatasetForTest.dataset_name,
-                project_id = project_id,
-                expected_output_csv = expected_prefix + "table_sizes_expected.csv",
-                cloud_sdk_docker = effective_cloud_sdk_docker,
+            call AssertTableSizesAreExpected {
+                input:
+                    go = JointVariantCalling.done,
+                    dataset_name = CreateDatasetForTest.dataset_name,
+                    project_id = project_id,
+                    expected_output_csv = expected_prefix + "table_sizes_expected.csv",
+                    cloud_sdk_docker = effective_cloud_sdk_docker,
+            }
         }
     }
 


### PR DESCRIPTION
This PR deals with the test failures that were occurring when we ran ALL chromosomes through the integration test, rather than just chr20 and X and Y (the default). It adds another truth set for all chromosomes.
Also two small changes.
- Skip the cost/table size check for the Hail integration, to allow it to get to the hail part if there are spurious test failures in cost.
- Change the name of the files used for table size and cost checking. Makes it easier to install new test data.

Passing integration test on all chromosomes [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration/job_history/d8837252-26fa-4d40-bdf1-e42ff8932fd1)
Passing integration test on chr20/x/y [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration/job_history/f552e7a3-d245-492d-b5e1-a35ba323fae8).