### PR TITLE
Add keep-contig-names parameter

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/fasta/FastaReferenceMaker.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/fasta/FastaReferenceMaker.java
@@ -73,6 +73,10 @@ public class FastaReferenceMaker extends ReferenceWalker {
     @Argument(fullName= LINE_WIDTH_LONG_NAME, doc="Maximum length of sequence to write per line", optional=true)
     public int basesPerLine = FastaReferenceWriter.DEFAULT_BASES_PER_LINE;
 
+    public static final String KEEP_CONTIG_NAMES = "keep-contig-names";
+    @Argument(fullName = KEEP_CONTIG_NAMES, doc="Keep the original contig names intact after modification", optional=true)
+    public boolean keepContigNames = false;
+
     protected FastaReferenceWriter writer;
     private int contigCount = 0;
     private int currentSequenceStartPosition = 0;
@@ -115,7 +119,12 @@ public class FastaReferenceMaker extends ReferenceWalker {
     private void finalizeSequence() {
         final String description = lastPosition.getContig() + ":" + currentSequenceStartPosition + "-" + lastPosition.getEnd();
         try {
-            writer.appendSequence(String.valueOf(contigCount), description, basesPerLine, Bytes.toArray(sequence));
+            if(keepContigNames) {
+                writer.appendSequence(lastPosition.getContig(), description, basesPerLine, Bytes.toArray(sequence));
+            }
+            else {
+                writer.appendSequence(String.valueOf(contigCount), description, basesPerLine, Bytes.toArray(sequence));
+            }
         } catch (IOException e) {
             throw new UserException.CouldNotCreateOutputFile("Failed while writing " + output + ".", e);
         }


### PR DESCRIPTION
A forum topic asked whether we can have a behavior to keep original contig names in FastaAlternateReferenceMaker tool. 

A new parameter `--keep-contig-names` is added. 

New optional behavior is to set contig names as 
`>originalcontigname description`

Here is my small local test and its result

**VCF**
```
##fileformat=VCFv4.2
##FILTER=<ID=PASS,Description="All filters passed">
##FORMAT=<ID=GT,Number=1,Type=String,Description="GT">
##contig=<ID=chr17,length=83257441>
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Sample
chr17	1	.	N	A	100	PASS	.	GT	1/1
```
**Original Fasta**
```
>chr17
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
```

**New Fasta with new optional behavior**
```
>chr17 chr17:1-83257441
ANNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
```

**Sequence dictionary created for the new Fasta.**

```
@HD	VN:1.0	SO:unsorted
@SQ	SN:chr17	LN:83257441	M5:8127f7ddcacb7afb1a6277cdd629fdcd	UR:file:///path/to/chr17_mod2.fasta
```

Default value is false therefore original behavior is kept. Should not hurt any current tests. 