### PR TITLE
removing deprecated genomes in the cloud docker image that was causing test failures

### DIFF
--- a/scripts/cnn_variant_wdl/cnn_variant_common_tasks.wdl
+++ b/scripts/cnn_variant_wdl/cnn_variant_common_tasks.wdl
@@ -322,7 +322,7 @@ command <<<
   echo "ls (4): complete"
   >>>
   runtime {
-    docker: "broadinstitute/genomes-in-the-cloud:2.1.1"
+    docker: "${gatk_docker}"
     memory: machine_mem + " MB"
 
     # Note that the space before SSD and HDD should be included.
@@ -352,7 +352,7 @@ task SamtoolsMergeBAMs {
     }
 
   runtime {
-    docker: "broadinstitute/genomes-in-the-cloud:2.1.1"
+    docker: "${gatk_docker}"
     memory: "16 GB"
     disks: "local-disk " + disk_space_gb + " HDD"
   }

--- a/scripts/cnn_variant_wdl/cnn_variant_common_tasks.wdl
+++ b/scripts/cnn_variant_wdl/cnn_variant_common_tasks.wdl
@@ -322,7 +322,7 @@ command <<<
   echo "ls (4): complete"
   >>>
   runtime {
-    docker: "$broadinstitute/gatk:gatkbase-3.2.0"
+    docker: "broadinstitute/gatk:gatkbase-3.2.0"
     memory: machine_mem + " MB"
 
     # Note that the space before SSD and HDD should be included.

--- a/scripts/cnn_variant_wdl/cnn_variant_common_tasks.wdl
+++ b/scripts/cnn_variant_wdl/cnn_variant_common_tasks.wdl
@@ -322,7 +322,7 @@ command <<<
   echo "ls (4): complete"
   >>>
   runtime {
-    docker: "${gatk_docker}"
+    docker: "$broadinstitute/gatk:gatkbase-3.2.0"
     memory: machine_mem + " MB"
 
     # Note that the space before SSD and HDD should be included.
@@ -352,7 +352,7 @@ task SamtoolsMergeBAMs {
     }
 
   runtime {
-    docker: "${gatk_docker}"
+    docker: "broadinstitute/gatk:gatkbase-3.2.0"
     memory: "16 GB"
     disks: "local-disk " + disk_space_gb + " HDD"
   }


### PR DESCRIPTION
Fixes broken docker image pull that throws an error:
```
docker pull broadinstitute/genomes-in-the-cloud:2.1.1
2.1.1: Pulling from broadinstitute/genomes-in-the-cloud
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/broadinstitute/genomes-in-the-cloud:2.1.1 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/

```