### PR TITLE
Swapped mito mode in Mutect to use the mode argument utils

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
@@ -7,9 +7,11 @@ import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineException;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.barclay.help.DocumentedFeature;
+import org.broadinstitute.hellbender.cmdline.GATKPlugin.GATKReadFilterPluginDescriptor;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.ShortVariantDiscoveryProgramGroup;
 import org.broadinstitute.hellbender.engine.*;
+import org.broadinstitute.hellbender.engine.filters.MappingQualityReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.walkers.annotator.*;
@@ -284,17 +286,6 @@ public final class Mutect2 extends AssemblyRegionWalker {
     }
 
     @Override
-    public Collection<Annotation> makeVariantAnnotations(){
-        final Collection<Annotation> annotations = super.makeVariantAnnotations();
-
-        if (MTAC.mitochondria) {
-            annotations.add(new OriginalAlignment());
-        }
-
-        return annotations;
-    }
-
-    @Override
     public Object onTraversalSuccess() {
         m2Engine.writeExtraOutputs(new File(outputVCF + DEFAULT_STATS_EXTENSION));
 
@@ -322,6 +313,13 @@ public final class Mutect2 extends AssemblyRegionWalker {
      */
     @Override
     protected String[] customCommandLineValidation() {
+        if (MTAC.mitochondria) {
+            //TODO check the OA argument, that might be the only thing that doesn't work
+            ModeArgumentUtils.setArgValues(
+                    getCommandLineParser(),
+                    MTAC.getMitochondriaModeNameValuePairs(),
+                    M2ArgumentCollection.MITOCHONDRIA_MODE_LONG_NAME);
+        }
         if (MTAC.flowMode != M2ArgumentCollection.FlowMode.NONE) {
             ModeArgumentUtils.setArgValues(
                     getCommandLineParser(),

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
@@ -314,7 +314,6 @@ public final class Mutect2 extends AssemblyRegionWalker {
     @Override
     protected String[] customCommandLineValidation() {
         if (MTAC.mitochondria) {
-            //TODO check the OA argument, that might be the only thing that doesn't work
             ModeArgumentUtils.setArgValues(
                     getCommandLineParser(),
                     MTAC.getMitochondriaModeNameValuePairs(),


### PR DESCRIPTION
@davidbenjamin what I was talking about earlier. It comes with the very nice side effect of pasting this to the command line output: 
![Screenshot 2024-09-23 at 3 44 08 PM](https://github.com/user-attachments/assets/cbe824d1-755a-41d2-9647-31a14ae8a402)
It also generally makes it much easier to track down "what does mito mode change exactly again?"