### PR TITLE
Update http-nio to 1.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -336,7 +336,7 @@ dependencies {
     implementation 'org.broadinstitute:gatk-bwamem-jni:1.0.4'
     implementation 'org.broadinstitute:gatk-fermilite-jni:1.2.0'
 
-    implementation 'org.broadinstitute:http-nio:1.1.0'
+    implementation 'org.broadinstitute:http-nio:1.1.1'
 
     // Required for COSMIC Funcotator data source:
     implementation 'org.xerial:sqlite-jdbc:3.44.1.0'


### PR DESCRIPTION
This release fixes several bugs when using HttpPath resolve methods that have been affecting users. In particular, they were causing issues when trying to construct HTTP URIs for companion files such as fasta/bam indices.
