### PR TITLE
Mutect2 germline resource can have split multiallelic format

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
@@ -433,10 +433,12 @@ public class SomaticGenotypingEngine implements AutoCloseable {
             List<OptionalInt> germlineIndices = GATKVariantContextUtils.alleleIndices(allAlleles, germlineVC.getAlleles());
             final List<Double> germlineAltAFs = Mutect2Engine.getAttributeAsDoubleList(germlineVC, VCFConstants.ALLELE_FREQUENCY_KEY, afOfAllelesNotInGermlineResource);
 
-            for (int alleleIndex = 1; alleleIndex < allAlleles.size(); alleleIndex++) { // start at 1 to skip the reference, which doesn't have an AF annotation
-                final Allele allele = allAlleles.get(alleleIndex);
-                // note the -1 since germlineAltAFs do not include ref
-                germlineIndices.get(alleleIndex).ifPresent(germlineIndex -> alleleFrequencies.put(allele, germlineAltAFs.get(germlineIndex - 1)));
+            if (germlineAltAFs.size() == (germlineVC.getNAlleles() - 1)) {  // skip VCs with a bad AF field that got parsed as a wrong-length list
+                for (int alleleIndex = 1; alleleIndex < allAlleles.size(); alleleIndex++) { // start at 1 to skip the reference, which doesn't have an AF annotation
+                    final Allele allele = allAlleles.get(alleleIndex);
+                    // note the -1 since germlineAltAFs do not include ref
+                    germlineIndices.get(alleleIndex).ifPresent(germlineIndex -> alleleFrequencies.put(allele, germlineAltAFs.get(germlineIndex - 1)));
+                }
             }
         }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
@@ -433,7 +433,7 @@ public class SomaticGenotypingEngine implements AutoCloseable {
             List<OptionalInt> germlineIndices = GATKVariantContextUtils.alleleIndices(allAlleles, germlineVC.getAlleles());
             final List<Double> germlineAltAFs = Mutect2Engine.getAttributeAsDoubleList(germlineVC, VCFConstants.ALLELE_FREQUENCY_KEY, afOfAllelesNotInGermlineResource);
 
-            for (int alleleIndex = 0; alleleIndex < allAlleles.size(); alleleIndex++) {
+            for (int alleleIndex = 1; alleleIndex < allAlleles.size(); alleleIndex++) { // start at 1 to skip the reference, which doesn't have an AF annotation
                 final Allele allele = allAlleles.get(alleleIndex);
                 // note the -1 since germlineAltAFs do not include ref
                 germlineIndices.get(alleleIndex).ifPresent(germlineIndex -> alleleFrequencies.put(allele, germlineAltAFs.get(germlineIndex - 1)));

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngineUnitTest.java
@@ -53,7 +53,7 @@ public class SomaticGenotypingEngineUnitTest {
         final int stop = start + length - 1;
         final VariantContext vc1 = new VariantContextBuilder("SOURCE", "1", start, stop, germlineAlleles)
                 .attribute(VCFConstants.ALLELE_FREQUENCY_KEY, germlineAltAFs).make();
-        final double[] result = SomaticGenotypingEngine.getGermlineAltAlleleFrequencies(calledAlleles, Optional.of(vc1), DEFAULT_AF);
+        final double[] result = SomaticGenotypingEngine.getGermlineAltAlleleFrequencies(calledAlleles, List.of(vc1), DEFAULT_AF);
         Assert.assertEquals(result, expected, 1.0e-10);
     }
 
@@ -69,7 +69,7 @@ public class SomaticGenotypingEngineUnitTest {
 
     @Test(dataProvider = "missingAFData")
     public void testGetGermlineAltAlleleFrequenciesWithMissingAF(final VariantContext vc) {
-        final double[] result = SomaticGenotypingEngine.getGermlineAltAlleleFrequencies(vc.getAlleles(), Optional.of(vc), DEFAULT_AF);
+        final double[] result = SomaticGenotypingEngine.getGermlineAltAlleleFrequencies(vc.getAlleles(), List.of(vc), DEFAULT_AF);
         Assert.assertEquals(result, new double[] {DEFAULT_AF}, 1.0e-10);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngineUnitTest.java
@@ -10,6 +10,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import javax.ws.rs.core.Variant;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -87,5 +88,19 @@ public class SomaticGenotypingEngineUnitTest {
     public void testGetGermlineAltAlleleFrequenciesWithMissingAF(final VariantContext vc) {
         final double[] result = SomaticGenotypingEngine.getGermlineAltAlleleFrequencies(vc.getAlleles(), List.of(vc), DEFAULT_AF);
         Assert.assertEquals(result, new double[] {DEFAULT_AF}, 1.0e-10);
+    }
+
+    // test getting alt allele frequencies when each alt has its own VCF line and its own VariantContext
+    @Test
+    public void testGetGermlineAltAlleleFrequenciesFromSplitAllelesFormat() {
+        final double af1 = 0.1;
+        final double af2 = 0.2;
+        final VariantContext vc1 = new VariantContextBuilder("SOURCE", "1", 1, 1, Arrays.asList(Allele.REF_A, Allele.ALT_C))
+                .attribute(VCFConstants.ALLELE_FREQUENCY_KEY, af1).make();
+        final VariantContext vc2 = new VariantContextBuilder("SOURCE", "1", 1, 1, Arrays.asList(Allele.REF_A, Allele.ALT_T))
+                .attribute(VCFConstants.ALLELE_FREQUENCY_KEY, af2).make();
+        final List<Allele> alleles = List.of(Allele.REF_A, Allele.ALT_C, Allele.ALT_T);
+        final double[] result = SomaticGenotypingEngine.getGermlineAltAlleleFrequencies(alleles, List.of(vc1, vc2), DEFAULT_AF);
+        Assert.assertEquals(result, new double[] {af1, af2}, 1.0e-10);
     }
 }


### PR DESCRIPTION
See this forum issue: https://gatk.broadinstitute.org/hc/en-us/community/posts/25681424869787-Mutect2-Filtering-Discrepancy-with-Different-Versions-of-gnomAD-Germline-Data