### PR TITLE
vs 1372 excess alt alleles -- set limit to 3 for a test

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -309,6 +309,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - rc-vs-1372-excess-alt-alleles-3-test
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -111,7 +111,7 @@ workflow GvsCreateFilterSet {
         intervals                  = SplitIntervals.interval_files[i],
         fq_alt_allele_table        = fq_alt_allele_table,
         alt_allele_table_timestamp = AltAlleleTableDatetimeCheck.last_modified_timestamp,
-        excess_alleles_threshold   = 1000000,
+        excess_alleles_threshold   = 3,
         output_file                = "${filter_set_name}_${i}.vcf.gz",
         project_id                 = project_id,
         dataset_id                 = dataset_name,


### PR DESCRIPTION
ok so we will want to set the limit to 100 and update the VCF header, but this is a start at what I want for the filter model creation update