### PR TITLE
RW-14014 Fix vpcError in wdl

### DIFF
--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -573,7 +573,7 @@ task CreateManifestAndOptionallyCopyOutputs {
     if [ -n "$OUTPUT_GCS_DIR" ]; then
       # Copy VCFs, indexes and the manifest to the output directory.
       echo manifest.txt >> vcf_manifest.txt
-      cat vcf_manifest.txt | gcloud storage cp -I ${OUTPUT_GCS_DIR}/
+      cat vcf_manifest.txt | xargs -IFILE gsutil cp FILE ${OUTPUT_GCS_DIR}/
     fi
   >>>
   output {

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -584,7 +584,7 @@ task CreateManifestAndOptionallyCopyOutputs {
         fi
       done < "vcf_manifest.txt"
     fi
-
+  >>>
   output {
     File manifest_lines = "manifest_lines.txt"
     File manifest = "manifest.txt"

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -573,7 +573,7 @@ task CreateManifestAndOptionallyCopyOutputs {
     if [ -n "$OUTPUT_GCS_DIR" ]; then
       # Copy VCFs, indexes and the manifest to the output directory.
       echo manifest.txt >> vcf_manifest.txt
-      cat vcf_manifest.txt | xargs -IFILE gsutil cp FILE ${OUTPUT_GCS_DIR}/
+      gcloud storage cp vcf_manifest.txt ${OUTPUT_GCS_DIR}/
     fi
   >>>
   output {

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -576,12 +576,8 @@ task CreateManifestAndOptionallyCopyOutputs {
 
       while IFS= read -r file; do
         # Check if the file exists before attempting to copy it
-        if [[ -f "$file" ]]; then
-          echo "Uploading $file to gs://$OUTPUT_GCS_DIR/"
-          gcloud storage cp vcf_manifest.txt ${OUTPUT_GCS_DIR}/
-        else
-          echo "File $file does not exist, skipping."
-        fi
+        echo "Uploading $file to gs://$OUTPUT_GCS_DIR/"
+        gcloud storage cp $file ${OUTPUT_GCS_DIR}/
       done < "vcf_manifest.txt"
     fi
   >>>

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -573,7 +573,7 @@ task CreateManifestAndOptionallyCopyOutputs {
     if [ -n "$OUTPUT_GCS_DIR" ]; then
       # Copy VCFs, indexes and the manifest to the output directory.
       echo manifest.txt >> vcf_manifest.txt
-      cat vcf_manifest.txt | gcloud storage cp -I ${OUTPUT_GCS_DIR}
+      cat vcf_manifest.txt | gcloud storage cp -I ${OUTPUT_GCS_DIR}/
     fi
   >>>
   output {

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -573,9 +573,18 @@ task CreateManifestAndOptionallyCopyOutputs {
     if [ -n "$OUTPUT_GCS_DIR" ]; then
       # Copy VCFs, indexes and the manifest to the output directory.
       echo manifest.txt >> vcf_manifest.txt
-      gcloud storage cp vcf_manifest.txt ${OUTPUT_GCS_DIR}/
+
+      while IFS= read -r file; do
+        # Check if the file exists before attempting to copy it
+        if [[ -f "$file" ]]; then
+          echo "Uploading $file to gs://$OUTPUT_GCS_DIR/"
+          gcloud storage cp vcf_manifest.txt ${OUTPUT_GCS_DIR}/
+        else
+          echo "File $file does not exist, skipping."
+        fi
+      done < "vcf_manifest.txt"
     fi
-  >>>
+
   output {
     File manifest_lines = "manifest_lines.txt"
     File manifest = "manifest.txt"


### PR DESCRIPTION
With `gcloud storage -I`, we're getting the following error.

```
..Copying gs://fc-56d2f6f5-3efa-46f7-8c01-0911fd77f888/submissions/73f18f4f-f88b-4f46-83d7-2998ce5a0d25/GvsExtractCohortFromSampleNames/097c9f79-900d-4e45-adaa-bb8f100dc53d/call-GvsExtractCallset/GvsExtractCallset/d249a1a4-204a-4972-bd0a-3bb12999bc86/call-ExtractTask/shard-1/0000000001-interval.vcf.gz to gs://fc-secure-f6332460-81bb-4ded-94e5-214743db1aa8/genomic-extractions/e9da8875-864a-4f96-b6fe-88e20bec8b44/vcfs/0000000001-interval.vcf.gz
ERROR: HTTPError 403: Request is prohibited by organization's policy. vpcServiceControlsUniqueIdentifier: GRWoMNGFnANXFJWmSXVv31rx0oUERx2Y_pgSlvX65JScnio75NqJgR29GsaU97wDGKBpC2o_cL_EY89S
ERROR: HTTPError 403: Request is prohibited by organization's policy. vpcServiceControlsUniqueIdentifier: d4CSCzEPJIJWrNUzRcTMOg_fDcjamQSXjYr94q76VTQb5k9-E73jUyysqJAL-13rVZ9H1EwRS7YzPdo4
```

Changing it back to non pipe syntax fixes the issue (the error is very deceiving)