### PR TITLE
Update Mutect2.java Documentation

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
@@ -135,9 +135,9 @@ import java.util.*;
  * </pre>
  *
  * <h4>(iii) Mitochondrial mode</h4>
- * <p>Mutect2 automatically sets parameters appropriately for calling on mitochondria with the <nobr>--mitochondria</nobr> flag.
+ * <p>Mutect2 automatically sets parameters appropriately for calling on mitochondria with the <nobr>--mitochondria-mode</nobr> flag.
  * Specifically, the mode sets <nobr>--initial-tumor-lod</nobr> to 0, <nobr>--tumor-lod-to-emit</nobr> to 0, <nobr>--af-of-alleles-not-in-resource</nobr> to
- * 4e-3, and the advanced parameter <nobr>--pruning-lod-threshold</nobr> to -4.</p>
+ * 4e-3, and the advanced parameter <nobr>--pruning-lod-threshold</nobr> to -4*ln(10).</p>
  *
  * <pre>
  *  gatk Mutect2 \


### PR DESCRIPTION
This commit changes the default --mitochondria-mode parameters to what they are supposed to be in the source code based on the raised question in the forum 

https://gatk.broadinstitute.org/hc/en-us/community/posts/29969305493147-Incorrect-documentation-for-mitochondria-mode-in-Mutect2

This commit also fixes the mitochondria mode flag to its correct naming in the documentation.