### PR TITLE
Extract Cohort optimizations [VS-493] [VS-1516]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -173,6 +173,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - vs_1516_yolo
          tags:
              - /.*/
    - name: GvsImportGenomes
@@ -241,6 +242,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - vs_1516_yolo
          tags:
              - /.*/
    - name: GvsWithdrawSamples
@@ -314,7 +316,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1490_fix_curate_input_array_files
+             - vs_1516_yolo
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -74,7 +74,7 @@ task GetToolVersions {
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
     String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2024-11-25-alpine-913039adf8f4"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
-    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2024-11-24-gatkbase-5b5c307bdb5e"
+    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2024-11-26-gatkbase-d5606c3ae1ab"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"
     String gotc_imputation_docker = "us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.5-1.10.2-0.1.16-1649948623"
     String plink_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/plink2:2024-04-23-slim-a0a65f52cc0e"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -74,7 +74,7 @@ task GetToolVersions {
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
     String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2024-11-25-alpine-913039adf8f4"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
-    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2024-11-26-gatkbase-d5606c3ae1ab"
+    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2024-11-27-gatkbase-6228df4f2266"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"
     String gotc_imputation_docker = "us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.5-1.10.2-0.1.16-1649948623"
     String plink_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/plink2:2024-04-23-slim-a0a65f52cc0e"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -74,7 +74,7 @@ task GetToolVersions {
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
     String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2024-11-25-alpine-913039adf8f4"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
-    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2024-11-23-gatkbase-83100df42ff2"
+    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2024-11-24-gatkbase-5cec8a146a61"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"
     String gotc_imputation_docker = "us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.5-1.10.2-0.1.16-1649948623"
     String plink_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/plink2:2024-04-23-slim-a0a65f52cc0e"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -74,7 +74,7 @@ task GetToolVersions {
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
     String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2024-11-25-alpine-913039adf8f4"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
-    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2024-11-24-gatkbase-5cec8a146a61"
+    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2024-11-24-gatkbase-5b5c307bdb5e"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"
     String gotc_imputation_docker = "us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.5-1.10.2-0.1.16-1649948623"
     String plink_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/plink2:2024-04-23-slim-a0a65f52cc0e"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -74,7 +74,7 @@ task GetToolVersions {
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
     String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2024-11-25-alpine-913039adf8f4"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
-    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2024-11-24-gatkbase-1807487d5912"
+    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2024-11-23-gatkbase-83100df42ff2"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"
     String gotc_imputation_docker = "us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.5-1.10.2-0.1.16-1649948623"
     String plink_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/plink2:2024-04-23-slim-a0a65f52cc0e"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -74,7 +74,7 @@ task GetToolVersions {
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
     String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2024-11-25-alpine-913039adf8f4"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
-    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2024-11-27-gatkbase-6228df4f2266"
+    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2024-11-28-gatkbase-b71132a18899"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"
     String gotc_imputation_docker = "us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.5-1.10.2-0.1.16-1649948623"
     String plink_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/plink2:2024-04-23-slim-a0a65f52cc0e"

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
@@ -325,6 +325,7 @@ public class ExtractCohortEngine {
                     }
                     long location = Long.parseLong(queryRow.get(SchemaUtils.LOCATION_FIELD_NAME).toString());
                     if (!vbs.containsVariant(location, location + 1)) {
+                        ++recordsDropped;
                         continue;
                     }
                     List<String> filters = Arrays.asList(queryRow.get(SchemaUtils.FILTERS).toString().split(","));

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
@@ -252,6 +252,9 @@ public class ExtractCohortEngine {
         String ploidyTableRestriction = null;
         final Map<String, Integer> samplePloidyMap = new HashMap<>();
 
+        // Note the IntelliJ warning here that this condition is always true. `minLocation` and `maxLocation` are
+        // Longs (not primitive longs), but the `decodeContig` invocations above do not null check and would have
+        // already NPEd if either of these values had been null.
         if (minLocation != null && maxLocation != null) {
             // This block of code already requires minLocation and maxLocation to be on the same chromosome, so we can rely on that here
             ploidyTableRestriction = "chromosome = " + ((minLocation/SchemaUtils.chromAdjustment) * SchemaUtils.chromAdjustment);
@@ -282,6 +285,14 @@ public class ExtractCohortEngine {
         } else {
             variantIterables = createVariantIterablesFromUnsortedAvroRanges(vetAvroFileName, refRangesAvroFileName, vbs, presortedAvroFiles);
         }
+
+        // Windowing: create a loop that starts here, after the ploidy lookup. Within this loop only process a
+        // fixed-size window's worth of data at a time, limiting the high-water mark of how much memory we consume.
+
+        // long windowSize = ...;
+        // for (int w = 0; w < ; w++) {
+        //     long effectiveMinLocation = minLocation + w * windowSize;
+        //     long effectiveMaxLocation = Math.min(effectiveMinLocation + windowSize, maxLocation);
 
         // First allele here is the ref, followed by the alts associated with that ref. We need this because at this
         // point the alleles haven't been joined and remapped to one reference allele.

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
@@ -310,6 +310,7 @@ public class ExtractCohortEngine {
                     fullYngMap.get(location).putIfAbsent(ref, new HashMap<>());
                     fullYngMap.get(location).get(ref).put(alt, yng);
                 }
+                logger.info("Processed " + recordsProcessed + " filter set info records, dropped " + recordsDropped + ".");
                 processBytesScanned(reader);
             }
         }
@@ -1106,8 +1107,6 @@ public class ExtractCohortEngine {
                 vbs);
 
         return new VariantIterables(sortedVet, sortedReferenceRange);
-
-        // createVariantsFromSortedRanges(sampleIdsToExtract, sortedVet, sortedReferenceRange, fullScoreMap, fullVQScoreMap, fullYngMap, samplePloidyMap, siteFilterMap, noVQScoreFilteringRequested);
     }
 
     //
