### PR TITLE
Base cohort extract scatter width on loaded sample count [VS-1513]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -315,7 +315,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1456_status_writes_bug
+             - vs_1513_dont_be_ridiculous
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -241,6 +241,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - vs_1513_dont_be_ridiculous
          tags:
              - /.*/
    - name: GvsWithdrawSamples

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -94,18 +94,18 @@ workflow GvsExtractCohortFromSampleNames {
   }
 
   File cohort_sample_names_file = select_first([write_array_task.output_file, cohort_sample_names])
-  Int effective_sample_count = length(read_lines(cohort_sample_names_file))
 
+  # scatter for WGS and exome samples based on past successful runs and NOT optimized
   Int effective_scatter_count = if defined(extract_scatter_count_override) then select_first([extract_scatter_count_override])
                                 else if is_wgs then
-                                     if effective_sample_count < 5000 then 1 # This results in 1 VCF per chromosome.
-                                     else if effective_sample_count < 20000 then 2000 # Stroke Anderson
-                                          else if effective_sample_count < 50000 then 10000
+                                     if GetNumSamplesLoaded.num_samples < 5000 then 1 # This results in 1 VCF per chromosome.
+                                     else if GetNumSamplesLoaded.num_samples < 20000 then 2000 # Stroke Anderson
+                                          else if GetNumSamplesLoaded.num_samples < 50000 then 10000
                                                else 20000
                                      else
-                                     if effective_sample_count < 5000 then 1 # This results in 1 VCF per chromosome.
-                                     else if effective_sample_count < 20000 then 1000
-                                          else if effective_sample_count < 50000 then 2500
+                                     if GetNumSamplesLoaded.num_samples < 5000 then 1 # This results in 1 VCF per chromosome.
+                                     else if GetNumSamplesLoaded.num_samples < 20000 then 1000
+                                          else if GetNumSamplesLoaded.num_samples < 50000 then 2500
                                                else 7500
 
   # allow an interval list to be passed in, but default it to our standard one if no args are here


### PR DESCRIPTION
`GvsExtractCallset` based the scatter count on the number of samples loaded, while `GvsExtractCohortFromSampleNames` based the scatter count on the number of samples being extracted. The latter was leading to severe memory issues when trying to extract a small cohort using a filter that had been built from a very large number of samples (e.g. 4 sample cohort from a 400K+ sample Echo filter).