### PR TITLE
Retain all source IDs on VariantContext merge + test

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
@@ -1255,7 +1255,7 @@ public final class GATKVariantContextUtils {
         final String ID = rsIDs.isEmpty() ? VCFConstants.EMPTY_ID_FIELD : Utils.join(",", rsIDs);
 
         // This preserves the GATK3-like behavior of reporting multiple sources, delimited with hyphen:
-        final String allSources = variantSources.isEmpty() ? name : variantSources.stream()
+        String allSources = variantSources.isEmpty() ? name : variantSources.stream()
                 .sorted()
                 .distinct()
                 .limit(MAX_SOURCES_TO_INCLUDE)

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
@@ -1255,11 +1255,16 @@ public final class GATKVariantContextUtils {
         final String ID = rsIDs.isEmpty() ? VCFConstants.EMPTY_ID_FIELD : Utils.join(",", rsIDs);
 
         // This preserves the GATK3-like behavior of reporting multiple sources, delimited with hyphen:
+        // NOTE: if storeAllVcfSources is false, variantSources will be empty and therefore no sorting is performed
         String allSources = variantSources.isEmpty() ? name : variantSources.stream()
                 .sorted()
                 .distinct()
                 .limit(MAX_SOURCES_TO_INCLUDE)
                 .collect(Collectors.joining("-"));
+
+        if (maxSourceFieldLength != -1 && allSources.length() > maxSourceFieldLength) {
+            allSources = allSources.substring(0, maxSourceFieldLength);
+        }
 
         final VariantContextBuilder builder = new VariantContextBuilder().source(allSources).id(ID);
         builder.loc(longestVC.getContig(), longestVC.getStart(), longestVC.getEnd());

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
@@ -34,11 +34,14 @@ import java.io.Serializable;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.BiFunction;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public final class GATKVariantContextUtils {
 
+    /** maximum number of sources to include when merging sources */
+    private static final int MAX_SOURCES_TO_INCLUDE = 10;
     private static final Logger logger = LogManager.getLogger(GATKVariantContextUtils.class);
 
     public static final String MERGE_FILTER_PREFIX = "filterIn";
@@ -1251,11 +1254,12 @@ public final class GATKVariantContextUtils {
 
         final String ID = rsIDs.isEmpty() ? VCFConstants.EMPTY_ID_FIELD : Utils.join(",", rsIDs);
 
-        // This preserves the GATK3-like behavior of reporting all sources, delimited with hyphen:
-        String allSources = variantSources.isEmpty() ? name : variantSources.stream().sorted().collect(Collectors.joining("-"));
-        if (maxSourceFieldLength != -1 && allSources.length() > maxSourceFieldLength) {
-            allSources = allSources.substring(0, maxSourceFieldLength);
-        }
+        // This preserves the GATK3-like behavior of reporting multiple sources, delimited with hyphen:
+        final String allSources = variantSources.isEmpty() ? name : variantSources.stream()
+                .sorted()
+                .distinct()
+                .limit(MAX_SOURCES_TO_INCLUDE)
+                .collect(Collectors.joining("-"));
 
         final VariantContextBuilder builder = new VariantContextBuilder().source(allSources).id(ID);
         builder.loc(longestVC.getContig(), longestVC.getStart(), longestVC.getEnd());

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
@@ -1096,16 +1096,18 @@ public final class GATKVariantContextUtils {
                                              final GenotypeMergeType genotypeMergeOptions,
                                              final boolean filteredAreUncalled) {
         int originalNumOfVCs = priorityListOfVCs == null ? 0 : priorityListOfVCs.size();
-        return simpleMerge(unsortedVCs, priorityListOfVCs, originalNumOfVCs, filteredRecordMergeType, genotypeMergeOptions, filteredAreUncalled);
+        return simpleMerge(unsortedVCs, priorityListOfVCs, originalNumOfVCs, filteredRecordMergeType, genotypeMergeOptions, filteredAreUncalled, false, -1);
     }
 
     public static VariantContext simpleMerge(final Collection<VariantContext> unsortedVCs,
                                              final List<String> priorityListOfVCs,
-                                             final int originalNumOfVCs,
                                              final FilteredRecordMergeType filteredRecordMergeType,
                                              final GenotypeMergeType genotypeMergeOptions,
-                                             final boolean filteredAreUncalled) {
-        return simpleMerge(unsortedVCs, priorityListOfVCs, originalNumOfVCs, filteredRecordMergeType, genotypeMergeOptions, filteredAreUncalled, false, -1);
+                                             final boolean filteredAreUncalled,
+                                             final boolean storeAllVcfSources,
+                                             final int maxSourceFieldLength) {
+        int originalNumOfVCs = priorityListOfVCs == null ? 0 : priorityListOfVCs.size();
+        return simpleMerge(unsortedVCs, priorityListOfVCs, originalNumOfVCs, filteredRecordMergeType, genotypeMergeOptions, filteredAreUncalled, storeAllVcfSources, maxSourceFieldLength);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
@@ -1128,7 +1128,7 @@ public final class GATKVariantContextUtils {
          * @param genotypeMergeOptions      merge option for genotypes
          * @param filteredAreUncalled       are filtered records uncalled?
          * @param storeAllVcfSources        if true, the sources of all VCs where isVariable()=true will be concatenated in the output VC's source field. If false, the source of the first VC will be used. This mirror's GATK3's behavior
-         * @param maxSourceFieldLength      if storeAllVcfSources=true, this value sets the max length of the resulting source field. set to -1 for unlimited
+         * @param maxSourceFieldLength      This can be used to enforce a maximum length for the value of the source field (primarily useful if storeAllVcfSources=true). Set to -1 for unlimited
          * @return new VariantContext       representing the merge of unsortedVCs
          */
     public static VariantContext simpleMerge(final Collection<VariantContext> unsortedVCs,

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
@@ -1099,28 +1099,41 @@ public final class GATKVariantContextUtils {
         return simpleMerge(unsortedVCs, priorityListOfVCs, originalNumOfVCs, filteredRecordMergeType, genotypeMergeOptions, filteredAreUncalled);
     }
 
-    /**
-     * Merges VariantContexts into a single hybrid.  Takes genotypes for common samples in priority order, if provided.
-     * If uniquifySamples is true, the priority order is ignored and names are created by concatenating the VC name with
-     * the sample name.
-     * simpleMerge does not verify any more unique sample names EVEN if genotypeMergeOptions == GenotypeMergeType.REQUIRE_UNIQUE. One should use
-     * SampleUtils.verifyUniqueSamplesNames to check that before using simpleMerge.
-     *
-     * For more information on this method see: http://www.thedistractionnetwork.com/programmer-problem/
-     *
-     * @param unsortedVCs               collection of unsorted VCs
-     * @param priorityListOfVCs         priority list detailing the order in which we should grab the VCs
-     * @param filteredRecordMergeType   merge type for filtered records
-     * @param genotypeMergeOptions      merge option for genotypes
-     * @param filteredAreUncalled       are filtered records uncalled?
-     * @return new VariantContext       representing the merge of unsortedVCs
-     */
     public static VariantContext simpleMerge(final Collection<VariantContext> unsortedVCs,
                                              final List<String> priorityListOfVCs,
                                              final int originalNumOfVCs,
                                              final FilteredRecordMergeType filteredRecordMergeType,
                                              final GenotypeMergeType genotypeMergeOptions,
                                              final boolean filteredAreUncalled) {
+        return simpleMerge(unsortedVCs, priorityListOfVCs, originalNumOfVCs, filteredRecordMergeType, genotypeMergeOptions, filteredAreUncalled, false, -1);
+    }
+
+    /**
+         * Merges VariantContexts into a single hybrid.  Takes genotypes for common samples in priority order, if provided.
+         * If uniquifySamples is true, the priority order is ignored and names are created by concatenating the VC name with
+         * the sample name.
+         * simpleMerge does not verify any more unique sample names EVEN if genotypeMergeOptions == GenotypeMergeType.REQUIRE_UNIQUE. One should use
+         * SampleUtils.verifyUniqueSamplesNames to check that before using simpleMerge.
+         *
+         * For more information on this method see: http://www.thedistractionnetwork.com/programmer-problem/
+         *
+         * @param unsortedVCs               collection of unsorted VCs
+         * @param priorityListOfVCs         priority list detailing the order in which we should grab the VCs
+         * @param filteredRecordMergeType   merge type for filtered records
+         * @param genotypeMergeOptions      merge option for genotypes
+         * @param filteredAreUncalled       are filtered records uncalled?
+         * @param storeAllVcfSources        if true, the sources of all VCs where isVariable()=true will be concatenated in the output VC's source field. If false, the source of the first VC will be used. This mirror's GATK3's behavior
+         * @param maxSourceFieldLength      if storeAllVcfSources=true, this value sets the max length of the resulting source field. set to -1 for unlimited
+         * @return new VariantContext       representing the merge of unsortedVCs
+         */
+    public static VariantContext simpleMerge(final Collection<VariantContext> unsortedVCs,
+                                             final List<String> priorityListOfVCs,
+                                             final int originalNumOfVCs,
+                                             final FilteredRecordMergeType filteredRecordMergeType,
+                                             final GenotypeMergeType genotypeMergeOptions,
+                                             final boolean filteredAreUncalled,
+                                             final boolean storeAllVcfSources,
+                                             final int maxSourceFieldLength) {
         if ( unsortedVCs == null || unsortedVCs.isEmpty() )
             return null;
 
@@ -1165,7 +1178,7 @@ public final class GATKVariantContextUtils {
                 longestVC = vc; // get the longest location
 
             nFiltered += vc.isFiltered() ? 1 : 0;
-            if ( vc.isVariant() ) variantSources.add(vc.getSource());
+            if ( storeAllVcfSources && vc.isVariant() ) variantSources.add(vc.getSource());
 
             AlleleMapper alleleMapping = resolveIncompatibleAlleles(refAllele, vc);
 
@@ -1237,7 +1250,10 @@ public final class GATKVariantContextUtils {
         final String ID = rsIDs.isEmpty() ? VCFConstants.EMPTY_ID_FIELD : Utils.join(",", rsIDs);
 
         // This preserves the GATK3-like behavior of reporting all sources, delimited with hyphen:
-        final String allSources = variantSources.isEmpty() ? name : variantSources.stream().sorted().collect(Collectors.joining("-"));
+        String allSources = variantSources.isEmpty() ? name : variantSources.stream().sorted().collect(Collectors.joining("-"));
+        if (maxSourceFieldLength != -1 && allSources.length() > maxSourceFieldLength) {
+            allSources = allSources.substring(0, maxSourceFieldLength);
+        }
 
         final VariantContextBuilder builder = new VariantContextBuilder().source(allSources).id(ID);
         builder.loc(longestVC.getContig(), longestVC.getStart(), longestVC.getEnd());

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtils.java
@@ -1236,7 +1236,10 @@ public final class GATKVariantContextUtils {
 
         final String ID = rsIDs.isEmpty() ? VCFConstants.EMPTY_ID_FIELD : Utils.join(",", rsIDs);
 
-        final VariantContextBuilder builder = new VariantContextBuilder().source(name).id(ID);
+        // This preserves the GATK3-like behavior of reporting all sources, delimited with hyphen:
+        final String allSources = variantSources.isEmpty() ? name : variantSources.stream().sorted().collect(Collectors.joining("-"));
+
+        final VariantContextBuilder builder = new VariantContextBuilder().source(allSources).id(ID);
         builder.loc(longestVC.getContig(), longestVC.getStart(), longestVC.getEnd());
         builder.alleles(alleles);
         builder.genotypes(genotypes);

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
@@ -667,10 +667,17 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
         final VariantContext vc2WithSource = new VariantContextBuilder(vc2).source("source2").make();
         final VariantContext merged = GATKVariantContextUtils.simpleMerge(
                 Arrays.asList(vc1WithSource, vc2WithSource), null, GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
-                GATKVariantContextUtils.GenotypeMergeType.UNIQUIFY, false);
+                GATKVariantContextUtils.GenotypeMergeType.UNIQUIFY, false, true, -1);
 
         // test sources are merged
         Assert.assertEquals(merged.getSource(), "source1-source2");
+
+        final VariantContext mergedTruncated = GATKVariantContextUtils.simpleMerge(
+                Arrays.asList(vc1WithSource, vc2WithSource), null, GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
+                GATKVariantContextUtils.GenotypeMergeType.UNIQUIFY, false, true, 2);
+
+        // test sources are merged and respects maxSourceFieldLength
+        Assert.assertEquals(mergedTruncated.getSource(), "so");
     }
 
 // TODO: remove after testing

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/GATKVariantContextUtilsUnitTest.java
@@ -659,6 +659,20 @@ public final class GATKVariantContextUtilsUnitTest extends GATKBaseTest {
         Assert.assertEquals(merged.getSampleNames(), new LinkedHashSet<>(Arrays.asList("s1.1", "s1.2")));
     }
 
+    @Test
+    public void testMergeSourceIDs() {
+        final VariantContext vc1 = makeVC("1", Arrays.asList(Aref, T), makeG("s1", Aref, T, -1));
+        final VariantContext vc1WithSource= new VariantContextBuilder(vc1).source("source1").make();
+        final VariantContext vc2 = makeVC("2", Arrays.asList(Aref, T), makeG("s1", Aref, T, -2));
+        final VariantContext vc2WithSource = new VariantContextBuilder(vc2).source("source2").make();
+        final VariantContext merged = GATKVariantContextUtils.simpleMerge(
+                Arrays.asList(vc1WithSource, vc2WithSource), null, GATKVariantContextUtils.FilteredRecordMergeType.KEEP_IF_ANY_UNFILTERED,
+                GATKVariantContextUtils.GenotypeMergeType.UNIQUIFY, false);
+
+        // test sources are merged
+        Assert.assertEquals(merged.getSource(), "source1-source2");
+    }
+
 // TODO: remove after testing
 //    @Test(expectedExceptions = IllegalStateException.class)
 //    public void testMergeGenotypesRequireUnique() {


### PR DESCRIPTION
This feature was initially opened in this PR: https://github.com/broadinstitute/gatk/pull/8750, after which @lbergelson and @droazen made comments here; https://github.com/broadinstitute/gatk/pull/8752. 

The driving use-case is that we took over the GATK3 MergeVariantsAndGenotypes tool at DISCVRseq and users have been requesting the older behavior on VCF merges, such as: https://github.com/BimberLab/DISCVRSeq/issues/313. 

The original PR has been languishing since March and I'm hoping to finalize this feature. Because I cant write to the GATK repo and b/c @lbergelson made some suggestions on a GATK-based branch I am going to put every together into one clean PR, which responds to the code review from the thread above. 

To recap background: 

- In GATK3, when merging variants, the IDs of all the source VCFs were retained. The GATK4 code path seems like it intended to do this, since the variantSources set is generated, but that variant isnt used for anything (I assume GATK3 code was partially carried forward to incompletely refactored?). 

- This PR is designed to allow code to opt-in to the old GATK behavior of retaining the IDs of source VCFs in the ID field. It will not change the default behavior for existing code.

- I dont think I can kick off the test suite, but these tests did pass here: https://github.com/broadinstitute/gatk/pull/8752.

Again, @lbergelson and @droazen both reviewed the original PR and seemed fine with it in principle. The primary concern raised by @droazen was to avoid changing the current defaults and to not create additional burden (such as adding sorts). I believe this addresses both of those concerns. @jamesemery commented on the thread at one point as well. 

Is there anything I can do to help move this forward? Thanks for your time. 