### PR TITLE
Intersect target and truth for P&S [VS-1460]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -279,6 +279,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - vs_1460_intersect_target_truth_ps
          tags:
              - /.*/
    - name: GvsQuickstartVcfIntegration

--- a/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
+++ b/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
@@ -548,12 +548,14 @@ task IntersectTargetIntervalListWithTruthBed {
         PS4='\D{+%F %T} \w $ '
         set -o errexit -o nounset -o pipefail -o xtrace
 
-        target_bed="~{target_interval_list}"
+        # `basename` so the output ends up in $PWD (/cromwell_root) and not wherever the inputs were localized.
+        # The outputs of these transformations need to be in a place where the `glob` expression will find them.
+        target_bed="$(basename ~{target_interval_list})"
         target_bed="${target_bed%%.interval_list}.bed"
 
         gatk IntervalListToBed -I ~{target_interval_list} -O "${target_bed}" --SORT
 
-        truth_bed="~{truth_bed}"
+        truth_bed="$(basename ~{truth_bed})"
         intersected_truth_bed="${truth_bed%%.bed}"
         intersected_truth_bed="${intersected_truth_bed}_intersected.bed"
 

--- a/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
+++ b/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
@@ -103,12 +103,12 @@ workflow GvsCalculatePrecisionAndSensitivity {
     call IntersectTargetIntervalListWithTruthBeds {
       input:
         truth_beds = truth_beds,
-        target_interval_list = target_interval_list,
+        target_interval_list = select_first([target_interval_list]),
         gatk_docker = effective_gatk_docker,
     }
   }
 
-  Array[File] effective_truth_beds = if (defined(target_interval_list)) then IntersectTargetIntervalListWithTruthBeds.intersected_truth_beds else truth_beds
+  Array[File] effective_truth_beds = if (defined(target_interval_list)) then select_first([IntersectTargetIntervalListWithTruthBeds.intersected_truth_beds]) else truth_beds
 
   scatter(i in range(length(sample_names))) {
     String sample_name = sample_names[i]

--- a/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
+++ b/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
@@ -555,8 +555,8 @@ task IntersectTargetIntervalListWithTruthBed {
 
         gatk IntervalListToBed -I ~{target_interval_list} -O "${target_bed}" --SORT
 
-        truth_bed="$(basename ~{truth_bed})"
-        intersected_truth_bed="${truth_bed%%.bed}"
+        truth_bed="~{truth_bed}"
+        intersected_truth_bed="$(basename ${truth_bed%%.bed})"
         intersected_truth_bed="${intersected_truth_bed}_intersected.bed"
 
         bedtools intersect -a "${target_bed}" -b ${truth_bed} > ${intersected_truth_bed}

--- a/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
+++ b/scripts/variantstore/wdl/GvsCalculatePrecisionAndSensitivity.wdl
@@ -553,6 +553,7 @@ task IntersectTargetIntervalListWithTruthBed {
 
         gatk IntervalListToBed -I ~{target_interval_list} -O "${target_bed}" --SORT
 
+        truth_bed="~{truth_bed}"
         intersected_truth_bed="${truth_bed%%.bed}"
         intersected_truth_bed="${intersected_truth_bed}_intersected.bed"
 


### PR DESCRIPTION
When a target interval list is provided for exomes, create a saner truth bed that intersects the provided truth beds with this target interval list. Successful run [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Exome%20Data%2049k/job_history/b3185159-e53e-4418-9803-a24c064df1a3).