### PR TITLE
Addressed an edge case in ScoreVariantAnnotations that can occur when one variant type is not present in the input VCF. [VS-1609]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -315,6 +315,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - vs_1609_edge_case
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -131,7 +131,7 @@ task GetToolVersions {
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
     String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-03-03-alpine-3de322e309ea"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
-    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2025-02-05-gatkbase-8e33fe63e6fc"
+    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2025-03-05-gatkbase-afa18f7ab47f"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"
     String gotc_imputation_docker = "us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.5-1.10.2-0.1.16-1649948623"
     String plink_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/plink2:2024-04-23-slim-a0a65f52cc0e"

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/scalable/ScoreVariantAnnotations.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/vqsr/scalable/ScoreVariantAnnotations.java
@@ -539,12 +539,14 @@ public class ScoreVariantAnnotations extends LabeledVariantAnnotationsWalker {
                                                                   final List<Boolean> isVariantType,
                                                                   final VariantAnnotationsScorer variantTypeScorer,
                                                                   final List<Double> allScores) {
-        final File variantTypeAnnotationsFile = LabeledVariantAnnotationsData.subsetAnnotationsToTemporaryFile(annotationNames, allAnnotations, isVariantType);
-        final File variantTypeScoresFile = IOUtils.createTempFile("temp", ".scores.hdf5");
-        variantTypeScorer.score(variantTypeAnnotationsFile, variantTypeScoresFile); // TODO we do not fail until here in the case of mismatched annotation names; we could fail earlier
-        final double[] variantTypeScores = VariantAnnotationsScorer.readScores(variantTypeScoresFile);
-        final Iterator<Double> variantTypeScoresIterator = Arrays.stream(variantTypeScores).iterator();
-        IntStream.range(0, allScores.size()).filter(isVariantType::get).forEach(i -> allScores.set(i, variantTypeScoresIterator.next()));
+        if (isVariantType.stream().anyMatch(x -> x)) {
+            final File variantTypeAnnotationsFile = LabeledVariantAnnotationsData.subsetAnnotationsToTemporaryFile(annotationNames, allAnnotations, isVariantType);
+            final File variantTypeScoresFile = IOUtils.createTempFile("temp", ".scores.hdf5");
+            variantTypeScorer.score(variantTypeAnnotationsFile, variantTypeScoresFile); // TODO we do not fail until here in the case of mismatched annotation names; we could fail earlier
+            final double[] variantTypeScores = VariantAnnotationsScorer.readScores(variantTypeScoresFile);
+            final Iterator<Double> variantTypeScoresIterator = Arrays.stream(variantTypeScores).iterator();
+            IntStream.range(0, allScores.size()).filter(isVariantType::get).forEach(i -> allScores.set(i, variantTypeScoresIterator.next()));
+        }
     }
 
     @Override


### PR DESCRIPTION
Mostly successful run here, excepting an unrelated and well-known GCP Batch 50006 error condition which when combined with a lack of `maxRetries` in `PrepGenesAnnotationJson` led to an early demise.