### PR TITLE
Fixing what looks like a a bug in MendelianViolationEvaluator

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/evaluators/MendelianViolationEvaluator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/varianteval/evaluators/MendelianViolationEvaluator.java
@@ -142,7 +142,7 @@ public class MendelianViolationEvaluator extends VariantEvaluator {
             HomVarHet_inheritedRef += mv.getParentsVarHetInheritedRef();
             HomVarHet_inheritedVar += mv.getParentsVarHetInheritedVar();
 
-            if(mv.getFamilyCalledCount()>0 || mv.getFamilyLowQualsCount()>0 || mv.getFamilyCalledCount()>0){
+            if(mv.getFamilyCalledCount()>0 || mv.getFamilyLowQualsCount()>0 || mv.getFamilyNoCallCount()>0){
                 nVariants++;
                 nFamCalled += mv.getFamilyCalledCount();
                 nLowQual += mv.getFamilyLowQualsCount();
@@ -155,7 +155,7 @@ public class MendelianViolationEvaluator extends VariantEvaluator {
         }
     }
 
-    private class ExtendedMendelianViolation extends MendelianViolation
+    private static class ExtendedMendelianViolation extends MendelianViolation
     {
         public ExtendedMendelianViolation(double threshold)
         {


### PR DESCRIPTION
* there was a duplicated condition which looks like a typo and causes nNoCall to be undercounted

@bbimber 
`mv.getFamilyCalledCount` was used twice as the condition in this if statement, I'm pretty sure it was a typo.  As far as I know you're the one using this code so I want to check with you before changing it.