### PR TITLE
FlowFeatureMapper optimization

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapper.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapper.java
@@ -27,6 +27,7 @@ import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.HaplotypeCall
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.ReferenceConfidenceMode;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
 import org.broadinstitute.hellbender.utils.haplotype.FlowBasedHaplotype;
 import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
 import org.broadinstitute.hellbender.utils.read.FlowBasedRead;
@@ -90,6 +91,7 @@ import java.util.function.Supplier;
 public final class FlowFeatureMapper extends ThreadedReadWalker {
 
     public static final int CAPACITY1 = 5000;
+    private static final long CACHE_SIZE_FACTOR = 5;
 
     static class CopyAttrInfo {
         public final String name;
@@ -318,6 +320,11 @@ public final class FlowFeatureMapper extends ThreadedReadWalker {
                 }
             });
             writerWorker.start();;
+        }
+
+        // if using threaded walker extend reference cache to avoid thrushing
+        if ( threadedWalker ) {
+            CachingIndexedFastaSequenceFile.requestedCacheSize = CachingIndexedFastaSequenceFile.DEFAULT_CACHE_SIZE * CACHE_SIZE_FACTOR;
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapper.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapper.java
@@ -34,6 +34,7 @@ import org.broadinstitute.hellbender.utils.haplotype.FlowBasedHaplotype;
 import org.broadinstitute.hellbender.utils.read.FlowBasedRead;
 
 import java.util.*;
+import java.util.function.Supplier;
 
 
 /**
@@ -197,7 +198,7 @@ public final class FlowFeatureMapper extends ReadWalker {
         int         filteredCount;
         int         nonIdentMBasesOnRead;
         int         featuresOnRead;
-        int         refEditDistance;
+        Supplier<Integer> refEditDistance;
         int         index;
         int         smqLeft;
         int         smqRight;
@@ -703,7 +704,9 @@ public final class FlowFeatureMapper extends ReadWalker {
         vcb.attribute(VCF_FC1, fr.nonIdentMBasesOnRead);
         vcb.attribute(VCF_FC2, fr.featuresOnRead);
         vcb.attribute(VCF_LENGTH, fr.read.getLength());
-        vcb.attribute(VCF_EDIST, fr.refEditDistance);
+        if ( !fmArgs.noEditDistance && fr.refEditDistance != null ) {
+            vcb.attribute(VCF_EDIST, fr.refEditDistance.get());
+        }
         vcb.attribute(VCF_INDEX, fr.index);
 
         // median/mean quality on?

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapper.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapper.java
@@ -781,12 +781,14 @@ public final class FlowFeatureMapper extends ThreadedReadWalker {
         vcb.attribute(VCF_FC1, fr.nonIdentMBasesOnRead);
         vcb.attribute(VCF_FC2, fr.featuresOnRead);
         vcb.attribute(VCF_LENGTH, fr.read.getLength());
-        if ( fmArgs.nmEditDistance ) {
-            int nmScore = SequenceUtil.calculateSamNmTag(fr.read.convertToSAMRecord(getHeaderForReads()), fr.referenceContext.getBases(new SimpleInterval(fr.read)), fr.read.getStart() - 1);
-            vcb.attribute(VCF_EDIST, nmScore);
-        } else if ( fr.refEditDistance != null ) {
-            int editDisance = fr.refEditDistance.get(); // this actually computes the distance
-            vcb.attribute(VCF_EDIST, editDisance);
+        if ( !fmArgs.noEditDistance) {
+            if (fmArgs.nmEditDistance) {
+                int nmScore = SequenceUtil.calculateSamNmTag(fr.read.convertToSAMRecord(getHeaderForReads()), fr.referenceContext.getBases(new SimpleInterval(fr.read)), fr.read.getStart() - 1);
+                vcb.attribute(VCF_EDIST, nmScore);
+            } else if (fr.refEditDistance != null) {
+                int editDisance = fr.refEditDistance.get(); // this actually computes the distance
+                vcb.attribute(VCF_EDIST, editDisance);
+            }
         }
         vcb.attribute(VCF_INDEX, fr.index);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapper.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapper.java
@@ -319,13 +319,20 @@ public final class FlowFeatureMapper extends ThreadedReadWalker {
                     }
                 }
             });
+            writerWorker.setUncaughtExceptionHandler(getUncaughtExceptionHandler());
             writerWorker.start();;
+        }
+
+        // if using threads, set handler for this thread as well
+        if ( threadedWalker || threadedWriter ) {
+            Thread.currentThread().setUncaughtExceptionHandler(getUncaughtExceptionHandler());
         }
 
         // if using threaded walker extend reference cache to avoid thrushing
         if ( threadedWalker ) {
             CachingIndexedFastaSequenceFile.requestedCacheSize = CachingIndexedFastaSequenceFile.DEFAULT_CACHE_SIZE * CACHE_SIZE_FACTOR;
         }
+
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperArgumentCollection.java
@@ -90,6 +90,12 @@ public class FlowFeatureMapperArgumentCollection implements Serializable{
     public boolean keepSupplementaryAlignments = false;
 
     /**
+     *  do not emit edit distance at all
+     **/
+    @Argument(fullName = "no-edit-distance", doc = "do not emit edit distance at all ?", optional = true)
+    public boolean noEditDistance = false;
+
+    /**
      *  edit distance should come from computed NM
      **/
     @Argument(fullName = "nm-edit-distance", doc = "edit distance should come from computed NM ?", optional = true)

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperArgumentCollection.java
@@ -96,6 +96,12 @@ public class FlowFeatureMapperArgumentCollection implements Serializable{
     public boolean noEditDistance = false;
 
     /**
+     *  use a separate thread for the mapper
+     **/
+    @Argument(fullName = "use-mapper-thread", doc = "use a separate thread for the mapper ?", optional = true)
+    public boolean useMapperThread = false;
+
+    /**
      *  debug negatives?
      **/
     @Hidden

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperArgumentCollection.java
@@ -90,10 +90,10 @@ public class FlowFeatureMapperArgumentCollection implements Serializable{
     public boolean keepSupplementaryAlignments = false;
 
     /**
-     *  no edit distance (compute intensive)?
+     *  edit distance should come from computed NM
      **/
-    @Argument(fullName = "no-edit-distance", doc = "do not emit edit-distance metrics (compute intensive) ?", optional = true)
-    public boolean noEditDistance = false;
+    @Argument(fullName = "nm-edit-distance", doc = "edit distance should come from computed NM ?", optional = true)
+    public boolean nmEditDistance = false;
 
     /**
      *  debug negatives?

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperArgumentCollection.java
@@ -90,6 +90,12 @@ public class FlowFeatureMapperArgumentCollection implements Serializable{
     public boolean keepSupplementaryAlignments = false;
 
     /**
+     *  no edit distance (compute intensive)?
+     **/
+    @Argument(fullName = "no-edit-distance", doc = "do not emit edit-distance metrics (compute intensive) ?", optional = true)
+    public boolean noEditDistance = false;
+
+    /**
      *  debug negatives?
      **/
     @Hidden

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperArgumentCollection.java
@@ -96,12 +96,6 @@ public class FlowFeatureMapperArgumentCollection implements Serializable{
     public boolean noEditDistance = false;
 
     /**
-     *  use a separate thread for the mapper
-     **/
-    @Argument(fullName = "use-mapper-thread", doc = "use a separate thread for the mapper ?", optional = true)
-    public boolean useMapperThread = false;
-
-    /**
      *  debug negatives?
      **/
     @Hidden

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/SNVMapper.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/SNVMapper.java
@@ -139,7 +139,7 @@ public class SNVMapper implements FeatureMapper {
                         }
 
                         // add this feature
-                        FlowFeatureMapper.MappedFeature feature = FlowFeatureMapper.MappedFeature.makeSNV(read, readOfs, ref[refOfs], referenceContext.getStart() + refOfs, readOfs - refOfs);
+                        FlowFeatureMapper.MappedFeature feature = FlowFeatureMapper.MappedFeature.makeSNV(read, readOfs, ref[refOfs], referenceContext.getStart() + refOfs, readOfs - refOfs, referenceContext);
                         if ( (fmArgs.reportAllAlts || fmArgs.tagBasesWithAdjacentRefDiff) && !surrounded )
                             feature.adjacentRefDiff = true;
                         feature.nonIdentMBasesOnRead = nonIdentMBases;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/SNVMapper.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/SNVMapper.java
@@ -70,7 +70,6 @@ public class SNVMapper implements FeatureMapper {
         } else {
             basesString = new String(Arrays.copyOfRange(bases, startSoftClip, bases.length - endSoftClip));
         }
-        int               refEditDistance = levDistance.apply(basesString, new String(ref));
 
         // count bases delta on M cigar elements
         int         nonIdentMBases = 0;
@@ -144,7 +143,7 @@ public class SNVMapper implements FeatureMapper {
                         if ( (fmArgs.reportAllAlts || fmArgs.tagBasesWithAdjacentRefDiff) && !surrounded )
                             feature.adjacentRefDiff = true;
                         feature.nonIdentMBasesOnRead = nonIdentMBases;
-                        feature.refEditDistance = refEditDistance;
+                        feature.refEditDistance = () -> levDistance.apply(basesString, new String(ref));
                         if ( !read.isReverseStrand() )
                             feature.index = readOfs;
                         else

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/ThreadedReadWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/ThreadedReadWalker.java
@@ -1,0 +1,106 @@
+package org.broadinstitute.hellbender.tools.walkers.featuremapping;
+
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.hellbender.engine.FeatureContext;
+import org.broadinstitute.hellbender.engine.ReadWalker;
+import org.broadinstitute.hellbender.engine.ReferenceContext;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+
+import java.util.concurrent.LinkedBlockingQueue;
+
+public abstract class ThreadedReadWalker extends ReadWalker implements Runnable {
+
+    public static final int CAPACITY = 5000;
+
+    // apply() message and queue - carrying read/referenceContext tuples
+    static class ApplyMessage {
+        GATKRead read;
+        ReferenceContext referenceContext;
+        FeatureContext featureContext;
+    }
+
+    private LinkedBlockingQueue<ApplyMessage> applyQueue;
+    private Thread  worker;
+
+    /**
+     * turn threaded walker on
+     **/
+    @Argument(fullName = "threaded-walker", doc = "turn threaded walker on?", optional = true)
+    public boolean threadedWalker = false;
+
+
+    @Override
+    public void onTraversalStart() {
+
+        // if running in threaded mode, start worker thread
+        if ( threadedWalker ) {
+            applyQueue = new LinkedBlockingQueue<>(CAPACITY);
+            worker = new Thread(this);
+            worker.start();
+        }
+    }
+
+    @Override
+    public void closeTool() {
+
+        // if running in threaded mode, signal end of input and wait for thread to complete
+        if ( threadedWalker ) {
+            try {
+                applyQueue.put(new ApplyMessage());
+                worker.join();
+            } catch (InterruptedException e) {
+                throw new GATKException("", e );
+            }
+        }
+    }
+
+    @Override
+    final public void apply(final GATKRead read, final ReferenceContext referenceContext, final FeatureContext featureContext) {
+
+        if ( !acceptRead(read, referenceContext, featureContext) ) {
+            return;
+        }
+
+        if ( threadedWalker ) {
+            // redirect message into queue
+            ApplyMessage message = new ApplyMessage();
+            message.read = read;
+            message.referenceContext = referenceContext;
+            message.featureContext = featureContext;
+            try {
+                applyQueue.put(message);
+            } catch (InterruptedException e) {
+                throw new GATKException("", e);
+            }
+        } else {
+            applyPossiblyThreaded(read, referenceContext, featureContext);
+        }
+    }
+
+    @Override
+    public void run() {
+
+        // loop on messages
+        ApplyMessage message;
+        while ( true ) {
+            // take next message off the queue
+            try {
+                message = applyQueue.take();
+            } catch (InterruptedException e) {
+                throw new GATKException("", e);
+            }
+
+            // end of stream?
+            if ( message.read == null ) {
+                break;
+            }
+
+            // process message
+            applyPossiblyThreaded(message.read, message.referenceContext, message.featureContext);
+        }
+    }
+
+    public abstract boolean acceptRead(GATKRead read, ReferenceContext referenceContext, FeatureContext featureContext);
+    public abstract void applyPossiblyThreaded(final GATKRead read, final ReferenceContext referenceContext, final FeatureContext featureContext);
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/ThreadedReadWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/ThreadedReadWalker.java
@@ -37,6 +37,7 @@ public abstract class ThreadedReadWalker extends ReadWalker implements Runnable 
         if ( threadedWalker ) {
             applyQueue = new LinkedBlockingQueue<>(CAPACITY);
             worker = new Thread(this);
+            worker.setUncaughtExceptionHandler(getUncaughtExceptionHandler());
             worker.start();
         }
     }
@@ -103,4 +104,13 @@ public abstract class ThreadedReadWalker extends ReadWalker implements Runnable 
 
     public abstract boolean acceptRead(GATKRead read, ReferenceContext referenceContext, FeatureContext featureContext);
     public abstract void applyPossiblyThreaded(final GATKRead read, final ReferenceContext referenceContext, final FeatureContext featureContext);
+
+    public Thread.UncaughtExceptionHandler getUncaughtExceptionHandler() {
+        Thread.UncaughtExceptionHandler handler = (th, ex) -> {
+            System.out.println("Uncaught exception: " + ex);
+            ex.printStackTrace(System.out);
+            System.exit(-1);
+        };
+        return handler;
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperIntegrationTest.java
@@ -254,4 +254,37 @@ public class FlowFeatureMapperIntegrationTest extends CommandLineProgramTest {
         }
     }
 
+    @Test
+    public void testMapperThread() throws IOException {
+
+        final File outputDir = createTempDir("testFlowFeatureMapperTest");
+        final File expectedFile = new File(testDir + "/snv_feature_mapper_output.vcf");
+        final File outputFile = UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ? expectedFile : new File(outputDir + "/snv_feature_mapper_output.vcf");
+
+        final String[] args = new String[] {
+                "-R", largeFileTestDir + "/Homo_sapiens_assembly38.fasta.gz",
+                "-O", outputFile.getAbsolutePath(),
+                "-I", testDir + "/snv_feature_mapper_input.cram",
+                "--copy-attr", "RG",
+                "--copy-attr", "AS,Integer,AS attribute, as copied",
+                "--copy-attr", "rq,Float",
+                "--limit-score", "100",
+                "--min-score", "0",
+                "--snv-identical-bases", "10",
+                "--debug-negatives", "false",
+                "--debug-read-name", "150451-BC94-0645901755",
+                "--use-mapper-thread"
+        };
+
+        // run the tool
+        runCommandLine(args);  // no assert, just make sure we don't throw
+
+        // make sure we've generated the otuput file
+        Assert.assertTrue(outputFile.exists());
+
+        // walk the output and expected files, compare non-comment lines
+        if ( !UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ) {
+            IntegrationTestSpec.assertEqualTextFiles(outputFile, expectedFile, "#");
+        }
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperIntegrationTest.java
@@ -273,7 +273,7 @@ public class FlowFeatureMapperIntegrationTest extends CommandLineProgramTest {
                 "--snv-identical-bases", "10",
                 "--debug-negatives", "false",
                 "--debug-read-name", "150451-BC94-0645901755",
-                "--use-mapper-thread"
+                "--threaded-walker"
         };
 
         // run the tool

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperIntegrationTest.java
@@ -221,11 +221,11 @@ public class FlowFeatureMapperIntegrationTest extends CommandLineProgramTest {
     }
 
     @Test
-    public void testNoEditDistance() throws IOException {
+    public void testNmEditDistance() throws IOException {
 
         final File outputDir = createTempDir("testFlowFeatureMapperTest");
-        final File expectedFile = new File(testDir + "/snv_feature_mapper_no_edit_disance_output.vcf");
-        final File outputFile = UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ? expectedFile : new File(outputDir + "/snv_feature_mapper_no_edit_disance_output.vcf");
+        final File expectedFile = new File(testDir + "/snv_feature_mapper_nm_edit_disance_output.vcf");
+        final File outputFile = UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ? expectedFile : new File(outputDir + "/snv_feature_mapper_nm_edit_disance_output.vcf");
 
         final String[] args = new String[] {
                 "-R", largeFileTestDir + "/Homo_sapiens_assembly38.fasta.gz",
@@ -239,7 +239,7 @@ public class FlowFeatureMapperIntegrationTest extends CommandLineProgramTest {
                 "--snv-identical-bases", "10",
                 "--debug-negatives", "false",
                 "--debug-read-name", "150451-BC94-0645901755",
-                "--no-edit-distance"
+                "--nm-edit-distance"
         };
 
         // run the tool

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperIntegrationTest.java
@@ -287,4 +287,38 @@ public class FlowFeatureMapperIntegrationTest extends CommandLineProgramTest {
             IntegrationTestSpec.assertEqualTextFiles(outputFile, expectedFile, "#");
         }
     }
+
+    @Test
+    public void testMapperWriterThreaded() throws IOException {
+
+        final File outputDir = createTempDir("testFlowFeatureMapperTest");
+        final File expectedFile = new File(testDir + "/snv_feature_mapper_output.vcf");
+        final File outputFile = UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ? expectedFile : new File(outputDir + "/snv_feature_mapper_output.vcf");
+
+        final String[] args = new String[] {
+                "-R", largeFileTestDir + "/Homo_sapiens_assembly38.fasta.gz",
+                "-O", outputFile.getAbsolutePath(),
+                "-I", testDir + "/snv_feature_mapper_input.cram",
+                "--copy-attr", "RG",
+                "--copy-attr", "AS,Integer,AS attribute, as copied",
+                "--copy-attr", "rq,Float",
+                "--limit-score", "100",
+                "--min-score", "0",
+                "--snv-identical-bases", "10",
+                "--debug-negatives", "false",
+                "--debug-read-name", "150451-BC94-0645901755",
+                "--threaded-writer"
+        };
+
+        // run the tool
+        runCommandLine(args);  // no assert, just make sure we don't throw
+
+        // make sure we've generated the otuput file
+        Assert.assertTrue(outputFile.exists());
+
+        // walk the output and expected files, compare non-comment lines
+        if ( !UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ) {
+            IntegrationTestSpec.assertEqualTextFiles(outputFile, expectedFile, "#");
+        }
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperIntegrationTest.java
@@ -220,4 +220,38 @@ public class FlowFeatureMapperIntegrationTest extends CommandLineProgramTest {
         }
     }
 
+    @Test
+    public void testNoEditDistance() throws IOException {
+
+        final File outputDir = createTempDir("testFlowFeatureMapperTest");
+        final File expectedFile = new File(testDir + "/snv_feature_mapper_no_edit_disance_output.vcf");
+        final File outputFile = UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ? expectedFile : new File(outputDir + "/snv_feature_mapper_no_edit_disance_output.vcf");
+
+        final String[] args = new String[] {
+                "-R", largeFileTestDir + "/Homo_sapiens_assembly38.fasta.gz",
+                "-O", outputFile.getAbsolutePath(),
+                "-I", testDir + "/snv_feature_mapper_input.bam",
+                "--copy-attr", "RG",
+                "--copy-attr", "AS,Integer,AS attribute, as copied",
+                "--copy-attr", "rq,Float",
+                "--limit-score", "100",
+                "--min-score", "0",
+                "--snv-identical-bases", "10",
+                "--debug-negatives", "false",
+                "--debug-read-name", "150451-BC94-0645901755",
+                "--no-edit-distance"
+        };
+
+        // run the tool
+        runCommandLine(args);  // no assert, just make sure we don't throw
+
+        // make sure we've generated the otuput file
+        Assert.assertTrue(outputFile.exists());
+
+        // walk the output and expected files, compare non-comment lines
+        if ( !UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ) {
+            IntegrationTestSpec.assertEqualTextFiles(outputFile, expectedFile, "#");
+        }
+    }
+
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/featuremapping/FlowFeatureMapperIntegrationTest.java
@@ -255,6 +255,40 @@ public class FlowFeatureMapperIntegrationTest extends CommandLineProgramTest {
     }
 
     @Test
+    public void testNoEditDistance() throws IOException {
+
+        final File outputDir = createTempDir("testFlowFeatureMapperTest");
+        final File expectedFile = new File(testDir + "/snv_feature_mapper_no_edit_disance_output.vcf");
+        final File outputFile = UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ? expectedFile : new File(outputDir + "/snv_feature_mapper_no_edit_disance_output.vcf");
+
+        final String[] args = new String[] {
+                "-R", largeFileTestDir + "/Homo_sapiens_assembly38.fasta.gz",
+                "-O", outputFile.getAbsolutePath(),
+                "-I", testDir + "/snv_feature_mapper_input.bam",
+                "--copy-attr", "RG",
+                "--copy-attr", "AS,Integer,AS attribute, as copied",
+                "--copy-attr", "rq,Float",
+                "--limit-score", "100",
+                "--min-score", "0",
+                "--snv-identical-bases", "10",
+                "--debug-negatives", "false",
+                "--debug-read-name", "150451-BC94-0645901755",
+                "--no-edit-distance"
+        };
+
+        // run the tool
+        runCommandLine(args);  // no assert, just make sure we don't throw
+
+        // make sure we've generated the otuput file
+        Assert.assertTrue(outputFile.exists());
+
+        // walk the output and expected files, compare non-comment lines
+        if ( !UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS ) {
+            IntegrationTestSpec.assertEqualTextFiles(outputFile, expectedFile, "#");
+        }
+    }
+
+    @Test
     public void testMapperThread() throws IOException {
 
         final File outputDir = createTempDir("testFlowFeatureMapperTest");

--- a/src/test/resources/large/featureMapping/snv_feature_mapper_input.cram
+++ b/src/test/resources/large/featureMapping/snv_feature_mapper_input.cram
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44edf4cfe7bf4c3897a2626dcc69f5a16c0a95b74ef101fbfc33e42204b723f9
+size 17140176

--- a/src/test/resources/large/featureMapping/snv_feature_mapper_input.cram.crai
+++ b/src/test/resources/large/featureMapping/snv_feature_mapper_input.cram.crai
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3fcaf3c2e53ad43c9db324f1573f94ee59cf52b8f2c05246026e17ede9e477ae
+size 453

--- a/src/test/resources/large/featureMapping/snv_feature_mapper_nm_edit_disance_output.vcf
+++ b/src/test/resources/large/featureMapping/snv_feature_mapper_nm_edit_disance_output.vcf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f385f11035635b35543e32f26239c403115c6ea9fb9fe52f1c22b8170daa3e8c
+size 5727533

--- a/src/test/resources/large/featureMapping/snv_feature_mapper_nm_edit_disance_output.vcf.idx
+++ b/src/test/resources/large/featureMapping/snv_feature_mapper_nm_edit_disance_output.vcf.idx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfc8068b45d5aa83080c41dad8b251012a9cf4287834dcf746e3b6f325fa4ebe
+size 120129

--- a/src/test/resources/large/featureMapping/snv_feature_mapper_no_edit_disance_output.vcf
+++ b/src/test/resources/large/featureMapping/snv_feature_mapper_no_edit_disance_output.vcf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:07689d2722ddcbc8d5471f1fa51bbeba60e62ce8754d6ebb9795e64fe4270ed4
-size 5476289

--- a/src/test/resources/large/featureMapping/snv_feature_mapper_no_edit_disance_output.vcf
+++ b/src/test/resources/large/featureMapping/snv_feature_mapper_no_edit_disance_output.vcf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f107859a15da37e78211eed16f70ba592d09f49fa71680ec85bd4af6dd6c8c53
+size 5476362

--- a/src/test/resources/large/featureMapping/snv_feature_mapper_no_edit_disance_output.vcf
+++ b/src/test/resources/large/featureMapping/snv_feature_mapper_no_edit_disance_output.vcf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07689d2722ddcbc8d5471f1fa51bbeba60e62ce8754d6ebb9795e64fe4270ed4
+size 5476289

--- a/src/test/resources/large/featureMapping/snv_feature_mapper_no_edit_disance_output.vcf.idx
+++ b/src/test/resources/large/featureMapping/snv_feature_mapper_no_edit_disance_output.vcf.idx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e18ecfc4a3ff82d796f6f80852a945d1a586acf052dd7224cb55ee6efeb468c
+size 120129

--- a/src/test/resources/large/featureMapping/snv_feature_mapper_no_edit_disance_output.vcf.idx
+++ b/src/test/resources/large/featureMapping/snv_feature_mapper_no_edit_disance_output.vcf.idx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4e18ecfc4a3ff82d796f6f80852a945d1a586acf052dd7224cb55ee6efeb468c
-size 120129

--- a/src/test/resources/large/featureMapping/snv_feature_mapper_no_edit_disance_output.vcf.idx
+++ b/src/test/resources/large/featureMapping/snv_feature_mapper_no_edit_disance_output.vcf.idx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d49b4bafdd1730b04296a814d6902547666f07b73778fbd12243e9b69eeb49c5
+size 120129


### PR DESCRIPTION
An effort to make the tool run faster. The following was improved/changed:

1. Edit distance calculation can now be based on NM tag
2. Core of the tool (anything after the input file reader) can be run on a separate thread. This is useful when reading CPU is significant (as in CRAM decoding). The implementation calls for a ThreadedReadWalker, implementing a pattern similar to ReadWalker and allowing the threading to optional. This implementation is currently private to the tool.
3. An option to defer output VCF creation to a separate thread