@@ -1138,7 +1137,6 @@ public class ExtractCohortEngine {
                 localSortMaxRecordsInRam,
                 vbs);
 
-        // createVariantsFromSortedRanges(sampleIdsToExtract, sortedVet, sortedReferenceRange, fullScoreMap, fullVQScoreMap, fullYngMap, samplePloidyMap, siteFilterMap, noVQScoreFilteringRequested);
         return new VariantIterables(sortedVet, sortedReferenceRange);
     }
 
@@ -1223,8 +1221,6 @@ public class ExtractCohortEngine {
             sortedVet = localSortedVet;
             sortedReferenceRange = localSortedReferenceRange;
         }
-
-        // createVariantsFromSortedRanges(sampleIdsToExtract, sortedVet, sortedReferenceRange, fullScoreMap, fullVQScoreMap, fullYngMap, samplePloidyMap, siteFilterMap, noVQScoreFilteringRequested);
 
         return new VariantIterables(sortedVet, sortedReferenceRange);
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
@@ -283,7 +283,7 @@ public class ExtractCohortEngine {
                 long recordsProcessed = 0;
                 long recordsDropped = 0;
                 for (final GenericRecord queryRow : reader) {
-                    if (++recordsProcessed % 10000 == 0) {
+                    if (++recordsProcessed % 100000 == 0) {
                         logger.info("Processed " + recordsProcessed + " filter set info records, dropped " + recordsDropped + ".");
                     }
                     final ExtractCohortFilterRecord filterRow = new ExtractCohortFilterRecord(queryRow, getVQScoreFieldName(), getScoreFieldName());
@@ -321,7 +321,7 @@ public class ExtractCohortEngine {
                 long recordsDropped = 0;
                 for (final GenericRecord queryRow : reader) {
                     if (++recordsProcessed % 10000 == 0) {
-                        logger.info("Processed " + recordsProcessed + " filter set info records, dropped " + recordsDropped + ".");
+                        logger.info("Processed " + recordsProcessed + " filter set sites records, dropped " + recordsDropped + ".");
                     }
                     long location = Long.parseLong(queryRow.get(SchemaUtils.LOCATION_FIELD_NAME).toString());
                     if (!vbs.containsVariant(location, location + 1)) {


### PR DESCRIPTION
Integration test run [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration/job_history/e4267ee8-0393-4212-87c1-de078a636a65).

Follows the bread crumbs in VS-493 to drop filter info and sites outside of variant locations for the samples being extracted.

Test runs here:

- [Baseline ah_var_store](https://app.terra.bio/#workspaces/gvs-dev/MLC%20NHGRI%20AnVIL%20GVS%20copy/job_history/32b3f348-b74f-4346-a92a-cdbe4500ff8d)
- [This branch](https://app.terra.bio/#workspaces/gvs-dev/MLC%20NHGRI%20AnVIL%20GVS%20copy/job_history/e0472760-2d82-4d6d-9ede-d809da07f126)

Findings:
- This data set is the biggest non-AoU dataset we have but is decidedly on the small side for being able to measure the effects of changes like this.
- For the particular runs linked above, the code on this branch dropped ~85% of unnecessary filter info.
- Presumably because there is less work being done, these extracts run more quickly than the baseline code.
- Questionable if these changes would help with "small subsets". In the "small subset" use cases we extract all samples, though only the variant data over a specified interval list. I don't think the current logic is informed by interval lists; we should look into this further.