### PR TITLE
optional column call_ps

### DIFF
--- a/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
+++ b/scripts/variantstore/wdl/GvsExtractAvroFilesForHail.wdl
@@ -279,7 +279,7 @@ task ExtractFromSuperpartitionedTables {
                 EXPORT DATA OPTIONS(
                 uri='${avro_prefix}/vets/vet_${str_table_index}/vet_${str_table_index}_*.avro', format='AVRO', compression='SNAPPY') AS
                 SELECT location, v.sample_id, ref, REPLACE(alt,',<NON_REF>','') alt, call_GT as GT, call_AD as AD, call_GQ as GQ, cast(SPLIT(call_pl,',')[OFFSET(0)] as int64) as RGQ,
-                call_PS as PS
+                SAFE_CAST(call_PS AS INT64) AS PS
                 FROM \`~{project_id}.~{dataset_name}.vet_${str_table_index}\` v
                 INNER JOIN \`~{project_id}.~{dataset_name}.sample_info\` s ON s.sample_id = v.sample_id
                 WHERE withdrawn IS NULL AND

--- a/scripts/variantstore/wdl/extract/create_ranges_cohort_extract_data_table.py
+++ b/scripts/variantstore/wdl/extract/create_ranges_cohort_extract_data_table.py
@@ -263,7 +263,7 @@ def populate_final_extract_table_with_vet(fq_ranges_dataset, fq_destination_tabl
 
         if len(partition_samples) > 0:
             subs = {}
-            insert = f"\nINSERT INTO `{fq_destination_table_data}` (location, sample_id, ref, alt, call_GT, call_GQ, call_AD, AS_QUALapprox, QUALapprox, CALL_PL, CALL_PGT, CALL_PID, CALL_PS) \n WITH \n"
+            insert = f"\nINSERT INTO `{fq_destination_table_data}` (location, sample_id, ref, alt, call_GT, call_GQ, call_AD, AS_QUALapprox, QUALapprox, CALL_PL, CALL_PGT, CALL_PID, SAFE_CAST(CALL_PS AS INT64) AS CALL_PS) \n WITH \n"
             fq_vet_table = f"{fq_ranges_dataset}.{VET_TABLE_PREFIX}{i:03}"
             j = 1
 


### PR DESCRIPTION
Not sure if this is the right change. We are seeing `Unrecognized name: CALL_PS at [4:136]` error in AoU genomic workflow

So make this optional, when column is missing, return null