### PR TITLE
VS-1336 - It's not a site FILTER (#8773)

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -309,6 +309,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_VS-1400_ItsNotASiteFilter_EchoCallsetVersion
          tags:
              - /.*/
    - name: GvsQuickstartHailIntegration
@@ -318,6 +319,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_VS-1400_ItsNotASiteFilter_EchoCallsetVersion
          tags:
              - /.*/
    - name: GvsQuickstartIntegration
@@ -328,6 +330,7 @@ workflows:
              - master
              - ah_var_store
              - vs_1334_vcf_max_alt_alleles_echo_callset
+             - gg_VS-1400_ItsNotASiteFilter_EchoCallsetVersion
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -309,7 +309,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_VS-1400_ItsNotASiteFilter_EchoCallsetVersion
          tags:
              - /.*/
    - name: GvsQuickstartHailIntegration
@@ -319,7 +318,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_VS-1400_ItsNotASiteFilter_EchoCallsetVersion
          tags:
              - /.*/
    - name: GvsQuickstartIntegration
@@ -330,7 +328,6 @@ workflows:
              - master
              - ah_var_store
              - vs_1334_vcf_max_alt_alleles_echo_callset
-             - gg_VS-1400_ItsNotASiteFilter_EchoCallsetVersion
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -73,7 +73,7 @@ task GetToolVersions {
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
     String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2024-05-06-alpine-778d8a77294d"
-    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2024_05_24-gatkbase-cdc749be72ba"
+    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2024_05_28-gatkbase-d303d1217d50"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"
     String gotc_imputation_docker = "us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.5-1.10.2-0.1.16-1649948623"

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/FilterSensitivityTools.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/FilterSensitivityTools.java
@@ -123,11 +123,20 @@ public class FilterSensitivityTools {
                 "Site failed " + model + " model VQSLOD cutoff of " + vqsLodThreshold.toString());
     }
 
-    public static VCFHeaderLine getTruthSensitivityHeader(Double truthSensitivityThreshold, Double vqsLodThreshold, String model) {
+    public static VCFHeaderLine getTruthSensitivityFilterHeader(Double truthSensitivityThreshold, Double vqsLodThreshold, String model) {
         if (truthSensitivityThreshold == null) {  // at this point, we know that all vqsr threshold inputs are null, so use defaults
             truthSensitivityThreshold = GATKVCFConstants.SNP.contains(model) ? DEFAULT_TRUTH_SENSITIVITY_THRESHOLD_SNPS : DEFAULT_TRUTH_SENSITIVITY_THRESHOLD_INDELS;
         }
         return new VCFFilterHeaderLine(GATKVCFConstants.VQSR_FAILURE_PREFIX + model,
                 "Site failed " + model + " model sensitivity cutoff (" + truthSensitivityThreshold + "), corresponding with VQSLOD cutoff of " + vqsLodThreshold.toString());
     }
+
+    public static VCFHeaderLine getTruthSensitivityHeader(Double truthSensitivityThreshold, Double vqsLodThreshold, String model) {
+        if (truthSensitivityThreshold == null) {  // at this point, we know that all vqsr threshold inputs are null, so use defaults
+            truthSensitivityThreshold = GATKVCFConstants.SNP.contains(model) ? DEFAULT_TRUTH_SENSITIVITY_THRESHOLD_SNPS : DEFAULT_TRUTH_SENSITIVITY_THRESHOLD_INDELS;
+        }
+        return new VCFHeaderLine(GATKVCFConstants.VQSR_FAILURE_PREFIX + model,
+                "Sample Genotype FT filter value indicating that the genotyped allele failed " + model + " model sensitivity cutoff (" + truthSensitivityThreshold + "), corresponding with VQSLOD cutoff of " + vqsLodThreshold.toString());
+    }
+
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/gvs/common/FilterSensitivityToolsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/gvs/common/FilterSensitivityToolsTest.java
@@ -15,12 +15,12 @@ import static org.testng.Assert.*;
 public class FilterSensitivityToolsTest {
 
     // for testing inputs
-    private Double definedDoubleInput = 0.0;
-    private Double undefinedDoubleInput = null;
-    private String definedStringInput = "I'm defined!";
-    private String undefinedStringInput = null;
+    private final Double definedDoubleInput = 0.0;
+    private final Double undefinedDoubleInput = null;
+    private final String definedStringInput = "I'm defined!";
+    private final String undefinedStringInput = null;
 
-    private Map<Double, Double> testTrancheMap = new TreeMap<>();
+    private final Map<Double, Double> testTrancheMap = new TreeMap<>();
 
     @BeforeMethod
     public void setUp() {
@@ -211,7 +211,7 @@ public class FilterSensitivityToolsTest {
         VCFFilterHeaderLine expectedHeader = new VCFFilterHeaderLine(GATKVCFConstants.VQSR_FAILURE_PREFIX + model,
                 "Site failed SNP model sensitivity cutoff (90.0), corresponding with VQSLOD cutoff of 0.0");
 
-        assertEquals(getTruthSensitivityHeader(truthSensitivityThreshold, vqsLodThreshold, GATKVCFConstants.SNP), expectedHeader);
+        assertEquals(getTruthSensitivityFilterHeader(truthSensitivityThreshold, vqsLodThreshold, GATKVCFConstants.SNP), expectedHeader);
     }
 
     @Test
@@ -222,7 +222,7 @@ public class FilterSensitivityToolsTest {
         VCFFilterHeaderLine expectedHeader = new VCFFilterHeaderLine(GATKVCFConstants.VQSR_FAILURE_PREFIX + model,
                 "Site failed INDEL model sensitivity cutoff (90.0), corresponding with VQSLOD cutoff of 0.0");
 
-        assertEquals(getTruthSensitivityHeader(truthSensitivityThreshold, vqsLodThreshold, GATKVCFConstants.INDEL), expectedHeader);
+        assertEquals(getTruthSensitivityFilterHeader(truthSensitivityThreshold, vqsLodThreshold, GATKVCFConstants.INDEL), expectedHeader);
     }
 
 }


### PR DESCRIPTION
* Change extract so that when we filter at the genotype level (with FT) the VCF header has the FT filter definition in the comment/unspecified field.
* Also minor renaming of ExtractCohort argument.
* Point to updated truth.
 
 [Here's](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration/job_history/94129da8-6faf-419b-ab75-a46c228b1bbe) an integration test run. Passing everything except ValidateVDS because `reference_data` not being written due to issues beyond my control.