### PR TITLE
GATK Reduced Docker Layers for ACR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_DOCKER=terrapublic.azurecr.io/gatkbase:3.2.0-squashed
+ARG BASE_DOCKER=broadinstitute/gatk:gatkbase-3.2.0
 
 # stage 1 for constructing the GATK zip
 FROM ${BASE_DOCKER} AS gradleBuild

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,14 @@ FROM ${BASE_DOCKER} AS gradleBuild
 LABEL stage=gatkIntermediateBuildImage
 ARG RELEASE=false
 
-#unnecessary
-#RUN ls .
+
 ADD . /gatk
 WORKDIR /gatk
 
 # Get an updated gcloud signing key, in case the one in the base image has expired
 #Download only resources required for the build, not for testing
-RUN rm /etc/apt/sources.list.d/google-cloud-sdk.list && \
+RUN ls . && \
+    rm /etc/apt/sources.list.d/google-cloud-sdk.list && \
     apt update &&\
     apt-key list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
@@ -79,15 +79,12 @@ RUN echo "source activate gatk" > /root/run_unit_tests.sh && \
     echo "ln -s /gatkCloneMountPoint/build/ /gatkCloneMountPoint/scripts/docker/build" >> /root/run_unit_tests.sh && \
     echo "cd /gatk/ && /gatkCloneMountPoint/gradlew -Dfile.encoding=UTF-8 -b /gatkCloneMountPoint/dockertest.gradle testOnPackagedReleaseJar jacocoTestReportOnPackagedReleaseJar -a -p /gatkCloneMountPoint" >> /root/run_unit_tests.sh
 
-#WORKDIR /root
 RUN cp -r /root/run_unit_tests.sh /gatk && \
     cp -r /root/gatk.jar /gatk
 ENV CLASSPATH=/gatk/gatk.jar:$CLASSPATH PATH=$CONDA_PATH/envs/gatk/bin:$CONDA_PATH/bin:$PATH
 
 # Start GATK Python environment
 
-#WORKDIR /gatk
-#ENV PATH $CONDA_PATH/envs/gatk/bin:$CONDA_PATH/bin:$PATH
 RUN conda env create -n gatk -f /gatk/gatkcondaenv.yml && \
     echo "source activate gatk" >> /gatk/gatkenv.rc && \
     echo "source /gatk/gatk-completion.sh" >> /gatk/gatkenv.rc && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
-ARG BASE_DOCKER=broadinstitute/gatk:gatkbase-3.2.0
+ARG BASE_DOCKER=terrapublic.azurecr.io/gatkbase:3.2.0-squashed
 
 # stage 1 for constructing the GATK zip
 FROM ${BASE_DOCKER} AS gradleBuild
 LABEL stage=gatkIntermediateBuildImage
 ARG RELEASE=false
 
-RUN ls .
+#unnecessary
+#RUN ls .
 ADD . /gatk
 WORKDIR /gatk
 
 # Get an updated gcloud signing key, in case the one in the base image has expired
+#Download only resources required for the build, not for testing
 RUN rm /etc/apt/sources.list.d/google-cloud-sdk.list && \
     apt update &&\
     apt-key list && \
@@ -19,16 +21,13 @@ RUN rm /etc/apt/sources.list.d/google-cloud-sdk.list && \
     apt-get -y clean  && \
     apt-get -y autoclean  && \
     apt-get -y autoremove && \
