### PR TITLE
VS-1466 restructure export vcf for copy reasons

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -165,6 +165,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_VS-1466_RestructureExportVcfForCopyReasons
          tags:
              - /.*/
    - name: GvsImportGenomes

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -291,6 +291,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_VS-1466_RestructureExportVcfForCopyReasons
          tags:
              - /.*/
    - name: GvsQuickstartHailIntegration
@@ -300,6 +301,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_VS-1466_RestructureExportVcfForCopyReasons
          tags:
              - /.*/
    - name: GvsQuickstartIntegration
@@ -310,6 +312,7 @@ workflows:
              - master
              - ah_var_store
              - vs_1456_status_writes_bug
+             - gg_VS-1466_RestructureExportVcfForCopyReasons
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -165,7 +165,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_VS-1466_RestructureExportVcfForCopyReasons
          tags:
              - /.*/
    - name: GvsImportGenomes
@@ -291,7 +290,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_VS-1466_RestructureExportVcfForCopyReasons
          tags:
              - /.*/
    - name: GvsQuickstartHailIntegration
@@ -301,7 +299,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_VS-1466_RestructureExportVcfForCopyReasons
          tags:
              - /.*/
    - name: GvsQuickstartIntegration
@@ -312,7 +309,6 @@ workflows:
              - master
              - ah_var_store
              - vs_1456_status_writes_bug
-             - gg_VS-1466_RestructureExportVcfForCopyReasons
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -258,16 +258,6 @@ workflow GvsExtractCallset {
         target_interval_list                  = target_interval_list,
     }
 
-#    call MakeManifestEntryAndOptionallyCopyOutputs {
-#      input:
-#        interval_index = i,
-#        output_vcf = ExtractTask.output_vcf,
-#        output_vcf_index = ExtractTask.output_vcf_index,
-#        output_vcf_bytes = ExtractTask.output_vcf_bytes,
-#        output_vcf_index_bytes = ExtractTask.output_vcf_index_bytes,
-#        output_gcs_dir = output_gcs_dir,
-#        cloud_sdk_docker = effective_cloud_sdk_docker,
-#    }
   }
 
   call SumBytes {
@@ -286,13 +276,6 @@ workflow GvsExtractCallset {
       output_gcs_dir = output_gcs_dir,
       cloud_sdk_docker = effective_cloud_sdk_docker,
   }
-
-#  call CreateManifest {
-#    input:
-#      manifest_lines = MakeManifestEntryAndOptionallyCopyOutputs.manifest,
-#      output_gcs_dir = output_gcs_dir,
-#      cloud_sdk_docker = effective_cloud_sdk_docker,
-#  }
 
   call Utils.GetBQTableLastModifiedDatetime {
     input:
@@ -315,8 +298,7 @@ workflow GvsExtractCallset {
     Array[File] output_vcf_indexes = ExtractTask.output_vcf_index
     Array[File] output_vcf_interval_files = SplitIntervals.interval_files
     Float total_vcfs_size_mb = SumBytes.total_mb
-#    File manifest = CreateManifest.manifest
-    File new_manifest = CreateManifestAndOptionallyCopyOutputs.manifest
+    File manifest = CreateManifestAndOptionallyCopyOutputs.manifest
     File sample_name_list = GenerateSampleListFile.sample_name_list
     String recorded_git_hash = effective_git_hash
     Boolean done = true

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "GvsUtils.wdl" as Utils
 
-# A comment?!?
+# A comment
 
 workflow GvsExtractCallset {
   input {
@@ -550,10 +550,7 @@ task CreateManifestAndOptionallyCopyOutputs {
           OUTPUT_FILE_INDEX_DEST=$LOCAL_VCF_INDEX
         fi
 
-        # Parent Task will collect manifest lines and create a joined file
-        # Currently, the schema is `[interval_number], [output_file_location], [output_file_size_bytes], [output_file_index_location], [output_file_size_bytes]`
-        echo ${interval_indices[$i]},${OUTPUT_FILE_DEST},${output_vcf_bytes[$i]},${OUTPUT_FILE_INDEX_DEST},${output_vcf_index_bytes[$i]}
-        echo ${interval_indices[$i]},${OUTPUT_FILE_DEST},${output_vcf_bytes[$i]},${OUTPUT_FILE_INDEX_DEST},${output_vcf_index_bytes[$i]} >> manifest.txt
+        echo ${interval_indices[$i]},${OUTPUT_FILE_DEST},${output_vcf_bytes[$i]},${OUTPUT_FILE_INDEX_DEST},${output_vcf_index_bytes[$i]} >> manifest_lines.txt
 
       done;
 
@@ -565,6 +562,7 @@ task CreateManifestAndOptionallyCopyOutputs {
     fi
   >>>
   output {
+    File manifest_lines = "manifest_lines.txt"
     File manifest = "manifest.txt"
   }
 

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "GvsUtils.wdl" as Utils
 
-# A comment?
+# A comment??
 
 workflow GvsExtractCallset {
   input {
@@ -533,12 +533,14 @@ task CreateManifestAndOptionallyCopyOutputs {
     echo -n >> manifest_lines.txt
     for (( i=0; i<${#interval_indices[@]}; ++i));
       do
-        echo "Interval " + i
+        echo "Interval " + $i
 
         OUTPUT_VCF=${output_vcfs[$i]}
-        LOCAL_VCF=basename $OUTPUT_VCF
+        LOCAL_VCF=$(basename $OUTPUT_VCF)
         OUTPUT_VCF_INDEX=${output_vcf_indices[$i]}
-        LOCAL_VCF_INDEX=basename $OUTPUT_VCF_INDEX
+        LOCAL_VCF_INDEX=$(basename $OUTPUT_VCF_INDEX)
+
+        echo ${interval_indices[$i]},${OUTPUT_FILE_DEST},${output_vcf_bytes[$i]},${OUTPUT_FILE_INDEX_DEST},${output_vcf_index_bytes[$i]}
 
         if [ -n "${OUTPUT_GCS_DIR}" ]; then
           gsutil cp $OUTPUT_VCF ${OUTPUT_GCS_DIR}/

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "GvsUtils.wdl" as Utils
 
-# A comment??
+# A comment?!?
 
 workflow GvsExtractCallset {
   input {
@@ -539,8 +539,6 @@ task CreateManifestAndOptionallyCopyOutputs {
         LOCAL_VCF=$(basename $OUTPUT_VCF)
         OUTPUT_VCF_INDEX=${output_vcf_indices[$i]}
         LOCAL_VCF_INDEX=$(basename $OUTPUT_VCF_INDEX)
-
-        echo ${interval_indices[$i]},${OUTPUT_FILE_DEST},${output_vcf_bytes[$i]},${OUTPUT_FILE_INDEX_DEST},${output_vcf_index_bytes[$i]}
 
         if [ -n "${OUTPUT_GCS_DIR}" ]; then
           gsutil cp $OUTPUT_VCF ${OUTPUT_GCS_DIR}/


### PR DESCRIPTION
Modify GvsExtractCallset so that you can change the value of 'output_gcs_dir' as an input and it won't cause the extract to be re-run (won't invalidate call caching).

Passing run [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/job_history/a5fd0daf-8816-42e4-ad15-3aa432e2ed80).
Passing Integration test [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration/job_history/3c874e74-4fdd-4cbb-af75-a44bb7e17ea1).