### PR TITLE
VS-1449 add reference string to vcf

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -327,6 +327,7 @@ workflows:
              - master
              - ah_var_store
              - vs_1590_mem_footprint_part_I
+             - gg_VS-1449_AddReferenceStringToVcf
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -327,7 +327,6 @@ workflows:
              - master
              - ah_var_store
              - rc-vs-1576-avro-update
-             - gg_VS-1449_AddReferenceStringToVcf
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -131,7 +131,7 @@ task GetToolVersions {
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
     String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-03-03-alpine-3de322e309ea"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
-    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2025-03-14-gatkbase-86d43023d53b"
+    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2025-03-20-gatkbase-728e45646e04"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"
     String gotc_imputation_docker = "us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.5-1.10.2-0.1.16-1649948623"
     String plink_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/plink2:2024-04-23-slim-a0a65f52cc0e"

--- a/scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
+++ b/scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
@@ -39,7 +39,7 @@ workflow GvsQuickstartIntegration {
     }
 
     String expected_subdir = if (!chr20_X_Y_only) then "all_chrs/"  else ""
-    File expected_output_prefix = "gs://gvs-internal-quickstart/integration/2024-10-29/" + expected_subdir
+    File expected_output_prefix = "gs://gvs-internal-quickstart/integration/2025-03-20/" + expected_subdir
     File truth_data_prefix = "gs://gvs-internal-quickstart/integration/test_data/2025-01-17/" + expected_subdir
 
     # WDL 1.0 trick to set a variable ('none') to be undefined.

--- a/scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
+++ b/scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
@@ -1,5 +1,7 @@
 version 1.0
 
+# It's a comment!
+
 import "GvsQuickstartVcfIntegration.wdl" as QuickstartVcfIntegration
 import "GvsQuickstartHailIntegration.wdl" as QuickstartHailIntegration
 import "GvsQuickstartVATIntegration.wdl" as QuickstartVATIntegration

--- a/scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
+++ b/scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
@@ -1,7 +1,5 @@
 version 1.0
 
-# It's a comment!
-
 import "GvsQuickstartVcfIntegration.wdl" as QuickstartVcfIntegration
 import "GvsQuickstartHailIntegration.wdl" as QuickstartHailIntegration
 import "GvsQuickstartVATIntegration.wdl" as QuickstartVATIntegration

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohort.java
@@ -412,6 +412,7 @@ public abstract class ExtractCohort extends ExtractTool {
         Map<Long, String> sampleIdToName = sampleList.getSampleIdToNameMap();
 
         reference = directlyAccessEngineReferenceDataSource();
+        extraHeaderLines.add(new VCFHeaderLine("reference", referenceArguments.getReferenceSpecifier().toString()));
 
         if (vetRangesExtractTableVersion == VetRangesExtractVersionEnum.V2) {
             extraHeaderLines.add(GATKVCFHeaderLines.getFormatLine(GATKVCFConstants.HAPLOTYPE_CALLER_PHASING_GT_KEY));

--- a/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortToPgenTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortToPgenTest.java
@@ -36,7 +36,7 @@ public class ExtractCohortToPgenTest extends CommandLineProgramTest {
       while (pvarZstdReader.ready()) {
         final String nextLine = pvarZstdReader.readLine();
         // Skip the source header line because some weirdness in the way the gatk build works makes that not match
-        if(nextLine.startsWith("##source"))
+        if ((nextLine.startsWith("##source")) || (nextLine.startsWith("##reference")))
           continue;
 
         decompressedPvarWriter.write(nextLine);

--- a/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortToPgenTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortToPgenTest.java
@@ -36,6 +36,7 @@ public class ExtractCohortToPgenTest extends CommandLineProgramTest {
       while (pvarZstdReader.ready()) {
         final String nextLine = pvarZstdReader.readLine();
         // Skip the source header line because some weirdness in the way the gatk build works makes that not match
+        // Skip the reference header line because the file path is local on where the test is run.
         if ((nextLine.startsWith("##source")) || (nextLine.startsWith("##reference")))
           continue;
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortToVcfTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortToVcfTest.java
@@ -82,7 +82,7 @@ public class ExtractCohortToVcfTest extends CommandLineProgramTest {
             .add("L", "chr20:10000000-20000000");
 
     runCommandLine(args);
-    // Decompress the vcf for validation
+    // Remove iine(s) from the generated VCF that
     final File decompressedVCF = removeSelectedHeaderLinesFromFile(outputVCF);
     IntegrationTestSpec.assertEqualTextFiles(decompressedVCF, expectedVCF);
   }


### PR DESCRIPTION
This PR modifies VCF extract to add the `reference=` line to the header of the VCFs

Passing integration test [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration/submission_history/ecef50d4-b1d9-48e0-a2a5-a211c203de32)