### PR TITLE
Revert explicit GAR references for now [VS-1342]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -306,7 +306,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - rsa_vs_1328
+             - vs_1342_revert_gar_bits_for_now
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -72,7 +72,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
-    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2024-02-14-alpine-40124cdc5"
+    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2024-04-22-alpine-1d619c94776c"
     String gatk_docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2024_03_19_dfd45f6"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/extract/build_docker.sh
+++ b/scripts/variantstore/wdl/extract/build_docker.sh
@@ -5,7 +5,7 @@ usage() {
 
 USAGE: ./build_docker.sh
 
-Generate a tag suitable for publication of a Variants Docker image.
+Build a Variants Docker image with an appropriate tag and push to GCR.
 Tags will be of the form <ISO 8601 Date>-alpine-<Docker image ID>.
 
 e.g. 2024-04-19-alpine-f000ba44
@@ -24,7 +24,7 @@ TAG=$(python3 ./build_docker_tag.py)
 # Take everything after the last dash to recover the Docker image ID from the tag.
 IMAGE_ID=${TAG##*-}
 BASE_REPO="broad-dsde-methods/variantstore"
-REPO_WITH_TAG="${BASE_REPO}/variantstore:${TAG}"
+REPO_WITH_TAG="${BASE_REPO}:${TAG}"
 docker tag "${IMAGE_ID}" "${REPO_WITH_TAG}"
 
 # Run unit tests before pushing.
@@ -46,11 +46,8 @@ fi
 
 set -o errexit
 
-GAR_TAG="us-central1-docker.pkg.dev/${REPO_WITH_TAG}"
-docker tag "${REPO_WITH_TAG}" "${GAR_TAG}"
+GCR_TAG="us.gcr.io/${REPO_WITH_TAG}"
+docker tag "${REPO_WITH_TAG}" "${GCR_TAG}"
+docker push "${GCR_TAG}"
 
-# Docker must be configured for GAR before pushes will work:
-# gcloud auth configure-docker us-central1-docker.pkg.dev
-docker push "${GAR_TAG}"
-
-echo "Docker image pushed to \"${GAR_TAG}\""
+echo "Docker image pushed to \"${GCR_TAG}\""


### PR DESCRIPTION
Revert explicit GAR references in our Docker build scripts for now. Variants team members are not Methods team members and thus do not have the access required to make Variants GAR repos public in the `broad-dsde-methods` project.

Note that Variants images are still ending up in GAR thanks to the magic of DevOps redirects. This PR also retains the Docker image ID-based referencing that was introduced at the same time as the explicit GAR references that are now being backed out.

Successful (or at least non-instafailing) [integration run here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration/job_history/2f00b836-0c2d-41e9-84b1-b8c6a2bea8f6).