### PR TITLE
Modified HaplotypeBasedVariantRecaller to support non-flow reads

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantrecalling/HaplotypeBasedVariantRecaller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/variantrecalling/HaplotypeBasedVariantRecaller.java
@@ -135,11 +135,11 @@ public final class HaplotypeBasedVariantRecaller extends GATKTool {
                     }
 
                     // get reads overlapping haplotypes
-                    final Map<SamReader, Collection<FlowBasedRead>> readsByReader = readsReader.getReads(haplotypeSpan, vcLoc);
+                    final Map<SamReader, Collection<GATKRead>> readsByReader = readsReader.getReads(haplotypeSpan, vcLoc);
                     final List<VariantContext>      variants = new LinkedList<>(Arrays.asList(vc));
                     if ( logger.isDebugEnabled() ) {
                         int readCount = 0;
-                        for ( Collection<FlowBasedRead> reads : readsByReader.values() )
+                        for ( Collection<GATKRead> reads : readsByReader.values() )
                             readCount += reads.size();
                         logger.debug(String.format("vcLoc %s, haplotypeSpan: %s, %d haplotypes, %d reads",
                                 vcLoc.toString(), haplotypeSpan.toString(), processedHaplotypes.size(), readCount, variants.size()));
@@ -150,16 +150,16 @@ public final class HaplotypeBasedVariantRecaller extends GATKTool {
                     final List<Map<Integer, AlleleLikelihoods<GATKRead, Allele>>> genotypeLikelihoodsList = new LinkedList<>();
                     final List<AssemblyResultSet>                                 assemblyResultList = new LinkedList<>();
                     final List<SAMFileHeader>                                     readsHeaderList = new LinkedList<>();
-                    for ( Map.Entry<SamReader, Collection<FlowBasedRead>> entry : readsByReader.entrySet() ) {
+                    for ( Map.Entry<SamReader, Collection<GATKRead>> entry : readsByReader.entrySet() ) {
                         final AssemblyResultSet assemblyResult = new AssemblyResultSet();
                         processedHaplotypes.forEach(haplotype -> assemblyResult.add(haplotype));
 
                         final Map<String, List<GATKRead>> perSampleReadList = new LinkedHashMap<>();
                         final SamReader                   samReader = entry.getKey();
-                        final Collection<FlowBasedRead>   reads = entry.getValue();
+                        final Collection<GATKRead>   reads = entry.getValue();
 
                         List<GATKRead> gtakReads = new LinkedList<>();
-                        reads.forEach(flowBasedRead -> gtakReads.add(flowBasedRead));
+                        reads.forEach(read -> gtakReads.add(read));
                         perSampleReadList.put(sampleNames[0], gtakReads);
                         AssemblyRegion regionForGenotyping = new AssemblyRegion(haplotypeSpan, 0, samReader.getFileHeader());
                         assemblyResult.setPaddedReferenceLoc(haplotypeSpan);

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantrecalling/TrimmedReadsReaderUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/variantrecalling/TrimmedReadsReaderUnitTest.java
@@ -5,6 +5,7 @@ import htsjdk.samtools.util.Locatable;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.read.FlowBasedRead;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -68,10 +69,10 @@ public class TrimmedReadsReaderUnitTest extends GATKBaseTest {
         Assert.assertNotNull(reader.getHeader(null));
 
         // reads
-        Map<SamReader, Collection<FlowBasedRead>> reads = reader.getReads(span, vcLoc);
+        Map<SamReader, Collection<GATKRead>> reads = reader.getReads(span, vcLoc);
         Assert.assertEquals(reads.size(), bamSources.length);
         int             bamSourceIndex = 0;
-        for ( Map.Entry<SamReader, Collection<FlowBasedRead>> entry : reads.entrySet() ) {
+        for ( Map.Entry<SamReader, Collection<GATKRead>> entry : reads.entrySet() ) {
 
             final BamSource       bamSource = bamSources[bamSourceIndex++];
 
@@ -83,8 +84,8 @@ public class TrimmedReadsReaderUnitTest extends GATKBaseTest {
             Assert.assertEquals(entry.getValue().size(), bamSource.readCount);
 
             // verify first and last
-            FlowBasedRead       firstRead = entry.getValue().iterator().next();
-            FlowBasedRead       lastRead = entry.getValue().stream().reduce((prev, next) -> next).orElse(null);
+            FlowBasedRead       firstRead = (FlowBasedRead) entry.getValue().iterator().next();
+            FlowBasedRead       lastRead = (FlowBasedRead) entry.getValue().stream().reduce((prev, next) -> next).orElse(null);
             Assert.assertEquals(firstRead.getName(), bamSource.firstReadName);
             Assert.assertEquals(lastRead.getName(), bamSource.lastReadName);
         }


### PR DESCRIPTION
Someone asked to adopt HaplotypeBasedVariantRecaller for Illumina reads. since it is a small fix, I think it is worth merging