### PR TITLE
Prioritize het calls when merging clustered SVs

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/cluster/CanonicalSVCollapser.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/cluster/CanonicalSVCollapser.java
@@ -129,21 +129,6 @@ public class CanonicalSVCollapser {
         return Long.compare(count1, count2);
     };
 
-    // Prioritize hets over non-hets
-    final Comparator<Genotype> genotypeHetComparator = (o1, o2) -> {
-        final long count1 = o1.getAlleles().stream().filter(Allele::isNonReference).filter(Allele::isCalled).count();
-        final long count2 = o2.getAlleles().stream().filter(Allele::isNonReference).filter(Allele::isCalled).count();
-        final boolean het1 = count1 == 1;
-        final boolean het2 = count2 == 1;
-        if (het1 && !het2) {
-            return 1;
-        } else if (het2 && !het1) {
-            return -1;
-        } else {
-            return 0;
-        }
-    };
-
     // Priotize fewer ALT alleles over more. When applied after non-ref comparator, hom-ref genotypes will not be encountered.
     final Comparator<Genotype> genotypeNonRefCountComparator = (o1, o2) -> {
         final long count1 = o1.getAlleles().stream().filter(Allele::isNonReference).filter(Allele::isCalled).count();
@@ -498,7 +483,6 @@ public class CanonicalSVCollapser {
                 .max(genotypeIsNonRefComparator
                         .thenComparing(genotypeCalledComparator)
                         .thenComparing(genotypeQualityComparator)
-                        .thenComparing(genotypeHetComparator)
                         .thenComparing(genotypeNonRefCountComparator)
                         .thenComparing(genotypeCopyNumberQualityComparator)
                         .thenComparing(genotypeCopyNumberComparator)

--- a/src/test/java/org/broadinstitute/hellbender/tools/sv/cluster/CanonicalSVCollapserUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/sv/cluster/CanonicalSVCollapserUnitTest.java
@@ -644,6 +644,24 @@ public class CanonicalSVCollapserUnitTest {
                                 createGenotypeTestAttributes(2)
                         )
                 },
+                // het preferred over hom ref even with lower gq
+                {
+                "sample",
+                Lists.newArrayList(
+                        Lists.newArrayList(Allele.REF_N, Allele.REF_N),
+                        Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_INS)
+                ),
+                Lists.newArrayList(
+                        createGenotypeTestAttributesWithGQ(2, 30),
+                        createGenotypeTestAttributesWithGQ(2, 20)
+                ),
+                Allele.REF_N,
+                GenotypeBuilder.create(
+                        "sample",
+                        Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_INS),
+                        createGenotypeTestAttributesWithGQ(2, 20)
+                )
+        },
                 // het preferred over hom-var
                 {
                         "sample",

--- a/src/test/java/org/broadinstitute/hellbender/tools/sv/cluster/CanonicalSVCollapserUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/sv/cluster/CanonicalSVCollapserUnitTest.java
@@ -644,25 +644,7 @@ public class CanonicalSVCollapserUnitTest {
                                 createGenotypeTestAttributes(2)
                         )
                 },