-    rm -rf /var/lib/apt/lists/*
-RUN git lfs install --force
-
-#Download only resources required for the build, not for testing
-RUN git lfs pull --include src/main/resources/large
-
-RUN export GRADLE_OPTS="-Xmx4048m -Dorg.gradle.daemon=false" && /gatk/gradlew clean collectBundleIntoDir shadowTestClassJar shadowTestJar -Drelease=$RELEASE
-RUN cp -r $( find /gatk/build -name "*bundle-files-collected" )/ /gatk/unzippedJar/
-RUN unzip -o -j $( find /gatk/unzippedJar -name "gatkPython*.zip" ) -d /gatk/unzippedJar/scripts
-RUN chmod -R a+rw /gatk/unzippedJar
+    rm -rf /var/lib/apt/lists/* && \
+    git lfs install --force && \
+    git lfs pull --include src/main/resources/large && \
+    export GRADLE_OPTS="-Xmx4048m -Dorg.gradle.daemon=false" && /gatk/gradlew clean collectBundleIntoDir shadowTestClassJar shadowTestJar -Drelease=$RELEASE && \
+    cp -r $( find /gatk/build -name "*bundle-files-collected" )/ /gatk/unzippedJar/ && \
+    unzip -o -j $( find /gatk/unzippedJar -name "gatkPython*.zip" ) -d /gatk/unzippedJar/scripts && \
+    chmod -R a+rw /gatk/unzippedJar
 
 FROM ${BASE_DOCKER}
 
@@ -47,17 +46,17 @@ RUN chmod -R a+rw /gatk
 COPY --from=gradleBuild /gatk/unzippedJar .
 
 #Setup linked jars that may be needed for running gatk
-RUN ln -s $( find /gatk -name "gatk*local.jar" ) gatk.jar
-RUN ln -s $( find /gatk -name "gatk*local.jar" ) /root/gatk.jar
-RUN ln -s $( find /gatk -name "gatk*spark.jar" ) gatk-spark.jar
+RUN ln -s $( find /gatk -name "gatk*local.jar" ) gatk.jar && \
+    ln -s $( find /gatk -name "gatk*local.jar" ) /root/gatk.jar && \
+    ln -s $( find /gatk -name "gatk*spark.jar" ) gatk-spark.jar
 
 WORKDIR /root
 
  # Make sure we can see a help message
-RUN java -jar gatk.jar -h
-RUN mkdir /gatkCloneMountPoint
-RUN mkdir /jars
-RUN mkdir .gradle
+RUN java -jar gatk.jar -h && \
+    mkdir /gatkCloneMountPoint && \
+    mkdir /jars && \
+    mkdir .gradle
 
 WORKDIR /gatk
 
@@ -80,15 +79,15 @@ RUN echo "source activate gatk" > /root/run_unit_tests.sh && \
     echo "ln -s /gatkCloneMountPoint/build/ /gatkCloneMountPoint/scripts/docker/build" >> /root/run_unit_tests.sh && \
     echo "cd /gatk/ && /gatkCloneMountPoint/gradlew -Dfile.encoding=UTF-8 -b /gatkCloneMountPoint/dockertest.gradle testOnPackagedReleaseJar jacocoTestReportOnPackagedReleaseJar -a -p /gatkCloneMountPoint" >> /root/run_unit_tests.sh
 
-WORKDIR /root
-RUN cp -r /root/run_unit_tests.sh /gatk
-RUN cp -r gatk.jar /gatk
-ENV CLASSPATH /gatk/gatk.jar:$CLASSPATH
+#WORKDIR /root
+RUN cp -r /root/run_unit_tests.sh /gatk && \
+    cp -r /root/gatk.jar /gatk
+ENV CLASSPATH=/gatk/gatk.jar:$CLASSPATH PATH=$CONDA_PATH/envs/gatk/bin:$CONDA_PATH/bin:$PATH
 
 # Start GATK Python environment
 
-WORKDIR /gatk
-ENV PATH $CONDA_PATH/envs/gatk/bin:$CONDA_PATH/bin:$PATH
+#WORKDIR /gatk
+#ENV PATH $CONDA_PATH/envs/gatk/bin:$CONDA_PATH/bin:$PATH
 RUN conda env create -n gatk -f /gatk/gatkcondaenv.yml && \
     echo "source activate gatk" >> /gatk/gatkenv.rc && \
     echo "source /gatk/gatk-completion.sh" >> /gatk/gatkenv.rc && \

--- a/scripts/docker/gatkbase/Dockerfile
+++ b/scripts/docker/gatkbase/Dockerfile
@@ -61,25 +61,4 @@ RUN apt update && \
     conda config --set solver libmamba && \
     rm -rf /root/.cache/pip
 
-# Set environment variables.
-# ENV HOME /root
-
-# ENV JAVA_LIBRARY_PATH /usr/lib/jni
-
-# Install miniconda
-# ENV DOWNLOAD_DIR /downloads
-# ENV CONDA_URL https://repo.anaconda.com/miniconda/Miniconda3-py310_23.10.0-1-Linux-x86_64.sh
-# ENV CONDA_SHA256 "c7a34df472feb69805b64df6e8db58363c5ccab41cd3b40b07e3e6dfb924359a"
-# ENV CONDA_PATH /opt/miniconda
-# ENV PATH $CONDA_PATH/bin:$PATH
-# RUN mkdir $DOWNLOAD_DIR && \
-#     wget -nv -O $DOWNLOAD_DIR/miniconda.sh $CONDA_URL && \
-#     test "$(sha256sum $DOWNLOAD_DIR/miniconda.sh | awk -v FS=' ' -v ORS='' '{print $1}')" = "$CONDA_SHA256" && \
-#     bash $DOWNLOAD_DIR/miniconda.sh -p $CONDA_PATH -b && \
-#     rm $DOWNLOAD_DIR/miniconda.sh && \
-#     conda clean -afy && \
-#     conda config --set auto_update_conda false && \
-#     conda config --set solver libmamba && \
-#     rm -rf /root/.cache/pip
-# Define default command.
 CMD ["bash"]

--- a/scripts/docker/gatkbase/Dockerfile
+++ b/scripts/docker/gatkbase/Dockerfile
@@ -3,10 +3,14 @@
 # NOTE: If you update the ubuntu version make sure to update the samtools/bcftools/bedtools versions in the README
 FROM ubuntu:22.04
 
+# Set environment variables.
 # Avoid interactive prompts during apt installs/upgrades
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND="noninteractive" HOME="/root" JAVA_LIBRARY_PATH="/usr/lib/jni" DOWNLOAD_DIR="/downloads" CONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-py310_23.10.0-1-Linux-x86_64.sh" CONDA_SHA256="c7a34df472feb69805b64df6e8db58363c5ccab41cd3b40b07e3e6dfb924359a" CONDA_PATH="/opt/miniconda" PATH="/opt/miniconda/bin:$PATH"
 
-#### Basic image utilities
+# Define working directory.
+WORKDIR /root
+
+#### Basic image utilities, google cloud support, and miniconda
 RUN apt update && \
     apt full-upgrade -y && \
     apt install -y --no-install-recommends \
@@ -32,12 +36,9 @@ RUN apt update && \
     apt -y clean  && \
     apt -y autoclean  && \
     apt -y autoremove && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN java -version
-
-#### Specific for google cloud support
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" \
+    rm -rf /var/lib/apt/lists/* && \
+    java -version && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" \
     | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
     | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
     apt update -y && \
@@ -49,26 +50,8 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
 #  Remove the anthos cli tool and related files since they are very large and we / anyone using the docker are unlikely to use them
 #  Remove the bundled python because we have python installed separately
     rm -rf /usr/lib/google-cloud-sdk/bin/anthoscli /usr/lib/google-cloud-sdk/platform/anthoscli_licenses /usr/lib/google-cloud-sdk/platform/bundledpythonunix && \
-    find / -wholename "*__pycache__/*.pyc" -exec rm {} + 
-
-# Set environment variables.
-ENV HOME /root
-
-# Define working directory.
-WORKDIR /root
-
-# Define default command.
-CMD ["bash"]
-
-ENV JAVA_LIBRARY_PATH /usr/lib/jni
-
-# Install miniconda
-ENV DOWNLOAD_DIR /downloads
-ENV CONDA_URL https://repo.anaconda.com/miniconda/Miniconda3-py310_23.10.0-1-Linux-x86_64.sh
-ENV CONDA_SHA256 "c7a34df472feb69805b64df6e8db58363c5ccab41cd3b40b07e3e6dfb924359a"
-ENV CONDA_PATH /opt/miniconda
-ENV PATH $CONDA_PATH/bin:$PATH
-RUN mkdir $DOWNLOAD_DIR && \
+    find / -wholename "*__pycache__/*.pyc" -exec rm {} + && \
+    mkdir $DOWNLOAD_DIR && \
     wget -nv -O $DOWNLOAD_DIR/miniconda.sh $CONDA_URL && \
     test "$(sha256sum $DOWNLOAD_DIR/miniconda.sh | awk -v FS=' ' -v ORS='' '{print $1}')" = "$CONDA_SHA256" && \
     bash $DOWNLOAD_DIR/miniconda.sh -p $CONDA_PATH -b && \
@@ -77,3 +60,26 @@ RUN mkdir $DOWNLOAD_DIR && \
     conda config --set auto_update_conda false && \
     conda config --set solver libmamba && \
     rm -rf /root/.cache/pip
+
+# Set environment variables.
+# ENV HOME /root
+
+# ENV JAVA_LIBRARY_PATH /usr/lib/jni
+
+# Install miniconda
+# ENV DOWNLOAD_DIR /downloads
+# ENV CONDA_URL https://repo.anaconda.com/miniconda/Miniconda3-py310_23.10.0-1-Linux-x86_64.sh
+# ENV CONDA_SHA256 "c7a34df472feb69805b64df6e8db58363c5ccab41cd3b40b07e3e6dfb924359a"
+# ENV CONDA_PATH /opt/miniconda
+# ENV PATH $CONDA_PATH/bin:$PATH
+# RUN mkdir $DOWNLOAD_DIR && \
+#     wget -nv -O $DOWNLOAD_DIR/miniconda.sh $CONDA_URL && \
+#     test "$(sha256sum $DOWNLOAD_DIR/miniconda.sh | awk -v FS=' ' -v ORS='' '{print $1}')" = "$CONDA_SHA256" && \
+#     bash $DOWNLOAD_DIR/miniconda.sh -p $CONDA_PATH -b && \
+#     rm $DOWNLOAD_DIR/miniconda.sh && \
+#     conda clean -afy && \
+#     conda config --set auto_update_conda false && \
+#     conda config --set solver libmamba && \
+#     rm -rf /root/.cache/pip
+# Define default command.
+CMD ["bash"]


### PR DESCRIPTION
As part of my work in the Pipeline Dev team, I created 2 GATK images to address issue discussed [here](https://github.com/broadinstitute/gatk/issues/8684) (ie. having too many docker layers, we hit ACR limits very quickly). The images are in terrapublic, a premium-tier ACR and is publicly accessible. I made two images, one is squashed to just 1 layer, the other is reduced to just 12 layers (from the original 45). With these changes and the fact that terrapublic is on [premium](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-skus#registry-throughput-and-throttling) tier, the maximum docker pulls per minute becomes  833 (ie. 10k readOps / 12 layers) for the reduced-layers image and 10,000 for the squashed one. We have yet to test these in our pipelines but I anticipate the squashed version to be slower since it won’t be able to take advantage of any parallel pulls or caching, hence the two versions to allow pipeline devs to decide which one is better for their use-case.
