### PR TITLE
Close a FeatureReader after use

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
@@ -236,8 +236,9 @@ public class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
 
         // Parse the user provided custom ploidy regions into ploidyRegions object containing SimpleCounts
         if (this.hcArgs.ploidyRegions != null) {
-            FeatureDataSource<NamedFeature> ploidyDataSource = new FeatureDataSource<>(this.hcArgs.ploidyRegions, FeatureDataSource.DEFAULT_QUERY_LOOKAHEAD_BASES, NamedFeature.class);
-            ploidyDataSource.forEach(r -> this.ploidyRegions.add(new SimpleCount(r)));
+            try (FeatureDataSource<NamedFeature> ploidyDataSource = new FeatureDataSource<>(this.hcArgs.ploidyRegions, FeatureDataSource.DEFAULT_QUERY_LOOKAHEAD_BASES, NamedFeature.class)) {
+                ploidyDataSource.forEach(r -> this.ploidyRegions.add(new SimpleCount(r)));
+            }
         }
 
         for (SimpleCount region : this.ploidyRegions) {


### PR DESCRIPTION
I missed this when it was merged, but we should really close out this FeatureReader.