-                // het preferred over hom ref even with lower gq
-                {
-                        "sample",
-                        Lists.newArrayList(
-                                Lists.newArrayList(Allele.REF_N, Allele.REF_N),
-                                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_INS)
-                        ),
-                        Lists.newArrayList(
-                                createGenotypeTestAttributesWithGQ(2, 30),
-                                createGenotypeTestAttributesWithGQ(2, 20)
-                        ),
-                        Allele.REF_N,
-                        GenotypeBuilder.create(
-                                "sample",
-                                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_INS),
-                                createGenotypeTestAttributesWithGQ(2, 20)
-                        )
-                },
-                // hom var preferred over het
+                // het preferred over hom-var
                 {
                         "sample",
                         Lists.newArrayList(
@@ -676,11 +658,11 @@ public class CanonicalSVCollapserUnitTest {
                         Allele.REF_N,
                         GenotypeBuilder.create(
                                 "sample",
-                                Lists.newArrayList(Allele.SV_SIMPLE_INS, Allele.SV_SIMPLE_INS),
+                                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_INS),
                                 createGenotypeTestAttributes(2)
                         )
                 },
-                // hom-var over het if GQ equal
+                // het over hom-var if GQ equal
                 {
                         "sample",
                         Lists.newArrayList(
@@ -694,11 +676,11 @@ public class CanonicalSVCollapserUnitTest {
                         Allele.REF_N,
                         GenotypeBuilder.create(
                                 "sample",
-                                Lists.newArrayList(Allele.SV_SIMPLE_INS, Allele.SV_SIMPLE_INS),
+                                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_INS),
                                 createGenotypeTestAttributes(2)
                         )
                 },
-                // het over hom-var if GQ is higher
+                // hom-var over het if GQ is higher
                 {
                         "sample",
                         Lists.newArrayList(
@@ -706,17 +688,17 @@ public class CanonicalSVCollapserUnitTest {
                                 Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_INS)
                         ),
                         Lists.newArrayList(
-                                createGenotypeTestAttributesWithGQ(2, 30),
-                                createGenotypeTestAttributesWithGQ(2, 40)
+                                createGenotypeTestAttributesWithGQ(2, 40),
+                                createGenotypeTestAttributesWithGQ(2, 30)
                         ),
                         Allele.REF_N,
                         GenotypeBuilder.create(
                                 "sample",
-                                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_INS),
+                                Lists.newArrayList(Allele.SV_SIMPLE_INS, Allele.SV_SIMPLE_INS),
                                 createGenotypeTestAttributesWithGQ(2, 40)
                         )
                 },
-                // hom var preferred over hom-ref too
+                // het preferred over hom-ref too
                 {
                         "sample",
                         Lists.newArrayList(
@@ -732,7 +714,7 @@ public class CanonicalSVCollapserUnitTest {
                         Allele.REF_N,
                         GenotypeBuilder.create(
                                 "sample",
-                                Lists.newArrayList(Allele.SV_SIMPLE_INS, Allele.SV_SIMPLE_INS),
+                                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_INS),
                                 createGenotypeTestAttributesWithGQ(2, 30)
                         )
                 },
@@ -791,7 +773,7 @@ public class CanonicalSVCollapserUnitTest {
                         Allele.REF_N,
                         GenotypeBuilder.create(
                                 "sample",
-                                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_INS, Allele.SV_SIMPLE_INS),
+                                Lists.newArrayList(Allele.REF_N, Allele.REF_N, Allele.SV_SIMPLE_INS),
                                 createGenotypeTestAttributes(3)
                         )
                 },
@@ -813,7 +795,7 @@ public class CanonicalSVCollapserUnitTest {
                         Allele.REF_N,
                         GenotypeBuilder.create(
                                 "sample",
-                                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_INS, Allele.SV_SIMPLE_INS),
+                                Lists.newArrayList(Allele.REF_N, Allele.REF_N, Allele.SV_SIMPLE_INS),
                                 createGenotypeTestAttributes(3)
                         )
                 },
@@ -841,7 +823,7 @@ public class CanonicalSVCollapserUnitTest {
                         Allele.REF_N,
                         GenotypeBuilder.create(
                                 "sample",
-                                Lists.newArrayList(Allele.SV_SIMPLE_INS, Allele.SV_SIMPLE_INS, Allele.SV_SIMPLE_INS),
+                                Lists.newArrayList(Allele.REF_N, Allele.REF_N, Allele.SV_SIMPLE_INS),
                                 createGenotypeTestAttributes(3)
                         )
                 },
@@ -1083,25 +1065,7 @@ public class CanonicalSVCollapserUnitTest {
                                 createGenotypeTestAttributes(1, 1)
                         )
                 },
