### PR TITLE
Fix GAR support [VS-1342]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -288,7 +288,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_VS-1324_IntegrationTestFailures
          tags:
              - /.*/
    - name: GvsQuickstartHailIntegration
@@ -298,7 +297,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_VS-1324_IntegrationTestFailures
          tags:
              - /.*/
    - name: GvsQuickstartIntegration
@@ -308,8 +306,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - rsa_vs_1328
-             - gg_VS-1324_IntegrationTestFailures
+             - vs_1342_maybe_stick_with_gar
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -72,7 +72,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
-    String variants_docker = "us.gcr.io/broad-dsde-methods/variantstore:2024-02-14-alpine-40124cdc5"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2024-04-22-alpine-32804b134a75"
     String gatk_docker = "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_2024_03_19_dfd45f6"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/extract/build_docker.sh
+++ b/scripts/variantstore/wdl/extract/build_docker.sh
@@ -6,6 +6,7 @@ usage() {
 USAGE: ./build_docker.sh
 
 Build a Variants Docker image with an appropriate tag and push to GAR.
+The repo name will be 'us-central1-docker.pkg.dev/broad-dsde-methods/gvs' and the image name will be 'variants'.
 Tags will be of the form <ISO 8601 Date>-alpine-<Docker image ID>.
 
 e.g. 2024-04-22-alpine-f000ba44
@@ -18,11 +19,18 @@ then
     usage
 fi
 
+# Write the full Docker image ID to a file. This will look something like:
+# sha256:5286e46648c595295dcb58a4cc2ec0b8893c9f26d7d49393908e5ae6d4dea188
 docker build . --iidfile idfile.txt
-
 FULL_IMAGE_ID=$(cat idfile.txt)
+
+# Take the slice of this full Docker image ID that corresponds with the output of `docker images`:
 IMAGE_ID=${FULL_IMAGE_ID:7:12}
+
+# The Variants Docker image is alpine-based.
 IMAGE_TYPE="alpine"
+
+# Build the image tag using the image type and Docker image ID:
 TAG=$(python3 ./build_docker_tag.py --image-id "${IMAGE_ID}" --image-type "${IMAGE_TYPE}")
 
 BASE_REPO="broad-dsde-methods/gvs"

--- a/scripts/variantstore/wdl/extract/build_docker_tag.py
+++ b/scripts/variantstore/wdl/extract/build_docker_tag.py
@@ -8,19 +8,13 @@ def build_tag(args):
     current_date = datetime.now()
     date_string = current_date.strftime('%Y-%m-%d')
 
-    if not args.dummy_testing_image_id:
-        proc = run(["bash", "-c", "docker images --quiet | head -1"], stdout=subprocess.PIPE)
-        docker_image_id = proc.stdout.rstrip().decode('utf-8')
-    else:
-        # Do not actually try to run git during testing, the .git directory is not mounted into the container.
-        docker_image_id = args.dummy_testing_image_id
-    return f"{date_string}-alpine-{docker_image_id}"
+    return f"{date_string}-alpine-{args.image_id}"
 
 
 def build_argument_parser():
     parser = argparse.ArgumentParser(allow_abbrev=False, description='Build a tag for Variants Docker image')
-    parser.add_argument('-d', '--dummy-testing-image-id', default=None,
-                        help='Dummy short Docker image ID to return during testing')
+    parser.add_argument('-i', '--image-id', required=True, help='Docker image ID')
+    parser.add_argument('-t', '--image-type', required=True, help='Docker image type, should be "alpine" or "slim".')
     return parser
 
 

--- a/scripts/variantstore/wdl/extract/build_docker_tag.py
+++ b/scripts/variantstore/wdl/extract/build_docker_tag.py
@@ -8,7 +8,7 @@ def build_tag(args):
     current_date = datetime.now()
     date_string = current_date.strftime('%Y-%m-%d')
 
-    return f"{date_string}-alpine-{args.image_id}"
+    return f"{date_string}-{args.image_type}-{args.image_id}"
 
 
 def build_argument_parser():

--- a/scripts/variantstore/wdl/extract/test_build_docker_tag.py
+++ b/scripts/variantstore/wdl/extract/test_build_docker_tag.py
@@ -11,6 +11,6 @@ class TestBuildDockerTag(unittest.TestCase):
     def test_tag(self):
         tag_re = re.compile(r"^20\d{2}-\d{2}-\d{2}-alpine-f00ba4ba5$")
 
-        args = self.argument_parser.parse_args(['--image-id', 'f00ba4ba5', '--image-type', 'slim'])
+        args = self.argument_parser.parse_args(['--image-id', 'f00ba4ba5', '--image-type', 'alpine'])
         tag = build_tag(args)
         self.assertTrue(tag_re.match(tag))

--- a/scripts/variantstore/wdl/extract/test_build_docker_tag.py
+++ b/scripts/variantstore/wdl/extract/test_build_docker_tag.py
@@ -11,6 +11,6 @@ class TestBuildDockerTag(unittest.TestCase):
     def test_tag(self):
         tag_re = re.compile(r"^20\d{2}-\d{2}-\d{2}-alpine-f00ba4ba5$")
 
-        args = self.argument_parser.parse_args(['--dummy-testing-image-id', 'f00ba4ba5'])
+        args = self.argument_parser.parse_args(['--image-id', 'f00ba4ba5', '--image-type', 'slim'])
         tag = build_tag(args)
         self.assertTrue(tag_re.match(tag))


### PR DESCRIPTION
- Push to `gvs` repo in `broad-dsde-methods` rather than `variantstore`.
- Fix the way image IDs are discovered.
- Support both `alpine` and non-`alpine` image types, setting up support for plink2.

Successful integration run [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration/job_history/c1c2fc65-104b-46af-a536-882d7c1e8954).