### PR TITLE
Add dependency submission workflow so we can monitor vulnerabilities

### DIFF
--- a/.github/workflows/dependency_submission.yml
+++ b/.github/workflows/dependency_submission.yml
@@ -1,0 +1,22 @@
+name: Dependency Submission
+
+on:
+  push:
+    branches: [ 'master' ]
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v4
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: 17
+    - name: Generate and submit dependency graph
+      uses: gradle/actions/dependency-submission@v4


### PR DESCRIPTION
@droazen This submits our dependencies so that dependabot can analyze them in the background.  

It's from https://github.com/marketplace/actions/build-with-gradle#the-dependency-submission-action