-                // Multi-allelic CNV, rare case with equal CNQ take CN!=ECN
-                {
-                        "sample",
-                        Lists.newArrayList(
-                                Collections.singletonList(Allele.NO_CALL),
-                                Collections.singletonList(Allele.NO_CALL)
-                        ),
-                        Lists.newArrayList(
-                                createGenotypeTestAttributesWithCNQ(1, 1, 30),
-                                createGenotypeTestAttributesWithCNQ(1, 0, 30)
-                        ),
-                        Allele.REF_N,
-                        GenotypeBuilder.create(
-                                "sample",
-                                Lists.newArrayList(Allele.NO_CALL),
-                                createGenotypeTestAttributesWithCNQ(1, 0, 30)
-                        )
-                },
-                // Multi-allelic CNV, haploid dup
+                // Multi-allelic CNV, with no CNQ use copy state closest to ref
                 {
                         "sample",
                         Lists.newArrayList(
@@ -1116,10 +1080,44 @@ public class CanonicalSVCollapserUnitTest {
                         GenotypeBuilder.create(
                                 "sample",
                                 Lists.newArrayList(Allele.NO_CALL),
-                                createGenotypeTestAttributes(1, 2)
+                                createGenotypeTestAttributes(1, 1)
                         )
                 },
-                // Multi-allelic CNV, when CNQ equal use CN!=ECN
+                // Multi-allelic CNV, when CNQ equal use copy state closest to ref
+                {
+                        "sample",
+                        Lists.newArrayList(
+                                Lists.newArrayList(Allele.NO_CALL, Allele.NO_CALL),
+                                Lists.newArrayList(Allele.NO_CALL, Allele.NO_CALL)
+                        ),
+                        Lists.newArrayList(
+                                createGenotypeTestAttributesWithCNQ(1, 1, 30),
+                                createGenotypeTestAttributesWithCNQ(1, 2, 30)
+                        ),
+                        Allele.REF_N,
+                        GenotypeBuilder.create(
+                                "sample",
+                                Lists.newArrayList(Allele.NO_CALL, Allele.NO_CALL),
+                                createGenotypeTestAttributesWithCNQ(1, 1, 30)
+                        )
+                },
+                {
+                        "sample",
+                        Lists.newArrayList(
+                                Lists.newArrayList(Allele.NO_CALL, Allele.NO_CALL),
+                                Lists.newArrayList(Allele.NO_CALL, Allele.NO_CALL)
+                        ),
+                        Lists.newArrayList(
+                                createGenotypeTestAttributesWithCNQ(2, 2, 30),
+                                createGenotypeTestAttributesWithCNQ(2, 3, 30)
+                        ),
+                        Allele.REF_N,
+                        GenotypeBuilder.create(
+                                "sample",
+                                Lists.newArrayList(Allele.NO_CALL, Allele.NO_CALL),
+                                createGenotypeTestAttributesWithCNQ(2, 2, 30)
+                        )
+                },
                 {
                         "sample",
                         Lists.newArrayList(
@@ -1134,10 +1132,9 @@ public class CanonicalSVCollapserUnitTest {
                         GenotypeBuilder.create(
                                 "sample",
                                 Lists.newArrayList(Allele.NO_CALL, Allele.NO_CALL),
-                                createGenotypeTestAttributesWithCNQ(2, 1, 30)
+                                createGenotypeTestAttributesWithCNQ(2, 2, 30)
                         )
                 },
-                // Multi-allelic CNV, when CNQ equal use CN!=ECN
                 {
                         "sample",
                         Lists.newArrayList(
@@ -1152,7 +1149,41 @@ public class CanonicalSVCollapserUnitTest {
                         GenotypeBuilder.create(
                                 "sample",
                                 Lists.newArrayList(Allele.NO_CALL, Allele.NO_CALL),
+                                createGenotypeTestAttributesWithCNQ(2, 2, 30)
+                        )
+                },
+                {
+                        "sample",
+                        Lists.newArrayList(
+                                Lists.newArrayList(Allele.NO_CALL, Allele.NO_CALL),
+                                Lists.newArrayList(Allele.NO_CALL, Allele.NO_CALL)
+                        ),
+                        Lists.newArrayList(
+                                createGenotypeTestAttributesWithCNQ(2, 1, 30),
                                 createGenotypeTestAttributesWithCNQ(2, 0, 30)
+                        ),
+                        Allele.REF_N,
+                        GenotypeBuilder.create(
+                                "sample",
+                                Lists.newArrayList(Allele.NO_CALL, Allele.NO_CALL),
+                                createGenotypeTestAttributesWithCNQ(2, 1, 30)
+                        )
+                },
+                {
+                        "sample",
+                        Lists.newArrayList(
+                                Lists.newArrayList(Allele.NO_CALL, Allele.NO_CALL),
+                                Lists.newArrayList(Allele.NO_CALL, Allele.NO_CALL)
+                        ),
+                        Lists.newArrayList(
+                                createGenotypeTestAttributesWithCNQ(2, 5, 30),
+                                createGenotypeTestAttributesWithCNQ(2, 6, 30)
+                        ),
+                        Allele.REF_N,
+                        GenotypeBuilder.create(
+                                "sample",
+                                Lists.newArrayList(Allele.NO_CALL, Allele.NO_CALL),
+                                createGenotypeTestAttributesWithCNQ(2, 5, 30)
                         )
                 },
                 // Multi-allelic CNV, conflicting del and dup genotypes determined by CNQ
@@ -1188,6 +1219,58 @@ public class CanonicalSVCollapserUnitTest {
                                 "sample",
                                 Lists.newArrayList(Allele.NO_CALL),
                                 createGenotypeTestAttributesWithCNQ(1, 2, 50)
+                        )
+                },
+                // DEL prioritized over DUP tiebreaker when same distance from expected copy state
+                {
+                        "sample",
+                        Lists.newArrayList(
+                                Collections.singletonList(Allele.NO_CALL),
+                                Collections.singletonList(Allele.NO_CALL)
+                        ),
+                        Lists.newArrayList(
+                                createGenotypeTestAttributesWithCNQ(1, 2, 30),
+                                createGenotypeTestAttributesWithCNQ(1, 0, 30)
+                        ),
+                        Allele.REF_N,
+                        GenotypeBuilder.create(
+                                "sample",
+                                Lists.newArrayList(Allele.NO_CALL),
+                                createGenotypeTestAttributesWithCNQ(1, 0, 30)
+                        )
+                },
+                {
+                        "sample",
+                        Lists.newArrayList(
+                                Collections.singletonList(Allele.NO_CALL),
+                                Collections.singletonList(Allele.NO_CALL)
+                        ),
+                        Lists.newArrayList(
+                                createGenotypeTestAttributesWithCNQ(2, 0, 30),
+                                createGenotypeTestAttributesWithCNQ(2, 4, 30)
+                        ),
+                        Allele.REF_N,
+                        GenotypeBuilder.create(
+                                "sample",
+                                Lists.newArrayList(Allele.NO_CALL),
+                                createGenotypeTestAttributesWithCNQ(2, 0, 30)
+                        )
+                },
+                {
+                        "sample",
+                        Lists.newArrayList(
+                                Collections.singletonList(Allele.NO_CALL),
+                                Collections.singletonList(Allele.NO_CALL)
+                        ),
+                        Lists.newArrayList(
+                                createGenotypeTestAttributesWithCNQ(2, 1, 30),
+                                createGenotypeTestAttributesWithCNQ(2, 3, 30)
+                        ),
+                        Allele.REF_N,
+                        GenotypeBuilder.create(
+                                "sample",
+                                Lists.newArrayList(Allele.NO_CALL),
+                                createGenotypeTestAttributesWithCNQ(2, 1, 30)
                         )
                 },
         };

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVClusterIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVClusterIntegrationTest.java
@@ -460,11 +460,11 @@ public class SVClusterIntegrationTest extends CommandLineProgramTest {
                 final int nonRefGenotypeCount = (int) variant.getGenotypes().stream().filter(g -> SVCallRecordUtils.isAltGenotype(g)).count();
                 Assert.assertEquals(nonRefGenotypeCount, 71);
                 final int alleleCount = (int) variant.getGenotypes().stream().flatMap(g -> g.getAlleles().stream()).filter(SVCallRecordUtils::isAltAllele).count();
-                Assert.assertEquals(alleleCount, 94);
+                Assert.assertEquals(alleleCount, 87);
                 final Genotype g = variant.getGenotype("HG00129");
-                Assert.assertTrue(g.isHomVar());
+                Assert.assertTrue(g.isHet());
                 Assert.assertEquals(VariantContextGetters.getAttributeAsInt(g, GATKSVVCFConstants.EXPECTED_COPY_NUMBER_FORMAT, -1), 2);
-                Assert.assertEquals(VariantContextGetters.getAttributeAsInt(g, GATKSVVCFConstants.COPY_NUMBER_FORMAT, -1), 0);
+                Assert.assertEquals(VariantContextGetters.getAttributeAsInt(g, GATKSVVCFConstants.COPY_NUMBER_FORMAT, -1), 1);
             }
         }
         Assert.assertEquals(expectedRecordsFound, 1);


### PR DESCRIPTION
Makes some small adjustments to tiebreaker criteria for merging genotypes with the `CanonicalSVCollapser`, which is used in the `SVCluster` and `GroupedSVCluster` tools. We've empirically found, after considering ref vs non-ref and GQ, that prioritizing hets over hom-var genotypes improves variant quality in terms of hardy-weinberg equilibrium. This is also the preferred behavior for GATK-SV, as false hom-var genotypes (when truly a het) is considered one of the more egregious error modes, particularly in association studies. 

A similar adjustment is made to multi-allelic CNV merging, in which copy states closer to reference are now preferred. 

In addition, a tiebreaker has been added in the case of conflicting copy states that are equally far from reference, e.g. merging a variant with copy states 1 and 3 on a diploid chromosome. In this case when copy state qualities are also equal (which should be rare), deletion copy states are prioritized over duplication. That is, copy state 1 would be chosen in the example. This is justified by the higher accuracy observed in large depth-only deletions compared to duplications. Since there are no other criteria on which to assess multi-allelic CNVs, this extra comparison is needed for stability.