### PR TITLE
VS-1485 - Optionally call CollectVariantCallingMetrics from ExtractVcfs

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -165,7 +165,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_AddVariantCallingMetrics
          tags:
              - /.*/
    - name: GvsImportGenomes
@@ -253,7 +252,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_AddVariantCallingMetrics
          tags:
              - /.*/
    - name: GvsBeta
@@ -292,7 +290,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_AddVariantCallingMetrics
          tags:
              - /.*/
    - name: GvsQuickstartHailIntegration
@@ -302,7 +299,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_AddVariantCallingMetrics
          tags:
              - /.*/
    - name: GvsQuickstartIntegration
@@ -313,7 +309,6 @@ workflows:
              - master
              - ah_var_store
              - vs_1456_status_writes_bug
-             - gg_AddVariantCallingMetrics
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -292,6 +292,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_AddVariantCallingMetrics
          tags:
              - /.*/
    - name: GvsQuickstartHailIntegration
@@ -301,6 +302,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_AddVariantCallingMetrics
          tags:
              - /.*/
    - name: GvsQuickstartIntegration
@@ -311,6 +313,7 @@ workflows:
              - master
              - ah_var_store
              - vs_1456_status_writes_bug
+             - gg_AddVariantCallingMetrics
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -165,6 +165,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_AddVariantCallingMetrics
          tags:
              - /.*/
    - name: GvsImportGenomes
@@ -252,6 +253,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_AddVariantCallingMetrics
          tags:
              - /.*/
    - name: GvsBeta

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -2,8 +2,6 @@ version 1.0
 
 import "GvsUtils.wdl" as Utils
 
-# It's a comment.
-
 workflow GvsExtractCallset {
   input {
     Boolean go = true

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -324,6 +324,8 @@ workflow GvsExtractCallset {
     Float total_vcfs_size_mb = SumBytes.total_mb
     File manifest = CreateManifest.manifest
     File sample_name_list = GenerateSampleListFile.sample_name_list
+    File? summary_metrics_file = GatherVariantCallingMetrics.summary_metrics_file
+    File? detail_metrics_file = GatherVariantCallingMetrics.detail_metrics_file
     String recorded_git_hash = effective_git_hash
     Boolean done = true
   }
@@ -677,8 +679,9 @@ task CollectVariantCallingMetrics {
   >>>
 
   output {
-    File detail_metrics_file = "~{metrics_filename_prefix}.variant_calling_detail_metrics"
     File summary_metrics_file = "~{metrics_filename_prefix}.variant_calling_summary_metrics"
+    File detail_metrics_file = "~{metrics_filename_prefix}.variant_calling_detail_metrics"
+    File monitoring_log = "monitoring.log"
   }
 
   runtime {
@@ -701,7 +704,7 @@ task GatherVariantCallingMetrics {
 
     Int memory_mb = 3000
     Int disk_size_gb = 200
-    String gatk_docker = "us.gcr.io/broad-gatk/gatk:4.5.0.0"
+    String gatk_docker
   }
 
   parameter_meta {
@@ -777,7 +780,8 @@ task GatherVariantCallingMetrics {
   }
 
   output {
-    File detail_metrics_file = "~{output_prefix}.variant_calling_detail_metrics"
     File summary_metrics_file = "~{output_prefix}.variant_calling_summary_metrics"
+    File detail_metrics_file = "~{output_prefix}.variant_calling_detail_metrics"
+    File monitoring_log = "monitoring.log"
   }
 }

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -33,6 +33,7 @@ workflow GvsExtractCohortFromSampleNames {
     # set to "NONE" if all the reference data was loaded into GVS in GvsImportGenomes
     String drop_state = "NONE"
     Boolean bgzip_output_vcfs = false
+    Boolean collect_variant_calling_metrics = false
 
     File? interval_list
     Int? extract_preemptible_override
@@ -151,6 +152,7 @@ workflow GvsExtractCohortFromSampleNames {
 
       drop_state = drop_state,
       bgzip_output_vcfs = bgzip_output_vcfs,
+      collect_variant_calling_metrics = collect_variant_calling_metrics,
       extract_preemptible_override = extract_preemptible_override,
       extract_maxretries_override = extract_maxretries_override,
       split_intervals_disk_size_override = split_intervals_disk_size_override,

--- a/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
+++ b/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
@@ -20,6 +20,7 @@ workflow GvsJointVariantCalling {
         String vcf_index_files_column_name
 
         Boolean bgzip_output_vcfs = false
+        Boolean collect_variant_calling_metrics = false
         String drop_state = "FORTY"
         Boolean use_VQSR = false
         Boolean use_compressed_references = false
@@ -228,6 +229,7 @@ workflow GvsJointVariantCalling {
             do_not_filter_override = extract_do_not_filter_override,
             drop_state = drop_state,
             bgzip_output_vcfs = bgzip_output_vcfs,
+            collect_variant_calling_metrics = collect_variant_calling_metrics,
             is_wgs = is_wgs,
             maximum_alternate_alleles = maximum_alternate_alleles,
             target_interval_list = target_interval_list,

--- a/scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
+++ b/scripts/variantstore/wdl/GvsQuickstartIntegration.wdl
@@ -307,6 +307,7 @@ workflow GvsQuickstartIntegration {
         String workspace_bucket = GetToolVersions.workspace_bucket
         String submission_id = GetToolVersions.submission_id
         String extract_output_gcs_dir = "~{workspace_bucket}/output_vcfs/by_submission_id/~{submission_id}/beta"
+        Boolean collect_variant_calling_metrics = true
 
         call Utils.CreateDatasetForTest {
             input:
@@ -340,6 +341,7 @@ workflow GvsQuickstartIntegration {
                 vcf_files_column_name = vcf_files_column_name,
                 vcf_index_files_column_name = vcf_index_files_column_name,
                 extract_output_gcs_dir = extract_output_gcs_dir,
+                collect_variant_calling_metrics = collect_variant_calling_metrics,
         }
 
         if (!QuickstartBeta.used_tighter_gcp_quotas) {


### PR DESCRIPTION
Added ability to call gatk tools to collect variant calling metrics.
It is optional, and defaulted to not collect.

Passing Extract run with metrics collected [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/job_history/97411a89-bd75-48dd-8dba-00d6af5373e7).
Passing Extract run where we don't (default) collect metrics [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/job_history/dfe6a72f-f2e0-4999-a7c9-f8243e0f1586).
Passing Integration test [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration/job_history/b11f03a9-16ef-4b1e-9b1c-c281f41b43a1)

