### PR TITLE
Add variant stratification and overlap metrics in SVConcordance

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/GATKSVVCFConstants.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/sv/utils/GATKSVVCFConstants.java
@@ -189,6 +189,11 @@ public final class GATKSVVCFConstants {
     public static final String TRUTH_ALLELE_NUMBER_INFO = "TRUTH_AN";
     public static final String TRUTH_ALLELE_FREQUENCY_INFO = "TRUTH_AF";
 
+    public static final String TRUTH_RECIPROCAL_OVERLAP_INFO = "TRUTH_RECIPROCAL_OVERLAP";
+    public static final String TRUTH_SIZE_SIMILARITY_INFO = "TRUTH_SIZE_SIMILARITY";
+    public static final String TRUTH_DISTANCE_START_INFO = "TRUTH_DISTANCE_START";
+    public static final String TRUTH_DISTANCE_END_INFO = "TRUTH_DISTANCE_END";
+
     // stratification
     public static final String STRATUM_INFO_KEY = "STRAT";
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/cluster/CanonicalSVLinkage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/cluster/CanonicalSVLinkage.java
@@ -39,8 +39,6 @@ public class CanonicalSVLinkage<T extends SVCallRecord> extends SVClusterLinkage
     protected ClusteringParameters mixedParams;
     protected ClusteringParameters evidenceParams;
 
-    protected boolean computeLinkageMetrics = false;
-
     public static final int INSERTION_ASSUMED_LENGTH_FOR_OVERLAP = 50;
     public static final int INSERTION_ASSUMED_LENGTH_FOR_SIZE_SIMILARITY = 1;
 
@@ -93,10 +91,6 @@ public class CanonicalSVLinkage<T extends SVCallRecord> extends SVClusterLinkage
         this.mixedParams = DEFAULT_MIXED_PARAMS;
         this.evidenceParams = DEFAULT_PESR_PARAMS;
         this.clusterDelWithDup = clusterDelWithDup;
-    }
-
-    public void enableLinkageMetrics() {
-        computeLinkageMetrics = true;
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/cluster/CanonicalSVLinkage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/cluster/CanonicalSVLinkage.java
@@ -5,7 +5,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants;
 import org.broadinstitute.hellbender.tools.sv.SVCallRecord;
-import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 
@@ -39,6 +38,8 @@ public class CanonicalSVLinkage<T extends SVCallRecord> extends SVClusterLinkage
     protected ClusteringParameters depthOnlyParams;
     protected ClusteringParameters mixedParams;
     protected ClusteringParameters evidenceParams;
+
+    protected boolean computeLinkageMetrics = false;
 
     public static final int INSERTION_ASSUMED_LENGTH_FOR_OVERLAP = 50;
     public static final int INSERTION_ASSUMED_LENGTH_FOR_SIZE_SIMILARITY = 1;
@@ -94,26 +95,30 @@ public class CanonicalSVLinkage<T extends SVCallRecord> extends SVClusterLinkage
         this.clusterDelWithDup = clusterDelWithDup;
     }
 
+    public void enableLinkageMetrics() {
+        computeLinkageMetrics = true;
+    }
+
     @Override
-    public boolean areClusterable(final SVCallRecord a, final SVCallRecord b) {
+    public CanonicalLinkageResult areClusterable(final SVCallRecord a, final SVCallRecord b) {
         if (!typesMatch(a, b)) {
-            return false;
+            return new CanonicalLinkageResult(false);
         }
         // Only require matching strands if BND or INV type
         if ((a.getType() == GATKSVVCFConstants.StructuralVariantAnnotationType.BND
                 || a.getType() == GATKSVVCFConstants.StructuralVariantAnnotationType.INV)
                 && !strandsMatch(a, b)) {
-            return false;
+            return new CanonicalLinkageResult(false);
         }
         // Checks appropriate parameter set
         if (evidenceParams.isValidPair(a, b)) {
-            return clusterTogetherWithParams(a, b, evidenceParams, dictionary);
+            return clusterTogetherWithParams(a, b, evidenceParams);
         } else if (mixedParams.isValidPair(a, b)) {
-            return clusterTogetherWithParams(a, b, mixedParams, dictionary);
+            return clusterTogetherWithParams(a, b, mixedParams);
         } else if (depthOnlyParams.isValidPair(a, b)) {
-            return clusterTogetherWithParams(a, b, depthOnlyParams, dictionary);
+            return clusterTogetherWithParams(a, b, depthOnlyParams);
         } else {
-            return false;
+            return new CanonicalLinkageResult(false);
         }
     }
 
@@ -149,60 +154,51 @@ public class CanonicalSVLinkage<T extends SVCallRecord> extends SVClusterLinkage
      * Helper function to test for clustering between two items given a particular set of parameters.
      * Note that the records have already been subjected to the checks in {@link #areClusterable(SVCallRecord, SVCallRecord)}.
      */
-    private static boolean clusterTogetherWithParams(final SVCallRecord a, final SVCallRecord b,
-                                                     final ClusteringParameters params,
-                                                     final SAMSequenceDictionary dictionary) {
+    private static CanonicalLinkageResult clusterTogetherWithParams(final SVCallRecord a, final SVCallRecord b,
+                                                                    final ClusteringParameters params) {
         // Contigs match
         if (!(a.getContigA().equals(b.getContigA()) && a.getContigB().equals(b.getContigB()))) {
-            return false;
+            return new CanonicalLinkageResult(false);
         }
 
         // If complex, test complex intervals
         if (a.getType() == GATKSVVCFConstants.StructuralVariantAnnotationType.CPX
-                && b.getType() == GATKSVVCFConstants.StructuralVariantAnnotationType.CPX &&
-                !testComplexIntervals(a, b, params.getReciprocalOverlap(), params.getSizeSimilarity(), params.getWindow(), dictionary)) {
-            return false;
+                && b.getType() == GATKSVVCFConstants.StructuralVariantAnnotationType.CPX) {
+            return testComplexIntervals(a, b, params.getReciprocalOverlap(), params.getSizeSimilarity(), params.getWindow(), params.getSampleOverlap());
         }
 
-        // Reciprocal overlap and size similarity
-        // Check bypassed if both are inter-chromosomal
-        final Boolean hasReciprocalOverlapAndSizeSimilarity;
-        if (a.isIntrachromosomal()) {
-            final boolean hasReciprocalOverlap = testReciprocalOverlap(a, b, params.getReciprocalOverlap());
-            final boolean hasSizeSimilarity = testSizeSimilarity(a, b, params.getSizeSimilarity());
-            hasReciprocalOverlapAndSizeSimilarity = hasReciprocalOverlap && hasSizeSimilarity;
-            if (params.requiresOverlapAndProximity() && !hasReciprocalOverlapAndSizeSimilarity) {
-                return false;
-            }
-        } else {
-            hasReciprocalOverlapAndSizeSimilarity = null;
-        }
+        final Integer breakpointDistance1 = getFirstBreakpointProximity(a, b);
+        final Integer breakpointDistance2 = getSecondBreakpointProximity(a, b);
+        final Double reciprocalOverlap = computeReciprocalOverlap(a, b);
+        final Double sizeSimliarity = computeSizeSimilarity(a, b);
 
-        // Breakend proximity
-        final boolean hasBreakendProximity = testBreakendProximity(a, b, params.getWindow(), dictionary);
-        // Use short-circuiting statements since sample overlap is the least scalable / slowest check
-        if (hasReciprocalOverlapAndSizeSimilarity == null) {
-            return hasBreakendProximity && hasSampleOverlap(a, b, params.getSampleOverlap());
+        final boolean hasBreakendProximity = testBreakendProximity(breakpointDistance1, breakpointDistance2, params.getWindow());
+        final boolean hasReciprocalOverlap = testReciprocalOverlap(reciprocalOverlap, params.getReciprocalOverlap());
+        final boolean hasSizeSimilarity = testSizeSimilarity(sizeSimliarity, params.getSizeSimilarity());
+        final boolean passesOverlapAndProximity = params.requiresOverlapAndProximity() ? (hasBreakendProximity && hasReciprocalOverlap) : (hasBreakendProximity || hasReciprocalOverlap);
+
+        // Don't do expensive overlap calculation if it fails other checks or the threshold is 0
+        final boolean result;
+        if (passesOverlapAndProximity && hasSizeSimilarity && params.getSampleOverlap() > 0) {
+            final Double sampleOverlap =  computeSampleOverlap(a, b);
+            result = testSampleOverlap(sampleOverlap, params.getSampleOverlap());
         } else {
-            if (params.requiresOverlapAndProximity()) {
-                return hasReciprocalOverlapAndSizeSimilarity && hasBreakendProximity && hasSampleOverlap(a, b, params.getSampleOverlap());
-            } else {
-                return (hasReciprocalOverlapAndSizeSimilarity || hasBreakendProximity) && hasSampleOverlap(a, b, params.getSampleOverlap());
-            }
+            result = passesOverlapAndProximity && hasSizeSimilarity;
         }
+        return new CanonicalLinkageResult(result, reciprocalOverlap, sizeSimliarity, breakpointDistance1, breakpointDistance2);
     }
 
     /**
      * Performs overlap testing on each pair of complex intervals in two records, requiring each pair to be
      * sufficiently similar by reciprocal overlap, size similarity, and breakend proximity.
      */
-    private static boolean testComplexIntervals(final SVCallRecord a, final SVCallRecord b, final double overlapThreshold,
-                                                final double sizeSimilarityThreshold, final int window,
-                                                final SAMSequenceDictionary dictionary) {
+    private static CanonicalLinkageResult testComplexIntervals(final SVCallRecord a, final SVCallRecord b, final double overlapThreshold,
+                                                               final double sizeSimilarityThreshold, final int window,
+                                                               final double sampleOverlapThreshold) {
         final List<SVCallRecord.ComplexEventInterval> intervalsA = a.getComplexEventIntervals();
         final List<SVCallRecord.ComplexEventInterval> intervalsB = b.getComplexEventIntervals();
         if (intervalsA.size() != intervalsB.size()) {
-            return false;
+            return new CanonicalLinkageResult(false);
         }
         final Iterator<SVCallRecord.ComplexEventInterval> iterA = intervalsA.iterator();
         final Iterator<SVCallRecord.ComplexEventInterval> iterB = intervalsB.iterator();
@@ -210,74 +206,100 @@ public class CanonicalSVLinkage<T extends SVCallRecord> extends SVClusterLinkage
             final SVCallRecord.ComplexEventInterval cpxIntervalA = iterA.next();
             final SVCallRecord.ComplexEventInterval cpxIintervalB = iterB.next();
             if (cpxIntervalA.getIntervalSVType() != cpxIintervalB.getIntervalSVType()) {
-                return false;
+                return new CanonicalLinkageResult(false);
             }
+            final Integer breakpointDistance1 = getFirstBreakpointProximity(a, b);
+            final Integer breakpointDistance2 = getSecondBreakpointProximity(a, b);
             final SimpleInterval intervalA = cpxIntervalA.getInterval();
             final SimpleInterval intervalB = cpxIintervalB.getInterval();
-            if (!(IntervalUtils.isReciprocalOverlap(intervalA, intervalB, overlapThreshold)
-                    && testSizeSimilarity(intervalA.getLengthOnReference(), intervalB.getLengthOnReference(), sizeSimilarityThreshold)
-                    && testBreakendProximity(new SimpleInterval(intervalA.getContig(), intervalA.getStart(), intervalA.getStart()),
-                    new SimpleInterval(intervalA.getContig(), intervalA.getEnd(), intervalA.getEnd()),
-                    new SimpleInterval(intervalB.getContig(), intervalB.getStart(), intervalB.getStart()),
-                    new SimpleInterval(intervalB.getContig(), intervalB.getEnd(), intervalB.getEnd()), window, dictionary))) {
-                return false;
+            final Double reciprocalOverlap = computeReciprocalOverlap(intervalA, intervalB);
+            final Double sizeSimilarity = computeSizeSimilarity(intervalA.size(), intervalB.size());
+            if (!(testReciprocalOverlap(reciprocalOverlap, overlapThreshold)
+                    && testSizeSimilarity(sizeSimilarity, sizeSimilarityThreshold)
+                    && testBreakendProximity(breakpointDistance1, breakpointDistance2, window))) {
+                return new CanonicalLinkageResult(false);
             }
         }
-        return true;
+        // Don't do expensive overlap calculation if threshold is 0
+        final Double sampleOverlap = sampleOverlapThreshold > 0 ? computeSampleOverlap(a, b) : Double.valueOf(1.);
+        return new CanonicalLinkageResult(testSampleOverlap(sampleOverlap, sampleOverlapThreshold));
     }
 
-    private static boolean testReciprocalOverlap(final SVCallRecord a, final SVCallRecord b, final double threshold) {
-        final SimpleInterval intervalA = new SimpleInterval(a.getContigA(), a.getPositionA(), a.getPositionA() + getLength(a, INSERTION_ASSUMED_LENGTH_FOR_OVERLAP) - 1);
-        final SimpleInterval intervalB = new SimpleInterval(b.getContigA(), b.getPositionA(), b.getPositionA() + getLength(b, INSERTION_ASSUMED_LENGTH_FOR_OVERLAP) - 1);
-        return IntervalUtils.isReciprocalOverlap(intervalA, intervalB, threshold);
-    }
-
-    private static boolean testSizeSimilarity(final SVCallRecord a, final SVCallRecord b, final double threshold) {
-        return testSizeSimilarity(getLength(a, INSERTION_ASSUMED_LENGTH_FOR_SIZE_SIMILARITY),
-                getLength(b, INSERTION_ASSUMED_LENGTH_FOR_SIZE_SIMILARITY), threshold);
-    }
-
-    private static boolean testSizeSimilarity(final int lengthA, final int lengthB, final double threshold) {
-        return Math.min(lengthA, lengthB) / (double) Math.max(lengthA, lengthB) >= threshold;
-    }
-
-    private static boolean testBreakendProximity(final SVCallRecord a, final SVCallRecord b, final int window,
-                                                 final SAMSequenceDictionary dictionary) {
-        return testBreakendProximity(a.getPositionAInterval(), a.getPositionBInterval(),
-                b.getPositionAInterval(), b.getPositionBInterval(), window, dictionary);
-    }
-
-    private static boolean testBreakendProximity(final SimpleInterval intervalA1, final SimpleInterval intervalA2,
-                                                 final SimpleInterval intervalB1, final SimpleInterval intervalB2,
-                                                 final int window, final SAMSequenceDictionary dictionary) {
-        final SimpleInterval intervalA1Padded = intervalA1.expandWithinContig(window, dictionary);
-        final SimpleInterval intervalA2Padded = intervalA2.expandWithinContig(window, dictionary);
-        if (intervalA1Padded == null) {
-            logger.warn("Invalid start position " + intervalA1.getContig() + ":" + intervalA1.getStart() +
-                    " - record will not be matched");
-            return false;
+    private static Double computeReciprocalOverlap(final SVCallRecord a, final SVCallRecord b) {
+        if (a.isIntrachromosomal() && b.isIntrachromosomal() && a.getContigA().equals(b.getContigA())) {
+            final int lengthA = getLength(a, INSERTION_ASSUMED_LENGTH_FOR_OVERLAP);
+            final int lengthB = getLength(b, INSERTION_ASSUMED_LENGTH_FOR_OVERLAP);
+            final SimpleInterval intervalA = new SimpleInterval(a.getContigA(), a.getPositionA(), a.getPositionA() + lengthA - 1);
+            final SimpleInterval intervalB = new SimpleInterval(b.getContigA(), b.getPositionA(), b.getPositionA() + lengthB - 1);
+            return computeReciprocalOverlap(intervalA, intervalB);
+        } else {
+            return null;
         }
-        if (intervalA2Padded == null) {
-            logger.warn("Invalid end position " + intervalA2.getContig() + ":" + intervalA2.getStart() +
-                    " - record will not be matched");
-            return false;
+    }
+
+    private static Double computeReciprocalOverlap(final SimpleInterval a, final SimpleInterval b) {
+        if (!a.overlaps(b)) {
+            return 0.;
         }
-        return intervalA1Padded.overlaps(intervalB1) && intervalA2Padded.overlaps(intervalB2);
+        return a.intersect(b).size() / (double) Math.max(a.size(), b.size());
+    }
+
+    private static boolean testReciprocalOverlap(final Double reciprocalOverlap, final double threshold) {
+        return reciprocalOverlap == null || reciprocalOverlap >= threshold;
+    }
+
+    private static Double computeSizeSimilarity(final SVCallRecord a, final SVCallRecord b) {
+        if (a.isIntrachromosomal() && b.isIntrachromosomal()) {
+            final int lengthA = getLength(a, INSERTION_ASSUMED_LENGTH_FOR_SIZE_SIMILARITY);
+            final int lengthB = getLength(b, INSERTION_ASSUMED_LENGTH_FOR_SIZE_SIMILARITY);
+            return computeSizeSimilarity(lengthA, lengthB);
+        } else {
+            return null;
+        }
+    }
+
+    private static double computeSizeSimilarity(final int lengthA, final int lengthB) {
+        return Math.min(lengthA, lengthB) / (double) Math.max(lengthA, lengthB);
+    }
+
+    private static boolean testSizeSimilarity(final Double sizeSimilarity, final double threshold) {
+        return sizeSimilarity == null || sizeSimilarity >= threshold;
+    }
+
+    private static boolean testBreakendProximity(final Integer distance1, final Integer distance2, final int window) {
+        return distance1 != null && distance2 != null && distance1 <= window && distance2 <= window;
+    }
+
+    private static Integer getFirstBreakpointProximity(final SVCallRecord a, final SVCallRecord b) {
+        if (a.getContigA().equals(b.getContigA())) {
+            return Math.abs(a.getPositionA() - b.getPositionA());
+        } else {
+            return null;
+        }
+    }
+
+    private static Integer getSecondBreakpointProximity(final SVCallRecord a, final SVCallRecord b) {
+        if (a.getContigB().equals(b.getContigB())) {
+            return Math.abs(a.getPositionB() - b.getPositionB());
+        } else {
+            return null;
+        }
     }
 
     /**
-     * Gets event length used for overlap testing.
+     * Gets event length
      */
-    private static int getLength(final SVCallRecord record, final int missingInsertionLength) {
-        Utils.validate(record.isIntrachromosomal(), "Record must be intra-chromosomal");
-        if (record.getType() == GATKSVVCFConstants.StructuralVariantAnnotationType.INS ||
-                record.getType() == GATKSVVCFConstants.StructuralVariantAnnotationType.CPX) {
-            return record.getLength() == null ? missingInsertionLength : Math.max(record.getLength(), 1);
-        } else if (record.getType() == GATKSVVCFConstants.StructuralVariantAnnotationType.BND) {
-            return record.getPositionB() - record.getPositionA() + 1;
+    private static int getLength(final SVCallRecord record, final int lengthIfMissing) {
+        if (record.getType() == GATKSVVCFConstants.StructuralVariantAnnotationType.BND) {
+            if (record.isIntrachromosomal()) {
+                // Correct for 0-length case, which is valid for BNDs
+                return Math.max(record.getPositionB() - record.getPositionA(), 1);
+            } else {
+                return 0;
+            }
         } else {
             // TODO lengths less than 1 shouldn't be valid
-            return Math.max(record.getLength() == null ? 1 : record.getLength(), 1);
+            return Math.max(record.getLength() == null ? lengthIfMissing : record.getLength(), 1);
         }
     }
 
@@ -336,6 +358,47 @@ public class CanonicalSVLinkage<T extends SVCallRecord> extends SVClusterLinkage
 
     public final void setEvidenceParams(ClusteringParameters evidenceParams) {
         this.evidenceParams = evidenceParams;
+    }
+
+    public static class CanonicalLinkageResult extends SVClusterLinkage.LinkageResult {
+        private final Double reciprocalOverlap;
+        private final Double sizeSimilarity;
+        private final Integer breakpointDistance1;
+        private final Integer breakpointDistance2;
+
+        public CanonicalLinkageResult(final boolean result) {
+            super(result);
+            this.reciprocalOverlap = null;
+            this.sizeSimilarity = null;
+            this.breakpointDistance1 = null;
+            this.breakpointDistance2 = null;
+        }
+
+        public CanonicalLinkageResult(final boolean result, final Double reciprocalOverlap, final Double sizeSimilarity,
+                                      final Integer breakpointDistance1,
+                                      final Integer breakpointDistance2) {
+            super(result);
+            this.reciprocalOverlap = reciprocalOverlap;
+            this.sizeSimilarity = sizeSimilarity;
+            this.breakpointDistance1 = breakpointDistance1;
+            this.breakpointDistance2 = breakpointDistance2;
+        }
+
+        public Double getReciprocalOverlap() {
+            return reciprocalOverlap;
+        }
+
+        public Double getSizeSimilarity() {
+            return sizeSimilarity;
+        }
+
+        public Integer getBreakpointDistance1() {
+            return breakpointDistance1;
+        }
+
+        public Integer getBreakpointDistance2() {
+            return breakpointDistance2;
+        }
     }
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/cluster/CanonicalSVLinkage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/cluster/CanonicalSVLinkage.java
@@ -354,6 +354,9 @@ public class CanonicalSVLinkage<T extends SVCallRecord> extends SVClusterLinkage
         this.evidenceParams = evidenceParams;
     }
 
+    /**
+     * Adds overlap metrics to the linkage check result
+     */
     public static class CanonicalLinkageResult extends SVClusterLinkage.LinkageResult {
         private final Double reciprocalOverlap;
         private final Double sizeSimilarity;

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/cluster/SVClusterEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/cluster/SVClusterEngine.java
@@ -138,7 +138,7 @@ public class SVClusterEngine {
         final Set<Integer> linkedItems = idToClusterMap.values().stream().map(Cluster::getItemIds)
                 .flatMap(List::stream)
                 .distinct()
-                .filter(other -> !other.equals(itemId) && linkage.areClusterable(item, getItem(other)))
+                .filter(other -> !other.equals(itemId) && linkage.areClusterable(item, getItem(other)).getResult())
                 .collect(Collectors.toCollection(LinkedHashSet::new));
 
         // Find clusters to which this item belongs, and which active clusters we're definitely done with

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/cluster/SVClusterLinkage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/cluster/SVClusterLinkage.java
@@ -117,7 +117,7 @@ public abstract class SVClusterLinkage<T extends SVLocatable> {
     }
 
     /**
-     * Used for storing the result of a clustering check between two record and any additional metadata
+     * Used for storing the result of a clustering check between two records and any additional metadata
      */
     public static class LinkageResult {
         private final boolean result;

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/cluster/SVClusterLinkage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/cluster/SVClusterLinkage.java
@@ -21,7 +21,7 @@ public abstract class SVClusterLinkage<T extends SVLocatable> {
      * @param a first item
      * @param b second item
      */
-    public abstract boolean areClusterable(final T a, final T b);
+    public abstract LinkageResult areClusterable(final T a, final T b);
 
     /**
      * Returns the maximum feasible starting position of any other item with the given item. That is, given item A and
@@ -46,62 +46,56 @@ public abstract class SVClusterLinkage<T extends SVLocatable> {
     }
 
     /**
-     * Checks for minimum fractional sample overlap of the two sets. Defaults to true if both sets are empty.
-     */
-    protected static boolean hasSampleSetOverlap(final Set<String> samplesA, final Set<String> samplesB, final double minSampleOverlap) {
-        final int denom = Math.max(samplesA.size(), samplesB.size());
-        if (denom == 0) {
-            return true;
-        }
-        final double sampleOverlap = getSampleSetOverlap(samplesA, samplesB) / (double) denom;
-        return sampleOverlap >= minSampleOverlap;
-    }
-
-    /**
      * Returns number of overlapping items
      */
-    protected static int getSampleSetOverlap(final Collection<String> a, final Set<String> b) {
-        return (int) a.stream().filter(b::contains).count();
+    protected static double getSampleSetOverlap(final Collection<String> a, final Set<String> b) {
+        final double denom = Math.max(a.size(), b.size());
+        if (denom == 0) {
+            return 1;
+        }
+        return a.stream().filter(b::contains).count() / denom;
     }
 
     /**
-     * Returns true if there is sufficient fractional carrier sample overlap in the two records. For CNVs, returns true
-     * if sufficient fraction of copy number states match.
+     * Returns true if the overlap is null or exceeds threshold.
      */
-    protected static boolean hasSampleOverlap(final SVCallRecord a, final SVCallRecord b, final double minSampleOverlap) {
-        if (minSampleOverlap > 0) {
-            if (a.getType() == GATKSVVCFConstants.StructuralVariantAnnotationType.CNV || b.getType() == GATKSVVCFConstants.StructuralVariantAnnotationType.CNV) {
-                // CNV sample overlap
-                final GenotypesContext genotypesA = a.getGenotypes();
-                final GenotypesContext genotypesB = b.getGenotypes();
-                final Set<String> samples = new HashSet<>(SVUtils.hashMapCapacity(genotypesA.size() + genotypesB.size()));
-                samples.addAll(genotypesA.getSampleNames());
-                samples.addAll(genotypesB.getSampleNames());
-                if (samples.isEmpty()) {
-                    // Empty case considered perfect overlap
-                    return true;
-                }
-                int numMatches = 0;
-                for (final String sample : samples) {
-                    final Genotype genotypeA = genotypesA.get(sample);
-                    final Genotype genotypeB = genotypesB.get(sample);
-                    // If one sample doesn't exist in the other set, assume reference copy state
-                    final int cnA = getCopyState(genotypeA, genotypeB);
-                    final int cnB = getCopyState(genotypeB, genotypeA);
-                    if (cnA == cnB) {
-                        numMatches++;
-                    }
-                }
-                final int numSamples = samples.size();
-                return (numMatches / (double) numSamples) >= minSampleOverlap;
-            } else {
-                // Non-CNV
-                final Set<String> samplesA = a.getCarrierSampleSet();
-                final Set<String> samplesB = b.getCarrierSampleSet();
-                return hasSampleSetOverlap(samplesA, samplesB, minSampleOverlap);
+    protected static boolean testSampleOverlap(final Double sampleOverlap, final double threshold) {
+        return sampleOverlap == null || sampleOverlap >= threshold;
+    }
+
+
+    /**
+     * Returns fractional carrier sample overlap in the two records. For CNVs, returns fraction of copy number states that match.
+     */
+    protected static Double computeSampleOverlap(final SVCallRecord a, final SVCallRecord b) {
+        if (a.getType() == GATKSVVCFConstants.StructuralVariantAnnotationType.CNV || b.getType() == GATKSVVCFConstants.StructuralVariantAnnotationType.CNV) {
+            // CNV sample overlap
+            final GenotypesContext genotypesA = a.getGenotypes();
+            final GenotypesContext genotypesB = b.getGenotypes();
+            final Set<String> samples = new HashSet<>(SVUtils.hashMapCapacity(genotypesA.size() + genotypesB.size()));
+            samples.addAll(genotypesA.getSampleNames());
+            samples.addAll(genotypesB.getSampleNames());
+            if (samples.isEmpty()) {
+                return null;
             }
+            int numMatches = 0;
+            for (final String sample : samples) {
+                final Genotype genotypeA = genotypesA.get(sample);
+                final Genotype genotypeB = genotypesB.get(sample);
+                // If one sample doesn't exist in the other set, assume reference copy state
+                final int cnA = getCopyState(genotypeA, genotypeB);
+                final int cnB = getCopyState(genotypeB, genotypeA);
+                if (cnA == cnB) {
+                    numMatches++;
+                }
+            }
+            final int numSamples = samples.size();
+            return (numMatches / (double) numSamples);
         } else {
-            return true;
+            // Non-CNV
+            final Set<String> samplesA = a.getCarrierSampleSet();
+            final Set<String> samplesB = b.getCarrierSampleSet();
+            return getSampleSetOverlap(samplesA, samplesB);
         }
     }
 
@@ -120,5 +114,14 @@ public abstract class SVClusterLinkage<T extends SVLocatable> {
             return VariantContextGetters.getAttributeAsInt(genotype, GATKSVVCFConstants.COPY_NUMBER_FORMAT,
                     VariantContextGetters.getAttributeAsInt(genotype, GATKSVVCFConstants.DEPTH_GENOTYPE_COPY_NUMBER_FORMAT, -1));
         }
+    }
+
+    /**
+     * Used for storing the result of a clustering check between two record and any additional metadata
+     */
+    public static class LinkageResult {
+        private final boolean result;
+        public LinkageResult(final boolean result) { this.result = result; }
+        public boolean getResult() { return result; }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/concordance/SVConcordanceAnnotator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/concordance/SVConcordanceAnnotator.java
@@ -9,6 +9,7 @@ import org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants;
 import org.broadinstitute.hellbender.tools.sv.SVAlleleCounter;
 import org.broadinstitute.hellbender.tools.sv.SVCallRecord;
 import org.broadinstitute.hellbender.tools.sv.SVCallRecordUtils;
+import org.broadinstitute.hellbender.tools.sv.cluster.CanonicalSVLinkage;
 import org.broadinstitute.hellbender.tools.walkers.validation.Concordance;
 import org.broadinstitute.hellbender.tools.walkers.validation.ConcordanceState;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -37,8 +38,7 @@ public class SVConcordanceAnnotator {
     }
 
     /**
-     * Annotator restricted to specific samples.
-     * @param samples samples to include for concordance computations. If null, all samples in eval records will be used.
+     * Option to enable annotating variants with overlap metrics.
      */
     public SVConcordanceAnnotator(final Set<String> samples) {
         this.samples = samples;
@@ -100,6 +100,13 @@ public class SVConcordanceAnnotator {
             attributes.put(GATKSVVCFConstants.VAR_PPV_INFO, Double.isNaN(metrics.VAR_PPV) ? null : metrics.VAR_PPV);
             attributes.put(GATKSVVCFConstants.VAR_SENSITIVITY_INFO, Double.isNaN(metrics.VAR_SENSITIVITY) ? null : metrics.VAR_SENSITIVITY);
             attributes.put(GATKSVVCFConstants.VAR_SPECIFICITY_INFO, Double.isNaN(metrics.VAR_SPECIFICITY) ? null : metrics.VAR_SPECIFICITY);
+        }
+        if (truthRecord != null) {
+            final CanonicalSVLinkage.CanonicalLinkageResult linkageResult = pair.getLinkage();
+            attributes.put(GATKSVVCFConstants.TRUTH_RECIPROCAL_OVERLAP_INFO, linkageResult.getReciprocalOverlap());
+            attributes.put(GATKSVVCFConstants.TRUTH_SIZE_SIMILARITY_INFO, linkageResult.getSizeSimilarity());
+            attributes.put(GATKSVVCFConstants.TRUTH_DISTANCE_START_INFO, linkageResult.getBreakpointDistance1());
+            attributes.put(GATKSVVCFConstants.TRUTH_DISTANCE_END_INFO, linkageResult.getBreakpointDistance2());
         }
 
         if (evalRecord.getType() != GATKSVVCFConstants.StructuralVariantAnnotationType.CNV) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/concordance/SVConcordanceAnnotator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/concordance/SVConcordanceAnnotator.java
@@ -38,7 +38,8 @@ public class SVConcordanceAnnotator {
     }
 
     /**
-     * Option to enable annotating variants with overlap metrics.
+     * Annotator restricted to specific samples.
+     * @param samples samples to include for concordance computations. If null, all samples in eval records will be used.
      */
     public SVConcordanceAnnotator(final Set<String> samples) {
         this.samples = samples;

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/concordance/SVConcordanceLinkage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/concordance/SVConcordanceLinkage.java
@@ -12,12 +12,12 @@ public class SVConcordanceLinkage extends CanonicalSVLinkage<SVCallRecord> {
     }
 
     @Override
-    public boolean areClusterable(final SVCallRecord a, final SVCallRecord b) {
+    public CanonicalLinkageResult areClusterable(final SVCallRecord a, final SVCallRecord b) {
         final GATKSVVCFConstants.StructuralVariantAnnotationType aType = a.getType();
         final GATKSVVCFConstants.StructuralVariantAnnotationType bType = b.getType();
         // Don't allow CNV/DEL or CNV/DUP matching, which is problematic for concordance calculations
         if ((aType == GATKSVVCFConstants.StructuralVariantAnnotationType.CNV || bType != GATKSVVCFConstants.StructuralVariantAnnotationType.CNV) && aType != bType) {
-            return false;
+            return new CanonicalLinkageResult(false);
         }
         return super.areClusterable(a, b);
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/concordance/StratifiedConcordanceEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/concordance/StratifiedConcordanceEngine.java
@@ -1,0 +1,168 @@
+package org.broadinstitute.hellbender.tools.sv.concordance;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.SVUtils;
+import org.broadinstitute.hellbender.tools.sv.SVCallRecord;
+import org.broadinstitute.hellbender.tools.sv.SVCallRecordUtils;
+import org.broadinstitute.hellbender.tools.sv.cluster.SVClusterEngineArgumentsCollection;
+import org.broadinstitute.hellbender.tools.sv.stratify.SVStratificationEngine;
+import org.broadinstitute.hellbender.tools.sv.stratify.SVStratificationEngineArgumentsCollection;
+import org.broadinstitute.hellbender.tools.walkers.sv.SVStratify;
+import org.broadinstitute.hellbender.tools.walkers.validation.Concordance;
+import org.broadinstitute.hellbender.tools.walkers.validation.ConcordanceState;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class StratifiedConcordanceEngine {
+
+    protected final Map<String, ClosestSVFinder> clusterEngineMap;
+    protected final SVStratificationEngine stratificationEngine;
+    protected final Map<Long, ItemTracker> variantStatusMap = new HashMap<>();
+    protected List<VariantContext> outputBuffer;
+    protected ClosestSVFinder defaultEngine;
+    protected SAMSequenceDictionary dictionary;
+    protected final SVStratificationEngineArgumentsCollection stratArgs;
+    protected Long nextItemId = 0L;
+
+    public StratifiedConcordanceEngine(final Map<String, ClosestSVFinder> clusterEngineMap,
+                                       final SVStratificationEngine stratificationEngine,
+                                       final SVStratificationEngineArgumentsCollection stratArgs,
+                                       final SVClusterEngineArgumentsCollection defaultClusteringArgs,
+                                       final SVConcordanceAnnotator defaultCollapser,
+                                       final SAMSequenceDictionary dictionary) {
+        Utils.validate(stratificationEngine.getStrata().size() == clusterEngineMap.size(),
+                "Stratification and clustering configurations have a different number of groups.");
+        for (final SVStratificationEngine.Stratum stratum : stratificationEngine.getStrata()) {
+            Utils.validate(clusterEngineMap.containsKey(stratum.getName()),
+                    "Could not find group " + stratum.getName() + " in clustering configuration.");
+        }
+
+        this.clusterEngineMap = clusterEngineMap;
+        this.stratificationEngine = stratificationEngine;
+        this.stratArgs = stratArgs;
+        this.outputBuffer = new ArrayList<>();
+        this.dictionary = dictionary;
+
+        final SVConcordanceLinkage defaultLinkage = new SVConcordanceLinkage(dictionary);
+        defaultLinkage.setDepthOnlyParams(defaultClusteringArgs.getDepthParameters());
+        defaultLinkage.setMixedParams(defaultClusteringArgs.getMixedParameters());
+        defaultLinkage.setEvidenceParams(defaultClusteringArgs.getPESRParameters());
+        this.defaultEngine = new ClosestSVFinder(defaultLinkage, defaultCollapser::annotate, false, dictionary);
+    }
+
+    public Collection<VariantContext> flush(boolean force) {
+        for (final String name : clusterEngineMap.keySet()) {
+            flushEngineToBuffer(clusterEngineMap.get(name), force, name);
+        }
+        flushEngineToBuffer(defaultEngine, force, SVStratify.DEFAULT_STRATUM);
+        final Collection<VariantContext> result = outputBuffer;
+        outputBuffer = new ArrayList<>();
+        return result;
+    }
+
+    public boolean isEmpty() {
+        return variantStatusMap.isEmpty() && outputBuffer.isEmpty();
+    }
+
+    public void addTruthVariant(final SVCallRecord record) {
+        final Long id = nextItemId++;
+        // truth variants can be matched across all stratification groups
+        for (final String name : clusterEngineMap.keySet()) {
+            addToEngine(record, id, true, clusterEngineMap.get(name), name);
+        }
+        addToEngine(record, id, true, defaultEngine, SVStratify.DEFAULT_STRATUM);
+    }
+
+    public void addEvalVariant(final SVCallRecord record) {
+        final Long id = nextItemId++;
+        // eval variants get stratified
+        final List<String> stratifications = stratificationEngine.getMatches(record,
+                        stratArgs.overlapFraction, stratArgs.numBreakpointOverlaps, stratArgs.numBreakpointOverlapsInterchrom)
+                .stream().map(SVStratificationEngine.Stratum::getName).collect(Collectors.toUnmodifiableList());
+        for (final String stratum : stratifications) {
+            Utils.validate(clusterEngineMap.containsKey(stratum), "Group undefined: " + stratum);
+            addToEngine(record, id, false, clusterEngineMap.get(stratum), stratum);
+        }
+        // default stratum
+        addToEngine(record, id, false, defaultEngine, SVStratify.DEFAULT_STRATUM);
+        // Keep track of which groups it was added to
+        Utils.validate(!variantStatusMap.containsKey(id), "Attempted to add duplicate id");
+        final List<String> stratList = new ArrayList<>(stratifications.size() + 1);
+        stratList.addAll(stratifications);
+        stratList.add(SVStratify.DEFAULT_STRATUM);
+        variantStatusMap.put(id, new ItemTracker(stratList));
+    }
+
+    /**
+     * Adds a record to the given concordance engine, flushing if hit a new contig
+     */
+    protected void addToEngine(final SVCallRecord record, final Long id, final boolean isTruth, final ClosestSVFinder engine, final String name) {
+        if (engine.getLastItemContig() != null && !record.getContigA().equals(engine.getLastItemContig())) {
+            flushEngineToBuffer(engine, true, name);
+        }
+        engine.add(record, id, isTruth);
+        flushEngineToBuffer(engine, false, name);
+    }
+
+    protected void flushEngineToBuffer(final ClosestSVFinder engine, final boolean force, final String name) {
+        for (final ClosestSVFinder.LinkageConcordanceRecord record: engine.flush(force)) {
+            final ItemTracker tracker = variantStatusMap.get(record.id());
+            Utils.validate(tracker != null, "Unregistered variant id: " + record.id());
+            tracker.eject(name, record.record());
+            if (tracker.allEjected()) {
+                Utils.nonNull(tracker.getOutput(), "No tracker output");
+                variantStatusMap.remove(record.id());
+                final List<String> strata = tracker.getGroups().stream().sorted().collect(Collectors.toUnmodifiableList());
+                final VariantContextBuilder builder = SVCallRecordUtils.getVariantBuilder(tracker.getOutput())
+                        .attribute(GATKSVVCFConstants.STRATUM_INFO_KEY, strata);
+                outputBuffer.add(builder.make());
+            }
+        }
+    }
+
+    protected static class ItemTracker {
+
+        private final Map<String, Integer> groupPriorityMap;
+        private SVCallRecord out;
+        private Integer outPriority;
+        private final List<String> groups;
+
+        public ItemTracker(final List<String> submittedTo) {
+            this.groups = submittedTo;
+            this.groupPriorityMap = new HashMap<>(SVUtils.hashMapCapacity(submittedTo.size()));
+            for (int i = 0; i < submittedTo.size(); i++) {
+                this.groupPriorityMap.put(submittedTo.get(i), i);
+            }
+        }
+
+        public void eject(final String name, final SVCallRecord record) {
+            final Integer priority = groupPriorityMap.remove(name);
+            Utils.nonNull(priority, "Unregistered name: " + name);
+            if (outPriority == null || (isTruePositive(record)) && (priority < outPriority || (priority > outPriority && !isTruePositive(out)))) {
+                out = record;
+                outPriority = priority;
+            }
+        }
+
+        private boolean isTruePositive(final SVCallRecord record) {
+            return ConcordanceState.TRUE_POSITIVE.getAbbreviation().equals(record.getAttributes().get(Concordance.TRUTH_STATUS_VCF_ATTRIBUTE));
+        }
+
+        public boolean allEjected() {
+            return groupPriorityMap.isEmpty();
+        }
+
+        public SVCallRecord getOutput() {
+            return out;
+        }
+
+        public List<String> getGroups() {
+            return groups;
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/stratify/OptionalSVStratificationEngineArgumentsCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/stratify/OptionalSVStratificationEngineArgumentsCollection.java
@@ -1,0 +1,21 @@
+package org.broadinstitute.hellbender.tools.sv.stratify;
+
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.hellbender.engine.GATKPath;
+import org.broadinstitute.hellbender.utils.tsv.TableUtils;
+
+public class OptionalSVStratificationEngineArgumentsCollection extends SVStratificationEngineArgumentsCollection {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Expected format is tab-delimited and contains columns NAME, SVTYPE, MIN_SIZE, MAX_SIZE, track. First line must
+     * be a header with column names. Comment lines starting with {@link TableUtils#COMMENT_PREFIX} are ignored.
+     */
+    @Argument(
+            doc = "Stratification configuration file (.tsv)",
+            fullName = STRATIFY_CONFIG_FILE_LONG_NAME,
+            optional = true
+    )
+    public GATKPath configFile;
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/stratify/RequiredSVStratificationEngineArgumentsCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/stratify/RequiredSVStratificationEngineArgumentsCollection.java
@@ -1,0 +1,20 @@
+package org.broadinstitute.hellbender.tools.sv.stratify;
+
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.hellbender.engine.GATKPath;
+import org.broadinstitute.hellbender.utils.tsv.TableUtils;
+
+public class RequiredSVStratificationEngineArgumentsCollection extends SVStratificationEngineArgumentsCollection {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Expected format is tab-delimited and contains columns NAME, SVTYPE, MIN_SIZE, MAX_SIZE, track. First line must
+     * be a header with column names. Comment lines starting with {@link TableUtils#COMMENT_PREFIX} are ignored.
+     */
+    @Argument(
+            doc = "Stratification configuration file (.tsv)",
+            fullName = STRATIFY_CONFIG_FILE_LONG_NAME
+    )
+    public GATKPath configFile;
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/stratify/SVStratificationEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/stratify/SVStratificationEngine.java
@@ -24,7 +24,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 // Groups variants by SVTYPE, SVLEN, and overlap with one or more interval sets
-public class SVStatificationEngine {
+public class SVStratificationEngine {
 
     // Configuration table column names
     public static final String NAME_COLUMN = "NAME";
@@ -38,12 +38,12 @@ public class SVStatificationEngine {
     public static final Set<String> NULL_TABLE_VALUES = Set.of("-1", "", "NULL", "NA");
 
     protected final Map<String, OverlapDetector<Locatable>> trackMap;
-    protected final Map<String, Stratum> strata;
+    protected final LinkedHashMap<String, Stratum> strata;
     protected final SAMSequenceDictionary dictionary;
 
-    public SVStatificationEngine(final SAMSequenceDictionary dictionary) {
+    public SVStratificationEngine(final SAMSequenceDictionary dictionary) {
         trackMap = new HashMap<>();
-        strata = new HashMap<>();
+        strata = new LinkedHashMap<>();
         this.dictionary = Utils.nonNull(dictionary);
     }
 
@@ -91,12 +91,12 @@ public class SVStatificationEngine {
      * @param dictionary reference dict
      * @return new engine
      */
-    public static SVStatificationEngine create(final Map<String, List<Locatable>> trackMap,
-                                               final GATKPath configFilePath,
-                                               final SAMSequenceDictionary dictionary) {
+    public static SVStratificationEngine create(final Map<String, List<Locatable>> trackMap,
+                                                final GATKPath configFilePath,
+                                                final SAMSequenceDictionary dictionary) {
         Utils.nonNull(trackMap);
         Utils.nonNull(configFilePath);
-        final SVStatificationEngine engine = new SVStatificationEngine(dictionary);
+        final SVStratificationEngine engine = new SVStratificationEngine(dictionary);
         for (final Map.Entry<String, List<Locatable>> entry : trackMap.entrySet()) {
             engine.addTrack(entry.getKey(), entry.getValue());
         }
@@ -118,7 +118,7 @@ public class SVStatificationEngine {
      * @param numBreakpointOverlapsInterchrom minimum breakpoint ends for interchromosomal variants (1, 2)
      * @return all matching strata
      */
-    public Collection<Stratum> getMatches(final SVCallRecord record, final double overlapFraction, final int numBreakpointOverlaps, final int numBreakpointOverlapsInterchrom) {
+    public List<Stratum> getMatches(final SVCallRecord record, final double overlapFraction, final int numBreakpointOverlaps, final int numBreakpointOverlapsInterchrom) {
         Utils.nonNull(record);
         final List<Stratum> result = new ArrayList<>();
         for (final Stratum stratification : strata.values()) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/sv/stratify/SVStratificationEngineArgumentsCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/sv/stratify/SVStratificationEngineArgumentsCollection.java
@@ -2,13 +2,12 @@ package org.broadinstitute.hellbender.tools.sv.stratify;
 
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.hellbender.engine.GATKPath;
-import org.broadinstitute.hellbender.utils.tsv.TableUtils;
 
 import java.io.Serializable;
 import java.util.List;
 
 /**
- * Arguments for use with {@link SVStatificationEngine}.
+ * Arguments for use with {@link SVStratificationEngine}.
  */
 public class SVStratificationEngineArgumentsCollection implements Serializable {
     // Command-line arguments
@@ -19,16 +18,6 @@ public class SVStratificationEngineArgumentsCollection implements Serializable {
     public static final String NUM_BREAKPOINT_OVERLAPS_LONG_NAME = "stratify-num-breakpoint-overlaps";
     public static final String NUM_BREAKPOINT_INTERCHROM_OVERLAPS_LONG_NAME = "stratify-num-breakpoint-overlaps-interchromosomal";
     private static final long serialVersionUID = 1L;
-
-    /**
-     * Expected format is tab-delimited and contains columns NAME, SVTYPE, MIN_SIZE, MAX_SIZE, track. First line must
-     * be a header with column names. Comment lines starting with {@link TableUtils#COMMENT_PREFIX} are ignored.
-     */
-    @Argument(
-            doc = "Stratification configuration file (.tsv)",
-            fullName = STRATIFY_CONFIG_FILE_LONG_NAME
-    )
-    public GATKPath configFile;
 
     @Argument(
             doc = "Track intervals file. Can be specified multiple times.",

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVConcordance.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVConcordance.java
@@ -2,10 +2,10 @@ package org.broadinstitute.hellbender.tools.walkers.sv;
 
 import com.google.common.collect.Sets;
 import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.util.SortingCollection;
 import htsjdk.variant.variantcontext.Genotype;
 import htsjdk.variant.variantcontext.GenotypeBuilder;
 import htsjdk.variant.variantcontext.VariantContext;
-import htsjdk.variant.variantcontext.VariantContextBuilder;
 import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.vcf.*;
 import org.apache.commons.collections4.Predicate;
@@ -20,18 +20,28 @@ import org.broadinstitute.hellbender.engine.AbstractConcordanceWalker;
 import org.broadinstitute.hellbender.engine.GATKPath;
 import org.broadinstitute.hellbender.engine.ReadsContext;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
+import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants;
 import org.broadinstitute.hellbender.tools.sv.SVCallRecord;
 import org.broadinstitute.hellbender.tools.sv.SVCallRecordUtils;
+import org.broadinstitute.hellbender.tools.sv.cluster.ClusteringParameters;
 import org.broadinstitute.hellbender.tools.sv.cluster.SVClusterEngineArgumentsCollection;
+import org.broadinstitute.hellbender.tools.sv.cluster.SVClusterWalker;
+import org.broadinstitute.hellbender.tools.sv.cluster.StratifiedClusteringTableParser;
 import org.broadinstitute.hellbender.tools.sv.concordance.ClosestSVFinder;
 import org.broadinstitute.hellbender.tools.sv.concordance.SVConcordanceAnnotator;
 import org.broadinstitute.hellbender.tools.sv.concordance.SVConcordanceLinkage;
+import org.broadinstitute.hellbender.tools.sv.concordance.StratifiedConcordanceEngine;
+import org.broadinstitute.hellbender.tools.sv.stratify.OptionalSVStratificationEngineArgumentsCollection;
+import org.broadinstitute.hellbender.tools.sv.stratify.SVStratificationEngine;
 import org.broadinstitute.hellbender.tools.walkers.validation.Concordance;
 import org.broadinstitute.hellbender.utils.SequenceDictionaryUtils;
+import org.broadinstitute.hellbender.utils.tsv.TableReader;
+import org.broadinstitute.hellbender.utils.tsv.TableUtils;
 import picard.vcf.GenotypeConcordance;
 
+import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -52,7 +62,19 @@ import java.util.stream.Collectors;
  * of the specific fields. For multi-allelic CNVs, only a copy state concordance metric is
  * annotated. Allele frequencies will be recalculated automatically if unavailable in the provided VCFs.
  *
- * For large inputs, users may enable the --do-not-sort flag to reduce memory usage.
+ * This tool also allows supports stratification of SVs into groups with specified matching criteria including SV type,
+ * size range, and interval overlap. Please see the {@link GroupedSVCluster} tool documentation for further details
+ * on how to specify stratification groups.
+ *
+ * Note that unlike {@link GroupedSVCluster}, this tool allows any variant to
+ * match more than one stratification group. If this occurs, groups will be prioritized by their ordering in the input
+ * stratification table, with groups appearing first receiving higher priority. While all matching groups will
+ * be listed in the STRAT INFO field, the variant ID pertaining to the highest-priority group will be populated in
+ * the TRUTH_VID field (groups with no matching variant are ignored). It is therefore recommended that the groups with
+ * the most specific clustering criteria be listed as higher priority.
+ *
+ * The "default" stratification group, with clustering parameters specified directly through the clustering program
+ * arguments (e.g. --depth-breakend-window, --pesr-interval-overlap, etc.), is always present and given lowest priority.
  *
  * <h3>Inputs</h3>
  *
@@ -94,29 +116,42 @@ import java.util.stream.Collectors;
 @DocumentedFeature
 public final class SVConcordance extends AbstractConcordanceWalker {
 
-    public static final String UNSORTED_OUTPUT_LONG_NAME = "do-not-sort";
-
     @Argument(
             doc = "Output VCF",
             fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
             shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME
     )
-    private GATKPath outputFile;
+    protected GATKPath outputFile;
 
+    /**
+     * Expected format is tab-delimited and contains columns NAME, RECIPROCAL_OVERLAP, SIZE_SIMILARITY, BREAKEND_WINDOW,
+     * SAMPLE_OVERLAP. First line must be a header with column names. Comment lines starting with
+     * {@link TableUtils#COMMENT_PREFIX} are ignored.
+     */
     @Argument(
-            doc = "Skip output sorting. This can substantially reduce memory usage.",
-            fullName = UNSORTED_OUTPUT_LONG_NAME
+            doc = "Configuration file (.tsv) containing the clustering parameters for each group",
+            fullName = GroupedSVCluster.CLUSTERING_CONFIG_FILE_LONG_NAME,
+            optional = true
     )
-    private boolean doNotSort;
+    public GATKPath strataClusteringConfigFile;
+
+    @Argument(fullName = SVClusterWalker.MAX_RECORDS_IN_RAM_LONG_NAME,
+            doc = "When writing VCF files that need to be sorted, this will specify the number of records stored in " +
+                    "RAM before spilling to disk. Increasing this number reduces the number of file handles needed to sort a " +
+                    "VCF file, and increases the amount of RAM needed.",
+            optional=true)
+    public int maxRecordsInRam = 10000;
 
     @ArgumentCollection
-    private final SVClusterEngineArgumentsCollection clusterParameterArgs = new SVClusterEngineArgumentsCollection();
+    protected final SVClusterEngineArgumentsCollection defaultClusteringArgs = new SVClusterEngineArgumentsCollection();
+    @ArgumentCollection
+    private final OptionalSVStratificationEngineArgumentsCollection stratArgs = new OptionalSVStratificationEngineArgumentsCollection();
 
-    private SAMSequenceDictionary dictionary;
-    private VariantContextWriter writer;
-    private SVConcordanceLinkage linkage;
-    private ClosestSVFinder engine;
-    private String currentContig = null;
+    protected StratifiedConcordanceEngine engine;
+    protected SAMSequenceDictionary dictionary;
+    protected SortingCollection<VariantContext> sortingBuffer;
+    protected VariantContextWriter writer;
+
 
     @Override
     protected Predicate<VariantContext> makeTruthVariantFilter() {
@@ -125,6 +160,7 @@ public final class SVConcordance extends AbstractConcordanceWalker {
 
     @Override
     public void onTraversalStart() {
+        super.onTraversalStart();
         // Use master sequence dictionary i.e. hg38 .dict file since the "best" dictionary is grabbed
         // from the VCF, which is sometimes out of order
         dictionary = getMasterSequenceDictionary();
@@ -135,67 +171,95 @@ public final class SVConcordance extends AbstractConcordanceWalker {
         // Check that vcfs are sorted the same
         SequenceDictionaryUtils.validateDictionaries("eval", getEvalHeader().getSequenceDictionary(),
                 "truth", getTruthHeader().getSequenceDictionary(), false, true);
-
-        linkage = new SVConcordanceLinkage(dictionary);
-        linkage.setDepthOnlyParams(clusterParameterArgs.getDepthParameters());
-        linkage.setMixedParams(clusterParameterArgs.getMixedParameters());
-        linkage.setEvidenceParams(clusterParameterArgs.getPESRParameters());
+        writer = createVCFWriter(outputFile);
+        final VCFHeader header = createHeader(getEvalHeader());
+        writer.writeHeader(header);
+        sortingBuffer = SortingCollection.newInstance(
+                VariantContext.class,
+                new VCFRecordCodec(header, true),
+                header.getVCFRecordComparator(),
+                maxRecordsInRam,
+                tmpDir.toPath());
 
         // Concordance computations should be done on common samples only
         final Set<String> commonSamples = Sets.intersection(
                 new HashSet<>(getEvalHeader().getGenotypeSamples()),
                 new HashSet<>(getTruthHeader().getGenotypeSamples()));
         final SVConcordanceAnnotator collapser = new SVConcordanceAnnotator(commonSamples);
-        engine = new ClosestSVFinder(linkage, collapser::annotate, !doNotSort, dictionary);
 
-        if (doNotSort) {
-            createOutputVariantIndex = false;
+        final Map<String, ClosestSVFinder> clusterEngineMap = new HashMap<>();
+        if (strataClusteringConfigFile != null) {
+            try (final TableReader<StratifiedClusteringTableParser.StratumParameters> tableReader = TableUtils.reader(strataClusteringConfigFile.toPath(), StratifiedClusteringTableParser::tableParser)) {
+                for (final StratifiedClusteringTableParser.StratumParameters parameters : tableReader) {
+                    // Identical parameters for each linkage type
+                    final ClusteringParameters pesrParams = ClusteringParameters.createPesrParameters(parameters.reciprocalOverlap(), parameters.sizeSimilarity(), parameters.breakendWindow(), parameters.sampleOverlap());
+                    final ClusteringParameters mixedParams = ClusteringParameters.createMixedParameters(parameters.reciprocalOverlap(), parameters.sizeSimilarity(), parameters.breakendWindow(), parameters.sampleOverlap());
+                    final ClusteringParameters depthParams = ClusteringParameters.createDepthParameters(parameters.reciprocalOverlap(), parameters.sizeSimilarity(), parameters.breakendWindow(), parameters.sampleOverlap());
+                    final SVConcordanceLinkage linkage = new SVConcordanceLinkage(dictionary);
+                    linkage.setDepthOnlyParams(depthParams);
+                    linkage.setMixedParams(mixedParams);
+                    linkage.setEvidenceParams(pesrParams);
+                    final ClosestSVFinder engine = new ClosestSVFinder(linkage, collapser::annotate, false, dictionary);
+                    clusterEngineMap.put(parameters.name(), engine);
+                }
+            } catch (final IOException e) {
+                throw new GATKException("IO error while reading config table", e);
+            }
         }
-        writer = createVCFWriter(outputFile);
-        writer.writeHeader(createHeader(getEvalHeader()));
+
+        if ((stratArgs.configFile == null) ^ (strataClusteringConfigFile == null)) {
+            throw new UserException.BadInput("Both --" + OptionalSVStratificationEngineArgumentsCollection.STRATIFY_CONFIG_FILE_LONG_NAME
+                    + " and --" + GroupedSVCluster.CLUSTERING_CONFIG_FILE_LONG_NAME + " must be used together, but only one was specified.");
+        }
+        final SVStratificationEngine stratEngine = SVStratify.loadStratificationConfig(stratArgs.configFile, stratArgs, dictionary);
+        engine = new StratifiedConcordanceEngine(clusterEngineMap, stratEngine, stratArgs, defaultClusteringArgs, collapser, dictionary);
     }
+
 
     @Override
     public Object onTraversalSuccess() {
-        flushClusters(true);
+        for (final VariantContext variant : engine.flush(true)) {
+            sortingBuffer.add(variant);
+        }
+        if (!engine.isEmpty()) {
+            throw new GATKException("Concordance engine is not empty, but it should be");
+        }
+        for (final VariantContext variant : sortingBuffer) {
+            writer.add(variant);
+        }
         return super.onTraversalSuccess();
     }
 
     @Override
     public void closeTool() {
-        super.closeTool();
+        if (sortingBuffer != null) {
+            sortingBuffer.cleanup();
+        }
         if (writer != null) {
             writer.close();
         }
+        super.closeTool();
     }
 
     @Override
     public void apply(final TruthVersusEval truthVersusEval, final ReadsContext readsContext, final ReferenceContext refContext) {
         if (truthVersusEval.hasTruth()) {
-            add(truthVersusEval.getTruth(), true);
+            final SVCallRecord record = minimizeTruthFootprint(SVCallRecordUtils.create(truthVersusEval.getTruth(), dictionary));
+            engine.addTruthVariant(record);
         }
         if (truthVersusEval.hasEval()) {
-            add(truthVersusEval.getEval(), false);
+            final SVCallRecord record = SVCallRecordUtils.create(truthVersusEval.getEval(), dictionary);
+            engine.addEvalVariant(record);
         }
-    }
-
-    private void add(final VariantContext variant, final boolean isTruth) {
-        SVCallRecord record = SVCallRecordUtils.create(variant, dictionary);
-        if (!record.getContigA().equals(currentContig)) {
-            flushClusters(true);
-            currentContig = record.getContigA();
+        for (final VariantContext variant : engine.flush(false)) {
+            sortingBuffer.add(variant);
         }
-        if (isTruth) {
-            record = minimizeTruthFootprint(record);
-        }
-        engine.add(record, isTruth);
-        flushClusters(false);
     }
 
     /**
      * Strips unneeded attributes from a truth variant to save memory.
      */
-    protected SVCallRecord minimizeTruthFootprint(final SVCallRecord item) {
+    private SVCallRecord minimizeTruthFootprint(final SVCallRecord item) {
         final List<Genotype> genotypes = item.getGenotypes().stream().map(SVConcordance::stripTruthGenotype).collect(Collectors.toList());
         return new SVCallRecord(item.getId(), item.getContigA(), item.getPositionA(),
                 item.getStrandA(), item.getContigB(), item.getPositionB(), item.getStrandB(), item.getType(),
@@ -216,14 +280,7 @@ public final class SVConcordance extends AbstractConcordanceWalker {
         return true;
     }
 
-    private void flushClusters(final boolean force) {
-        engine.flush(force).stream()
-                .map(SVCallRecordUtils::getVariantBuilder)
-                .map(VariantContextBuilder::make)
-                .forEach(writer::add);
-    }
-
-    private VCFHeader createHeader(final VCFHeader header) {
+    protected VCFHeader createHeader(final VCFHeader header) {
         header.addMetaDataLine(new VCFFormatHeaderLine(GenotypeConcordance.CONTINGENCY_STATE_TAG, VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, "The genotype concordance contingency state"));
         header.addMetaDataLine(new VCFFormatHeaderLine(GATKSVVCFConstants.TRUTH_CN_EQUAL_FORMAT, 1, VCFHeaderLineType.Integer, "Truth CNV copy state is equal (1=True, 0=False)"));
         header.addMetaDataLine(Concordance.TRUTH_STATUS_HEADER_LINE);
@@ -241,11 +298,14 @@ public final class SVConcordance extends AbstractConcordanceWalker {
         header.addMetaDataLine(new VCFInfoHeaderLine(GATKSVVCFConstants.TRUTH_ALLELE_COUNT_INFO, VCFHeaderLineCount.A, VCFHeaderLineType.Integer, "Truth set allele count"));
         header.addMetaDataLine(new VCFInfoHeaderLine(GATKSVVCFConstants.TRUTH_ALLELE_NUMBER_INFO, VCFHeaderLineCount.A, VCFHeaderLineType.Integer, "Truth set allele number"));
         header.addMetaDataLine(new VCFInfoHeaderLine(GATKSVVCFConstants.TRUTH_ALLELE_FREQUENCY_INFO, VCFHeaderLineCount.A, VCFHeaderLineType.Float, "Truth set allele frequency"));
+        header.addMetaDataLine(new VCFInfoHeaderLine(GATKSVVCFConstants.TRUTH_RECIPROCAL_OVERLAP_INFO, 1, VCFHeaderLineType.Float, "Reciprocal overlap with truth variant"));
+        header.addMetaDataLine(new VCFInfoHeaderLine(GATKSVVCFConstants.TRUTH_SIZE_SIMILARITY_INFO, 1, VCFHeaderLineType.Float, "Size similarity with truth variant"));
+        header.addMetaDataLine(new VCFInfoHeaderLine(GATKSVVCFConstants.TRUTH_DISTANCE_START_INFO, 1, VCFHeaderLineType.Integer, "Start coordinate distance in bp to truth variant's start"));
+        header.addMetaDataLine(new VCFInfoHeaderLine(GATKSVVCFConstants.TRUTH_DISTANCE_END_INFO, 1, VCFHeaderLineType.Integer, "End coordinate distance in bp to truth variant's end"));
         header.addMetaDataLine(VCFStandardHeaderLines.getInfoLine(VCFConstants.ALLELE_FREQUENCY_KEY));
         header.addMetaDataLine(VCFStandardHeaderLines.getInfoLine(VCFConstants.ALLELE_COUNT_KEY));
         header.addMetaDataLine(VCFStandardHeaderLines.getInfoLine(VCFConstants.ALLELE_NUMBER_KEY));
+        SVStratify.addStratifyMetadata(header);
         return header;
     }
-
-
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVConcordance.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVConcordance.java
@@ -172,7 +172,7 @@ public final class SVConcordance extends AbstractConcordanceWalker {
                     "RAM before spilling to disk. Increasing this number reduces the number of file handles needed to sort a " +
                     "VCF file, and increases the amount of RAM needed.",
             optional=true)
-    public int maxRecordsInRam = 100;
+    public int maxRecordsInRam = 1000;
 
     @ArgumentCollection
     protected final SVClusterEngineArgumentsCollection defaultClusteringArgs = new SVClusterEngineArgumentsCollection();

--- a/src/test/java/org/broadinstitute/hellbender/tools/sv/SVTestUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/sv/SVTestUtils.java
@@ -173,14 +173,14 @@ public class SVTestUtils {
     }
 
     public static final SVCallRecord makeRecordWithCarriers(final List<String> allSamples, final Set<String> carrierSamples) {
-        final List<GenotypeBuilder> genotypes = makeDeletionGenotypesWithCarriers(allSamples, carrierSamples, Allele.SV_SIMPLE_DEL);
+        final List<GenotypeBuilder> genotypes = makeGenotypesWithCarriers(allSamples, carrierSamples, Allele.SV_SIMPLE_DEL);
         return makeRecord("", "chr1", 100, Boolean.TRUE, "chr1", 200, Boolean.FALSE,
                 GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, Collections.emptyList(),
                 List.of(Allele.REF_N, Allele.SV_SIMPLE_DEL), genotypes);
     }
 
     public static final SVCallRecord makeComplexRecordWithCarriers(final List<String> allSamples, final Set<String> carrierSamples) {
-        final List<Genotype> genotypes = makeDeletionGenotypesWithCarriers(allSamples, carrierSamples, SVTestUtils.CPX_ALLELE)
+        final List<Genotype> genotypes = makeGenotypesWithCarriers(allSamples, carrierSamples, SVTestUtils.CPX_ALLELE)
                 .stream().map(GenotypeBuilder::make).collect(Collectors.toUnmodifiableList());
         return new SVCallRecord("cpx1", "chr1", 1000, null,
                 "chr1", 2000, null,
@@ -192,7 +192,7 @@ public class SVTestUtils {
                 genotypes, Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
     }
 
-    private static List<GenotypeBuilder> makeDeletionGenotypesWithCarriers(final List<String> allSamples, final Set<String> carrierSamples, final Allele altAllele) {
+    private static List<GenotypeBuilder> makeGenotypesWithCarriers(final List<String> allSamples, final Set<String> carrierSamples, final Allele altAllele) {
         final List<GenotypeBuilder> genotypes = new ArrayList<>(allSamples.size());
         for (final String sample : allSamples) {
             final GenotypeBuilder builder = new GenotypeBuilder(sample);

--- a/src/test/java/org/broadinstitute/hellbender/tools/sv/cluster/BinnedCNVDefragmenterTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/sv/cluster/BinnedCNVDefragmenterTest.java
@@ -77,13 +77,13 @@ public class BinnedCNVDefragmenterTest {
     @Test(dataProvider = "clusterTogetherInputsDefault")
     public void testClusterTogetherDefault(final SVCallRecord call1, final SVCallRecord call2,
                                            final boolean expectedResult, final String name) {
-        Assert.assertEquals(defaultDefragmenter.getLinkage().areClusterable(call1, call2), expectedResult, name);
+        Assert.assertEquals(defaultDefragmenter.getLinkage().areClusterable(call1, call2).getResult(), expectedResult, name);
     }
 
     @Test(dataProvider = "clusterTogetherInputsSingleSample")
     public void testClusterTogetherSingleSample(final SVCallRecord call1, final SVCallRecord call2,
                                                 final boolean expectedResult, final String name) {
-        Assert.assertEquals(binnedDefragmenter.getLinkage().areClusterable(call1, call2), expectedResult, name);
+        Assert.assertEquals(binnedDefragmenter.getLinkage().areClusterable(call1, call2).getResult(), expectedResult, name);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/hellbender/tools/sv/cluster/CNVDefragmenterTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/sv/cluster/CNVDefragmenterTest.java
@@ -28,43 +28,43 @@ public class CNVDefragmenterTest {
                 1000, Collections.emptyList(), Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM),
                 Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DUP),
                 Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, dictionary);
-        Assert.assertFalse(defragmenter.areClusterable(deletion, duplication), "Different sv types should not cluster");
+        Assert.assertFalse(defragmenter.areClusterable(deletion, duplication).getResult(), "Different sv types should not cluster");
 
         final SVCallRecord duplicationNonDepthOnly = new SVCallRecord("test_dup", "chr1", 1000, false, "chr1", 1999, true, GATKSVVCFConstants.StructuralVariantAnnotationType.DUP, null, Collections.emptyList(),
                 1000, Collections.emptyList(), Lists.newArrayList(GATKSVVCFConstants.DEPTH_ALGORITHM, SVTestUtils.PESR_ALGORITHM),
                 Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DUP),
                 Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, dictionary);
-        Assert.assertFalse(defragmenter.areClusterable(duplication, duplicationNonDepthOnly), "Clustered records must be depth-only");
+        Assert.assertFalse(defragmenter.areClusterable(duplication, duplicationNonDepthOnly).getResult(), "Clustered records must be depth-only");
 
         final SVCallRecord cnv = new SVCallRecord("test_cnv", "chr1", 1000, null, "chr1", 1999, null, GATKSVVCFConstants.StructuralVariantAnnotationType.CNV, null, Collections.emptyList(),
                 1000, Collections.emptyList(), Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM),
                 Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL, Allele.SV_SIMPLE_DUP),
                 Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, dictionary);
-        Assert.assertFalse(defragmenter.areClusterable(deletion, cnv), "Different sv types should not cluster");
+        Assert.assertFalse(defragmenter.areClusterable(deletion, cnv).getResult(), "Different sv types should not cluster");
 
         final SVCallRecord insertion = new SVCallRecord("test_ins", "chr1", 1000, true, "chr1", 1001, false, GATKSVVCFConstants.StructuralVariantAnnotationType.INS, null, Collections.emptyList(),
                 1000, Collections.emptyList(), SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
                 Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_INS),
                 Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, dictionary);
-        Assert.assertFalse(defragmenter.areClusterable(insertion, insertion), "Only CNVs should be valid");
+        Assert.assertFalse(defragmenter.areClusterable(insertion, insertion).getResult(), "Only CNVs should be valid");
 
         final SVCallRecord deletion2 = new SVCallRecord("test_del2", "chr1", 1000, true, "chr1", 1999, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, Collections.emptyList(),
                 1000, Collections.emptyList(), Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM),
                 Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL),
                 Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, dictionary);
-        Assert.assertTrue(defragmenter.areClusterable(deletion, deletion2), "Valid identical records should cluster");
+        Assert.assertTrue(defragmenter.areClusterable(deletion, deletion2).getResult(), "Valid identical records should cluster");
 
         final SVCallRecord deletion3 = new SVCallRecord("test_del3", "chr1", 2999, true, "chr1", 3998, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, Collections.emptyList(),
                 1000, Collections.emptyList(), Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM),
                 Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL),
                 Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, dictionary);
-        Assert.assertTrue(defragmenter.areClusterable(deletion, deletion3), "Should cluster due to overlap");
+        Assert.assertTrue(defragmenter.areClusterable(deletion, deletion3).getResult(), "Should cluster due to overlap");
 
         final SVCallRecord deletion4 = new SVCallRecord("test_del3", "chr1", 3000, true, "chr1", 3999, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, Collections.emptyList(),
                 1000, Collections.emptyList(), Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM),
                 Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL),
                 Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, dictionary);
-        Assert.assertFalse(defragmenter.areClusterable(deletion, deletion4), "Should barely not cluster");
+        Assert.assertFalse(defragmenter.areClusterable(deletion, deletion4).getResult(), "Should barely not cluster");
     }
 
     @DataProvider(name = "testOverlapBuilders")
@@ -165,16 +165,16 @@ public class CNVDefragmenterTest {
                         new GenotypeBuilder(altGenotypeMaker1.name("sample2").make()),
                         new GenotypeBuilder(altGenotypeMaker1.name("sample3").make())
                 ));
-        Assert.assertFalse(defragmenter.areClusterable(deletionARR1, deletionARR2));
-        Assert.assertFalse(defragmenter.areClusterable(deletionARR1, deletionRAR));
-        Assert.assertFalse(defragmenter.areClusterable(deletionARR1, deletionAAR));
-        Assert.assertFalse(defragmenter.areClusterable(deletionARR1, deletionAAA));
-        Assert.assertFalse(defragmenter.areClusterable(deletionRAR, deletionAAR));
-        Assert.assertFalse(defragmenter.areClusterable(deletionRAR, deletionAAA));
+        Assert.assertFalse(defragmenter.areClusterable(deletionARR1, deletionARR2).getResult());
+        Assert.assertFalse(defragmenter.areClusterable(deletionARR1, deletionRAR).getResult());
+        Assert.assertFalse(defragmenter.areClusterable(deletionARR1, deletionAAR).getResult());
+        Assert.assertFalse(defragmenter.areClusterable(deletionARR1, deletionAAA).getResult());
+        Assert.assertFalse(defragmenter.areClusterable(deletionRAR, deletionAAR).getResult());
+        Assert.assertFalse(defragmenter.areClusterable(deletionRAR, deletionAAA).getResult());
 
-        Assert.assertTrue(defragmenter.areClusterable(deletionARR1, deletionARR1Copy));
-        Assert.assertTrue(defragmenter.areClusterable(deletionAAR, deletionAAA));
-        Assert.assertTrue(defragmenter.areClusterable(deletionAAR, deletionAAR2));
+        Assert.assertTrue(defragmenter.areClusterable(deletionARR1, deletionARR1Copy).getResult());
+        Assert.assertTrue(defragmenter.areClusterable(deletionAAR, deletionAAA).getResult());
+        Assert.assertTrue(defragmenter.areClusterable(deletionAAR, deletionAAR2).getResult());
     }
 
     @DataProvider(name = "maxPositionIntervals")
@@ -201,7 +201,7 @@ public class CNVDefragmenterTest {
                 call2End - call2Start + 1, Collections.emptyList(), Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM),
                 Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL),
                 Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, dictionary);
-        Assert.assertTrue(defragmenter.areClusterable(call1, call2));
+        Assert.assertTrue(defragmenter.areClusterable(call1, call2).getResult());
 
         final int call3Start = maxClusterableStart + 1;
         final int call3End = dictionary.getSequence(call1.getContigA()).getSequenceLength();
@@ -209,6 +209,6 @@ public class CNVDefragmenterTest {
                 call3End - call3Start + 1, Collections.emptyList(), Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM),
                 Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL),
                 Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, dictionary);
-        Assert.assertFalse(defragmenter.areClusterable(call1, call3));
+        Assert.assertFalse(defragmenter.areClusterable(call1, call3).getResult());
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/sv/cluster/CanonicalSVLinkageTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/sv/cluster/CanonicalSVLinkageTest.java
@@ -1,0 +1,723 @@
+package org.broadinstitute.hellbender.tools.sv.cluster;
+
+import com.google.common.collect.Lists;
+import htsjdk.variant.variantcontext.Allele;
+import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants;
+import org.broadinstitute.hellbender.tools.sv.SVCallRecord;
+import org.broadinstitute.hellbender.tools.sv.SVTestUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class CanonicalSVLinkageTest extends GATKBaseTest {
+
+    private static final CanonicalSVLinkage<SVCallRecord> linkage = SVTestUtils.getNewDefaultLinkage();
+    private static final ClusteringParameters depthOnlyParametersSizeSimilarity = ClusteringParameters.createDepthParameters(0.1, 0.5, 10000000, 0);
+    private static final ClusteringParameters mixedParametersSizeSimilarity = ClusteringParameters.createMixedParameters(0.1, 0.5, 5000, 0);
+    private static final ClusteringParameters evidenceParametersSizeSimilarity = ClusteringParameters.createPesrParameters(0.1, 0.5, 5000, 0);
+    private static final CanonicalSVLinkage<SVCallRecord> linkageSizeSimilarity = new CanonicalSVLinkage<>(SVTestUtils.hg38Dict, false);
+
+    // Assign length according to coordinate scheme
+    private static Integer inferLength(final String contigA, final int posA, final String contigB, final int posB) {
+        if (contigA.equals(contigB)) {
+            if (posA == posB) {
+                // no interval
+                return null;
+            } else {
+                // intrachromosomal and intervaled
+                return posB - posA;
+            }
+        } else {
+            // interchromosomal
+            return null;
+        }
+    }
+
+    @BeforeTest
+    public void initializeClusterEngine() {
+        linkageSizeSimilarity.setDepthOnlyParams(depthOnlyParametersSizeSimilarity);
+        linkageSizeSimilarity.setMixedParams(mixedParametersSizeSimilarity);
+        linkageSizeSimilarity.setEvidenceParams(evidenceParametersSizeSimilarity);
+    }
+
+    @Test
+    public void testClusterTogether() {
+        Assert.assertTrue(linkage.areClusterable(SVTestUtils.depthOnly, SVTestUtils.depthAndStuff).getResult());
+        Assert.assertFalse(linkage.areClusterable(SVTestUtils.depthOnly, SVTestUtils.inversion).getResult());
+        Assert.assertFalse(linkage.areClusterable(SVTestUtils.call1, SVTestUtils.call2).getResult());
+        Assert.assertTrue(linkage.areClusterable(SVTestUtils.call1, SVTestUtils.overlapsCall1).getResult());
+    }
+
+    @DataProvider(name = "clusterTogetherVaryPositionsProvider")
+    public Object[][] clusterTogetherVaryPositionsProvider() {
+        return new Object[][]{
+                {500, 1001, 1001, 1502, false, 1/502., 1., 501, 501},  // abutting
+                {500, 1001, 500, 1001, true, 1., 1., 0, 0},  // exactly equal
+                {500, 1001, 600, 1101, true, 402/502., 1., 100, 100},  // barely meet reciprocal overlap
+                {500, 1001, 601, 1102, false, 401/502., 1., 101, 101}, // call2 shifted slightly up
+                {500, 1000, 600, 1101, false, 401/502., 501/502., 100, 101}, // call1 slightly larger
+                {500, 501, 500, 501, true, 1., 1., 0, 0}, // tiny but equal
+                {500, 501, 500, 502, false, 2/3., 2/3., 0, 1}, // tiny but call2 twice as big
+                {500, 500, 500, 500, true, 1., 1., 0, 0}, // 0-length and equal
+                {500, 500, 501, 501, false, 0., 1., 1, 1}, // 0-length and not equal
+                {1, SVTestUtils.chr1Length, 1, SVTestUtils.chr1Length, true, 1., 1., 0, 0}, // really big
+                {1, 10001, 1, 10001, true, 1., 1., 0, 0}, // left contig edge
+                {SVTestUtils.chr1Length - 10000, SVTestUtils.chr1Length, SVTestUtils.chr1Length - 10000, SVTestUtils.chr1Length, true, 1., 1., 0, 0}, // right contig edge
+                {100000, 200000, 101001, 201001, false, 99000/100001., 1., 1001, 1001}, // window test fail
+                {100000, 200000, 101000, 201000, true, 99001/100001., 1., 1000, 1000} // window test success
+        };
+    }
+
+    @Test(dataProvider= "clusterTogetherVaryPositionsProvider")
+    public void testClusterTogetherVaryPositions(final int start1, final int end1, final int start2, final int end2,
+                                                 final boolean result, final double reciprocalOverlap, final double sizeSimilarity, final int dist1, final int dist2) {
+        final SVCallRecord call1 = new SVCallRecord("call1", "chr1", start1, true,
+                "chr1", end1, false,
+                GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, Collections.emptyList(), end1 - start1 + 1, Collections.emptyList(), SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
+                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL, Allele.SV_SIMPLE_DUP),
+                SVTestUtils.threeGenotypes, Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+        final SVCallRecord call2 = new SVCallRecord("call2", "chr1", start2, true,
+                "chr1", end2, false,
+                GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, Collections.emptyList(), end2 - start2 + 1, Collections.emptyList(), Lists.newArrayList(GATKSVVCFConstants.DEPTH_ALGORITHM),
+                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL, Allele.SV_SIMPLE_DUP),
+                SVTestUtils.threeGenotypes, Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+        final CanonicalSVLinkage.CanonicalLinkageResult linkageResult = linkage.areClusterable(call1, call2);
+        Assert.assertEquals(linkageResult.getResult(), result);
+        Assert.assertEquals(linkageResult.getReciprocalOverlap(), reciprocalOverlap);
+        Assert.assertEquals(linkageResult.getSizeSimilarity(), sizeSimilarity);
+        Assert.assertEquals(linkageResult.getBreakpointDistance1(), dist1);
+        Assert.assertEquals(linkageResult.getBreakpointDistance2(), dist2);
+    }
+
+    @DataProvider(name = "testClusterTogetherWithSizeSimilarityDataProvider")
+    public Object[][] testClusterTogetherWithSizeSimilarityDataProvider() {
+        return new Object[][]{
+                {1001, 2000, 1001, 2000, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, true},
+                {1001, 2000, 1501, 2000, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, true},
+                {1001, 2000, 1900, 2900, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, true},
+                // Fails size similarity
+                {1001, 2000, 1502, 2000, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, false},
+                {1001, 2000, 1901, 2399, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, false},
+                // Fails reciprocal overlap
+                {1001, 2000, 1902, 2900, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, false}
+        };
+    }
+
+    @Test(dataProvider= "testClusterTogetherWithSizeSimilarityDataProvider")
+    public void testClusterTogetherWithSizeSimilarity(final int start1, final int end1,
+                                                      final int start2, final int end2,
+                                                      final GATKSVVCFConstants.StructuralVariantAnnotationType svtype,
+                                                      final boolean expectedResult) {
+        // PESR
+        final SVCallRecord record1 = SVTestUtils.newPESRCallRecordWithIntervalAndType(start1, end1, svtype);
+        final SVCallRecord record2 = SVTestUtils.newPESRCallRecordWithIntervalAndType(start2, end2, svtype);
+        Assert.assertEquals(linkageSizeSimilarity.areClusterable(record1, record2).getResult(), expectedResult);
+        Assert.assertEquals(linkageSizeSimilarity.areClusterable(record2, record1).getResult(), expectedResult);
+
+        // Depth only
+        final SVCallRecord record3 = SVTestUtils.newDepthCallRecordWithIntervalAndType(start1, end1, svtype);
+        final SVCallRecord record4 = SVTestUtils.newDepthCallRecordWithIntervalAndType(start2, end2, svtype);
+        Assert.assertEquals(linkageSizeSimilarity.areClusterable(record3, record4).getResult(), expectedResult);
+        Assert.assertEquals(linkageSizeSimilarity.areClusterable(record4, record3).getResult(), expectedResult);
+    }
+
+    @DataProvider(name = "testClusterTogetherWithSizeSimilarityInsertionsDataProvider")
+    public Object[][] testClusterTogetherWithSizeSimilarityInsertionsDataProvider() {
+        return new Object[][]{
+                {1000, 1000, 1000, 1000, true},
+                {1000, 1000, 1000, 500, true},
+                {1000, 1000, 1000, 2000, true},
+                {1000, 1000, 100, 1000, true},
+                {1000, 1000, 1900, 1000, true},
+                // Fails reciprocal overlap
+                {1000, 1000, 99, 1000, false},
+                {1000, 1000, 1901, 1000, false},
+                // Fails size similarity
+                {1000, 1000, 1000, 499, false},
+                {1000, 2001, 1000, 1000, false},
+        };
+    }
+
+    @Test(dataProvider= "testClusterTogetherWithSizeSimilarityInsertionsDataProvider")
+    public void testClusterTogetherWithSizeSimilarityInsertions(final int start1, final int length1,
+                                                                final int start2, final int length2,
+                                                                final boolean expectedResult) {
+        final SVCallRecord record1 = SVTestUtils.newInsertionWithPositionAndLength(start1, length1);
+        final SVCallRecord record2 = SVTestUtils.newInsertionWithPositionAndLength(start2, length2);
+        Assert.assertEquals(linkageSizeSimilarity.areClusterable(record1, record2).getResult(), expectedResult);
+        Assert.assertEquals(linkageSizeSimilarity.areClusterable(record2, record1).getResult(), expectedResult);
+    }
+
+    @Test(expectedExceptions = { IllegalArgumentException.class })
+    public void testClusterTogetherInvalidInterval() {
+        // End position beyond contig end after padding
+        final SVCallRecord deletion1 = new SVCallRecord("test_del", "chr1", 1000, true, "chr1", 248956423 + SVTestUtils.defaultEvidenceParameters.getWindow(), false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
+                null, Collections.emptyList(),
+                null, Collections.emptyList(), Collections.singletonList(SVTestUtils.PESR_ALGORITHM),
+                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL),
+                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+        final SVCallRecord deletion2 = new SVCallRecord("test_del", "chr1", 1000, true, "chr1", 248956422, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
+                null, Collections.emptyList(),
+                null, Collections.emptyList(), Collections.singletonList(SVTestUtils.PESR_ALGORITHM),
+                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL),
+                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+        linkage.areClusterable(deletion1, deletion2);
+        Assert.fail("Expected exception not thrown");
+    }
+
+    @Test
+    public void testGetClusteringIntervalEdge() {
+        //edge case - end of contig
+        Assert.assertTrue(linkage.getMaxClusterableStartingPosition(SVTestUtils.rightEdgeCall) <= SVTestUtils.chr1Length);
+    }
+
+    @DataProvider(name = "maxPositionIntervals")
+    public Object[][] recordPairs() {
+        return new Object[][]{
+                {100, 200},
+                {50000, 500000},
+                {1, 1},
+                {1, 2}
+        };
+    }
+
+    @Test(dataProvider= "maxPositionIntervals")
+    public void testGetMaxClusterableStartingPosition(final int start, final int end) {
+        testGetMaxClusterableStartingPositionWithAlgorithm(start, end, GATKSVVCFConstants.DEPTH_ALGORITHM);
+        testGetMaxClusterableStartingPositionWithAlgorithm(start, end, SVTestUtils.PESR_ALGORITHM);
+    }
+
+    private void testGetMaxClusterableStartingPositionWithAlgorithm(final int start, final int end, final String algorithm) {
+        final SVCallRecord call1 = new SVCallRecord("call1", "chr1", start, true, "chr1", end, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
+                null, Collections.emptyList(),
+                end - start + 1, Collections.emptyList(), Collections.singletonList(algorithm),
+                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL),
+                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+        final int maxClusterableStart = linkage.getMaxClusterableStartingPosition(call1);
+
+        final int call2Start = maxClusterableStart;
+        final SVCallRecord call2Depth = new SVCallRecord("call2", "chr1", call2Start, true, "chr1", call2Start + call1.getLength() - 1, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
+                null, Collections.emptyList(),
+                call1.getLength(), Collections.emptyList(), Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM),
+                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL),
+                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+        final SVCallRecord call2Pesr = new SVCallRecord("call2", "chr1", call2Start, true, "chr1", call2Start + call1.getLength() - 1, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
+                null, Collections.emptyList(),
+                call1.getLength(), Collections.emptyList(), SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
+                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL),
+                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+        Assert.assertTrue(linkage.areClusterable(call1, call2Depth).getResult() || linkage.areClusterable(call1, call2Pesr).getResult());
+
+        final int call3Start = maxClusterableStart + 1;
+        final SVCallRecord call3Depth = new SVCallRecord("call2", "chr1", call3Start, true, "chr1", call3Start + call1.getLength() - 1, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
+                null, Collections.emptyList(),
+                call1.getLength(), Collections.emptyList(), Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM),
+                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL),
+                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+        final SVCallRecord call3Pesr = new SVCallRecord("call2", "chr1", call3Start, true, "chr1", call3Start + call1.getLength() - 1, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
+                null, Collections.emptyList(),
+                call1.getLength(), Collections.emptyList(), SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
+                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL),
+                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+        Assert.assertFalse(linkage.areClusterable(call1, call3Depth).getResult() || linkage.areClusterable(call1, call3Pesr).getResult());
+    }
+
+    @Test
+    public void testGetClusteringIntervalLists() {
+        //test overloaded function with List
+        final List<SVCallRecord> pesrClusterList = new ArrayList<>();
+        pesrClusterList.add(SVTestUtils.depthAndStuff);
+        final int pesrCluster1 = linkage.getMaxClusterableStartingPosition(pesrClusterList);
+        Assert.assertTrue(pesrCluster1 >= SVTestUtils.depthAndStuff.getPositionA() + SVTestUtils.defaultEvidenceParameters.getWindow());
+        Assert.assertTrue(pesrCluster1 >= SVTestUtils.depthAndStuff.getPositionA() + SVTestUtils.defaultMixedParameters.getWindow());
+        //add an upstream variant
+        pesrClusterList.add(SVTestUtils.depthAndStuff2);
+        final int pesrCluster2 = linkage.getMaxClusterableStartingPosition(pesrClusterList);
+        Assert.assertTrue(pesrCluster2 >= pesrCluster1);
+        //add a downstream variant
+        pesrClusterList.add(SVTestUtils.depthAndStuff3);
+        final int pesrCluster3 = linkage.getMaxClusterableStartingPosition(pesrClusterList);
+        Assert.assertTrue(pesrCluster3 >= SVTestUtils.depthAndStuff3.getPositionA() + SVTestUtils.defaultEvidenceParameters.getWindow());
+        Assert.assertTrue(pesrCluster3 >= SVTestUtils.depthAndStuff3.getPositionA() + SVTestUtils.defaultMixedParameters.getWindow());
+    }
+
+    @Test
+    public void testIsDepthOnlyCall() {
+        Assert.assertTrue(SVTestUtils.call1.isDepthOnly());
+        Assert.assertFalse(SVTestUtils.depthAndStuff.isDepthOnly());
+        Assert.assertFalse(SVTestUtils.inversion.isDepthOnly());
+    }
+
+    @DataProvider(name = "testClusterTogetherVaryPositionsBNDData")
+    public Object[][] testClusterTogetherVaryPositionsBNDData() {
+        return new Object[][]{
+                // length 0 edge case
+                {
+                        "chr1", 100, "chr1", 100,
+                        "chr1", 100, "chr1", 100,
+                        0.5, 0.5, 100,
+                        true, 1., 1., 0, 0
+                },
+                // simple interchromosomal
+                {
+                        "chr1", 100, "chr2", 100,
+                        "chr1", 100, "chr2", 100,
+                        0.5, 0.5, 0,
+                        true, null, null, 0, 0
+                },
+                {
+                        "chr1", 100, "chr2", 101,
+                        "chr1", 100, "chr2", 100,
+                        0.5, 0.5, 0,
+                        false, null, null, 0, 1
+                },
+                {
+                        "chr1", 101, "chr2", 100,
+                        "chr1", 100, "chr2", 100,
+                        0.5, 0.5, 0,
+                        false, null, null, 1, 0
+                },
+                // reciprocal overlap for intrachromosomal records
+                {
+                        "chr1", 100, "chr1", 200,
+                        "chr1", 150, "chr1", 250,
+                        0.5, 0.5, 50,
+                        true, 0.5, 1., 50, 50
+                },
+                // fails window
+                {
+                        "chr1", 100, "chr1", 200,
+                        "chr1", 150, "chr1", 250,
+                        0.5, 0.5, 49,
+                        false, 0.5, 1., 50, 50
+                },
+                {
+                        "chr1", 100, "chr1", 200,
+                        "chr1", 100, "chr1", 250,
+                        0.5, 0.5, 49,
+                        false, 2/3., 2/3., 0, 50
+                },
+                {
+                        "chr1", 100, "chr1", 200,
+                        "chr1", 150, "chr1", 200,
+                        0.5, 0.5, 49,
+                        false, 0.5, 0.5, 50, 0
+                },
+                // fails reciprocal overlap
+                {
+                        "chr1", 100, "chr1", 200,
+                        "chr1", 150, "chr1", 250,
+                        0.51, 0.5, 50,
+                        false, 0.5, 1., 50, 50
+                },
+                // fails size similarity
+                {
+                        "chr1", 100, "chr1", 200,
+                        "chr1", 150, "chr1", 200,
+                        0.5, 0.51, 50,
+                        false, 0.5, 0.5, 50, 0
+                }
+        };
+    }
+
+    @Test(dataProvider= "testClusterTogetherVaryPositionsBNDData")
+    public void testClusterTogetherVaryPositionsBND(final String chrom1A, final int start1, final String chrom1B, final int end1,
+                                                    final String chrom2A, final int start2, final String chrom2B, final int end2,
+                                                    final double reciprocalOverlapThresh, final double sizeSimilarityThresh, final int window,
+                                                    final boolean result, final Double expectedReciprocalOverlap, final Double expectedSizeSimilarity,
+                                                    final Integer expectedDist1, final Integer expectedDist2) {
+        final SVCallRecord call1 = new SVCallRecord("call1", chrom1A, start1, true,
+                chrom1B, end1, false,
+                GATKSVVCFConstants.StructuralVariantAnnotationType.BND, null, Collections.emptyList(), null, Collections.emptyList(), SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
+                Lists.newArrayList(Allele.REF_N, SVTestUtils.BND_ALLELE),
+                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+        final SVCallRecord call2 = new SVCallRecord("call2", chrom2A, start2, true,
+                chrom2B, end2, false,
+                GATKSVVCFConstants.StructuralVariantAnnotationType.BND, null, Collections.emptyList(), null, Collections.emptyList(), SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
+                Lists.newArrayList(Allele.REF_N, SVTestUtils.BND_ALLELE),
+                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+        final CanonicalSVLinkage<SVCallRecord> linkage = new CanonicalSVLinkage<>(SVTestUtils.hg38Dict, false);
+        linkage.setEvidenceParams(ClusteringParameters.createPesrParameters(reciprocalOverlapThresh, sizeSimilarityThresh, window, 0));
+        final CanonicalSVLinkage.CanonicalLinkageResult linkageResult = linkage.areClusterable(call1, call2);
+        Assert.assertEquals(linkageResult.getResult(), result);
+        Assert.assertEquals(linkageResult.getReciprocalOverlap(), expectedReciprocalOverlap);
+        Assert.assertEquals(linkageResult.getSizeSimilarity(), expectedSizeSimilarity);
+        Assert.assertEquals(linkageResult.getBreakpointDistance1(), expectedDist1);
+        Assert.assertEquals(linkageResult.getBreakpointDistance2(), expectedDist2);
+    }
+
+    @Test
+    public void testClusterTogetherVaryTypes() {
+        for (final GATKSVVCFConstants.StructuralVariantAnnotationType type1 : GATKSVVCFConstants.StructuralVariantAnnotationType.values()) {
+            // Pass in null strands to let them be determined automatically
+            final SVCallRecord call1 = new SVCallRecord("call1", "chr1", 1000, SVTestUtils.getValidTestStrandA(type1),
+                    "chr1", 2001, SVTestUtils.getValidTestStrandB(type1), type1, null, Collections.emptyList(),
+                    SVTestUtils.getLength(1000, 2001, type1), Collections.emptyList(), Lists.newArrayList(GATKSVVCFConstants.DEPTH_ALGORITHM),
+                    Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+            for (final GATKSVVCFConstants.StructuralVariantAnnotationType type2 : GATKSVVCFConstants.StructuralVariantAnnotationType.values()) {
+                final SVCallRecord call2 = new SVCallRecord("call2", "chr1", 1000, SVTestUtils.getValidTestStrandA(type2),
+                        "chr1", 2001, SVTestUtils.getValidTestStrandB(type2), type2, null, Collections.emptyList(),
+                        SVTestUtils.getLength(1000, 2001, type2), Collections.emptyList(), Lists.newArrayList(GATKSVVCFConstants.DEPTH_ALGORITHM),
+                        Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+                // Should only cluster together if same type, except CNVs
+                if ((type1 == GATKSVVCFConstants.StructuralVariantAnnotationType.CNV && call2.isSimpleCNV()) ||
+                        (type2 == GATKSVVCFConstants.StructuralVariantAnnotationType.CNV && call1.isSimpleCNV())) {
+                    Assert.assertTrue(linkage.areClusterable(call1, call2).getResult());
+                } else {
+                    Assert.assertEquals(linkage.areClusterable(call1, call2).getResult(), type1 == type2);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testClusterTogetherVaryStrands() {
+        final List<Boolean> bools = Lists.newArrayList(Boolean.TRUE, Boolean.FALSE);
+        for (final Boolean strand1A : bools) {
+            for (final Boolean strand1B : bools) {
+                final SVCallRecord call1 = new SVCallRecord("call1", "chr1", 1000, strand1A,
+                        "chr1", 2001, strand1B, GATKSVVCFConstants.StructuralVariantAnnotationType.BND, null, Collections.emptyList(),
+                        null, Collections.emptyList(), Lists.newArrayList(GATKSVVCFConstants.DEPTH_ALGORITHM),
+                        Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+                for (final Boolean strand2A : bools) {
+                    for (final Boolean strand2B : bools) {
+                        final SVCallRecord call2 = new SVCallRecord("call2", "chr1", 1000, strand2A,
+                                "chr1", 2001, strand2B, GATKSVVCFConstants.StructuralVariantAnnotationType.BND, null, Collections.emptyList(),
+                                null, Collections.emptyList(), Lists.newArrayList(GATKSVVCFConstants.DEPTH_ALGORITHM),
+                                Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+                        // Should only cluster if strands match
+                        Assert.assertEquals(linkage.areClusterable(call1, call2).getResult(), strand1A == strand2A && strand1B == strand2B);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testClusterTogetherVaryContigs() {
+        final List<String> contigs = Lists.newArrayList("chr1", "chrX");
+        for (int i = 0; i < contigs.size(); i++) {
+            final String contig1A = contigs.get(i);
+            for (int j = i; j < contigs.size(); j++) {
+                final String contig1B = contigs.get(j);
+                final SVCallRecord call1 = new SVCallRecord("call1", contig1A, 1000, true,
+                        contig1B, 2001, false, GATKSVVCFConstants.StructuralVariantAnnotationType.BND, null, Collections.emptyList(),
+                        null, Collections.emptyList(), SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
+                        Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+                for (int k = 0; k < contigs.size(); k++) {
+                    final String contig2A = contigs.get(k);
+                    for (int m = k; m < contigs.size(); m++) {
+                        final String contig2B = contigs.get(m);
+                        final SVCallRecord call2 = new SVCallRecord("call2", contig2A, 1000, true,
+                                contig2B, 2001, false, GATKSVVCFConstants.StructuralVariantAnnotationType.BND, null, Collections.emptyList(),
+                                null, Collections.emptyList(), SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
+                                Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+                        // Should only cluster if contigs match
+                        Assert.assertEquals(linkage.areClusterable(call1, call2).getResult(), contig1A.equals(contig2A) && contig1B.equals(contig2B));
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testClusterTogetherVaryAlgorithms() {
+        final List<List<String>> algorithmsList = Lists.newArrayList(
+                Arrays.asList(GATKSVVCFConstants.DEPTH_ALGORITHM),
+                Arrays.asList(GATKSVVCFConstants.DEPTH_ALGORITHM, SVTestUtils.PESR_ALGORITHM),
+                SVTestUtils.PESR_ONLY_ALGORITHM_LIST
+        );
+        for (final List<String> algorithms1 : algorithmsList) {
+            final SVCallRecord call1 = new SVCallRecord("call1", "chr1", 1000, true,
+                    "chr1", 2001, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, Collections.emptyList(),
+                    1002, Collections.emptyList(), algorithms1, Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+            for (final List<String> algorithms2 : algorithmsList) {
+                final SVCallRecord call2 = new SVCallRecord("call2", "chr1", 1000, true,
+                        "chr1", 2001, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, Collections.emptyList(),
+                        1002, Collections.emptyList(), algorithms2, Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+                // All combinations should cluster
+                Assert.assertTrue(linkage.areClusterable(call1, call2).getResult());
+            }
+        }
+    }
+
+    @Test
+    public void testClusterTogetherCNVs() {
+        final SVCallRecord cnv1 = SVTestUtils.makeRecord("cnv1", "chr1", 1001, null,
+                "chr1", 2001, null, GATKSVVCFConstants.StructuralVariantAnnotationType.CNV,
+                null, SVTestUtils.DEPTH_ONLY_ALGORITHM_LIST,
+                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL, Allele.SV_SIMPLE_DUP),
+                Collections.emptyList());
+
+        final SVCallRecord cnv2 = SVTestUtils.makeRecord("cnv2", "chr1", 1001, null,
+                "chr1", 2001, null, GATKSVVCFConstants.StructuralVariantAnnotationType.CNV,
+                null, SVTestUtils.DEPTH_ONLY_ALGORITHM_LIST,
+                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL, Allele.SV_SIMPLE_DUP),
+                Collections.emptyList());
+
+        final SVCallRecord del1 = SVTestUtils.makeRecord("del1", "chr1", 1001, null,
+                "chr1", 2001, null, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
+                null, SVTestUtils.DEPTH_ONLY_ALGORITHM_LIST,
+                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL),
+                Collections.emptyList());
+
+        final SVCallRecord dup1 = SVTestUtils.makeRecord("dup1", "chr1", 1001, null,
+                "chr1", 2001, null, GATKSVVCFConstants.StructuralVariantAnnotationType.DUP,
+                null, SVTestUtils.DEPTH_ONLY_ALGORITHM_LIST,
+                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DUP),
+                Collections.emptyList());
+
+        Assert.assertTrue(linkage.areClusterable(cnv1, cnv2).getResult());
+        Assert.assertTrue(linkage.areClusterable(cnv1, del1).getResult());
+        Assert.assertTrue(linkage.areClusterable(cnv1, dup1).getResult());
+        Assert.assertFalse(linkage.areClusterable(del1, dup1).getResult());
+    }
+
+    @DataProvider(name = "testMatchCNVNoGTData")
+    public Object[][] testMatchCNVNoGTData() {
+        return new Object[][]{
+                // Empty
+                {0, new int[]{}, new int[]{}, true},
+                // Both equal
+                {0, new int[]{0}, new int[]{0}, true},
+                {1, new int[]{1}, new int[]{1}, true},
+                {2, new int[]{2}, new int[]{2}, true},
+                {2, new int[]{3}, new int[]{3}, true},
+                // Unequal
+                {2, new int[]{1}, new int[]{2}, false},
+                {2, new int[]{2}, new int[]{1}, false},
+                // Equal multiple
+                {2, new int[]{2, 2}, new int[]{2, 2}, true},
+                {2, new int[]{4, 2}, new int[]{4, 2}, true},
+                // Unequal multiple
+                {2, new int[]{2, 2}, new int[]{2, 1}, false},
+                {2, new int[]{0, 2}, new int[]{1, 1}, false},
+                {2, new int[]{3, 2}, new int[]{2, 2}, false},
+                {2, new int[]{6, 2}, new int[]{4, 2}, false},
+        };
+    }
+
+    @Test(dataProvider= "testMatchCNVNoGTData")
+    public void testMatchCNVNoGT(final int ploidy, final int[] copyNumbers1, final int[] copyNumbers2, final boolean expected) {
+        final List<Allele> alleles = Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_CNV);
+        final GATKSVVCFConstants.StructuralVariantAnnotationType svtype = GATKSVVCFConstants.StructuralVariantAnnotationType.CNV;
+        // Create genotypes with copy number attribute (and no GT)
+        final SVCallRecord recordCN1 = SVTestUtils.getCNVRecordWithCN(ploidy, alleles, svtype, copyNumbers1, GATKSVVCFConstants.COPY_NUMBER_FORMAT);
+        final SVCallRecord recordCN2 = SVTestUtils.getCNVRecordWithCN(ploidy, alleles, svtype, copyNumbers2, GATKSVVCFConstants.COPY_NUMBER_FORMAT);
+
+        // With sample overlap
+        final ClusteringParameters depthOnlyParams = ClusteringParameters.createDepthParameters(0.8, 0, 10000000, 1);
+        final CanonicalSVLinkage<SVCallRecord> linkage = new CanonicalSVLinkage<>(SVTestUtils.hg38Dict, false);
+        linkage.setDepthOnlyParams(depthOnlyParams);
+
+        Assert.assertEquals(linkage.areClusterable(recordCN1, recordCN2).getResult(), expected);
+
+        final SVCallRecord recordRDCN1 = SVTestUtils.getCNVRecordWithCN(ploidy, alleles, svtype, copyNumbers1, GATKSVVCFConstants.DEPTH_GENOTYPE_COPY_NUMBER_FORMAT);
+        final SVCallRecord recordRDCN2 = SVTestUtils.getCNVRecordWithCN(ploidy, alleles, svtype, copyNumbers2, GATKSVVCFConstants.DEPTH_GENOTYPE_COPY_NUMBER_FORMAT);
+        Assert.assertEquals(linkage.areClusterable(recordRDCN1, recordRDCN2).getResult(), expected);
+    }
+
+    @DataProvider(name = "testClusterTogetherIntervaledComplexData")
+    public Object[][] testClusterTogetherIntervaledComplexData() {
+        return new Object[][]{
+                // exact match
+                {"chr1", 1000, "chr1", 2000,
+                        GATKSVVCFConstants.ComplexVariantSubtype.delINV,
+                        Arrays.asList(
+                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 1100, 1500)),
+                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.INV, new SimpleInterval("chr1", 1600, 1900))
+                        ),
+                        true
+                },
+                // match within parameters
+                {"chr1", 1100, "chr1", 1900,
+                        GATKSVVCFConstants.ComplexVariantSubtype.delINV,
+                        Arrays.asList(
+                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 1150, 1550)),
+                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.INV, new SimpleInterval("chr1", 1650, 1800))
+                        ),
+                        true
+                },
+                // different contigs
+                {"chr2", 1000, "chr2", 2000,
+                        GATKSVVCFConstants.ComplexVariantSubtype.delINV,
+                        Arrays.asList(
+                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 1100, 1500)),
+                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.INV, new SimpleInterval("chr1", 1600, 1900))
+                        ),
+                        false
+                },
+                // different coordinates
+                {"chr1", 1600, "chr1", 2400,
+                        GATKSVVCFConstants.ComplexVariantSubtype.delINV,
+                        Arrays.asList(
+                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 1100, 1500)),
+                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.INV, new SimpleInterval("chr1", 1600, 1900))
+                        ),
+                        false
+                },
+                // different subtypes
+                {"chr1", 1000, "chr1", 2000,
+                        GATKSVVCFConstants.ComplexVariantSubtype.delINVdel,
+                        Arrays.asList(
+                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 1100, 1500)),
+                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.INV, new SimpleInterval("chr1", 1600, 1900))
+                        ),
+                        false
+                },
+                // different number of intervals
+                {"chr1", 1000, "chr1", 2000,
+                        GATKSVVCFConstants.ComplexVariantSubtype.delINV,
+                        Arrays.asList(
+                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 1100, 1500))
+                        ),
+                        false
+                },
+                // different cpx intervals
+                {"chr1", 1000, "chr1", 2000,
+                        GATKSVVCFConstants.ComplexVariantSubtype.delINV,
+                        Arrays.asList(
+                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 800, 1100)),
+                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.INV, new SimpleInterval("chr1", 1600, 1900))
+                        ),
+                        false
+                },
+                // second cpx interval type is different
+                {"chr1", 1000, "chr1", 2000,
+                        GATKSVVCFConstants.ComplexVariantSubtype.delINV,
+                        Arrays.asList(
+                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 1100, 1500)),
+                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP, new SimpleInterval("chr1", 1600, 1900))
+                        ),
+                        false
+                },
+        };
+    }
+
+    @Test(dataProvider= "testClusterTogetherIntervaledComplexData")
+    public void testClusterTogetherIntervaledComplex(final String contigA, final int posA, final String contigB, final int posB,
+                                                     final GATKSVVCFConstants.ComplexVariantSubtype subtype,
+                                                     final List<SVCallRecord.ComplexEventInterval> cpxIntervals, final boolean expected) {
+        final SVCallRecord cpx1 = new SVCallRecord("cpx1", "chr1", 1000, null,
+                "chr1", 2000, null,
+                GATKSVVCFConstants.StructuralVariantAnnotationType.CPX,
+                GATKSVVCFConstants.ComplexVariantSubtype.delINV,
+                Arrays.asList(SVCallRecord.ComplexEventInterval.decode("DEL_chr1:1100-1500", SVTestUtils.hg38Dict), SVCallRecord.ComplexEventInterval.decode("INV_chr1:1600-1900", SVTestUtils.hg38Dict)),
+                1000, Collections.emptyList(), Collections.singletonList(SVTestUtils.PESR_ALGORITHM),
+                Lists.newArrayList(Allele.REF_N, SVTestUtils.CPX_ALLELE),
+                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+        final Integer length2 = inferLength(contigA, posA, contigB, posB);
+        final SVCallRecord cpx2 = new SVCallRecord("cpx2", contigA, posA, null,
+                contigB, posB, null,
+                GATKSVVCFConstants.StructuralVariantAnnotationType.CPX,
+                subtype,
+                cpxIntervals,
+                length2, Collections.emptyList(), Collections.singletonList(SVTestUtils.PESR_ALGORITHM),
+                Lists.newArrayList(Allele.REF_N, SVTestUtils.CPX_ALLELE),
+                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+        Assert.assertEquals(linkage.areClusterable(cpx1, cpx2).getResult(), expected);
+    }
+
+    @DataProvider(name = "testClusterTogetherInsertedComplexData")
+    public Object[][] testClusterTogetherInsertedComplexData() {
+        return new Object[][]{
+                // exact match
+                {"chr1", 1000, "chr1", 1000,
+                        GATKSVVCFConstants.ComplexVariantSubtype.dDUP,
+                        Arrays.asList(
+                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP, new SimpleInterval("chr1", 6000, 8000))
+                        ),
+                        true
+                },
+                // close match
+                {"chr1", 1010, "chr1", 1010,
+                        GATKSVVCFConstants.ComplexVariantSubtype.dDUP,
+                        Arrays.asList(
+                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP, new SimpleInterval("chr1", 6200, 7990))
+                        ),
+                        true
+                },
+                // not match by coordinates
+                {"chr1", 2000, "chr1", 3000,
+                        GATKSVVCFConstants.ComplexVariantSubtype.dDUP,
+                        Arrays.asList(
+                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP, new SimpleInterval("chr1", 6200, 7990))
+                        ),
+                        false
+                },
+                // not match by subtype
+                {"chr1", 1000, "chr1", 1000,
+                        GATKSVVCFConstants.ComplexVariantSubtype.dDUP_iDEL,
+                        Arrays.asList(
+                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP, new SimpleInterval("chr1", 6000, 8000))
+                        ),
+                        false
+                },
+                // not match by cpx interval
+                {"chr1", 1000, "chr1", 1000,
+                        GATKSVVCFConstants.ComplexVariantSubtype.dDUP,
+                        Arrays.asList(
+                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP, new SimpleInterval("chr1", 9000, 11000))
+                        ),
+                        false
+                },
+                // different cpx interval type
+                {"chr1", 1000, "chr1", 1000,
+                        GATKSVVCFConstants.ComplexVariantSubtype.dDUP,
+                        Arrays.asList(
+                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.INV, new SimpleInterval("chr1", 6000, 8000))
+                        ),
+                        false
+                },
+        };
+    }
+
+    @Test(dataProvider= "testClusterTogetherInsertedComplexData")
+    public void testClusterTogetherInsertedComplex(final String contigA, final int posA, final String contigB, final int posB,
+                                                   final GATKSVVCFConstants.ComplexVariantSubtype subtype,
+                                                   final List<SVCallRecord.ComplexEventInterval> cpxIntervals, final boolean expected) {
+        final SVCallRecord cpx1 = new SVCallRecord("cpx1", "chr1", 1000, null,
+                "chr1", 1000, null,
+                GATKSVVCFConstants.StructuralVariantAnnotationType.CPX,
+                GATKSVVCFConstants.ComplexVariantSubtype.dDUP,
+                Arrays.asList(new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP, new SimpleInterval("chr1", 6000, 8000))),
+                2000, Collections.emptyList(), Collections.singletonList(SVTestUtils.PESR_ALGORITHM),
+                Lists.newArrayList(Allele.REF_N, SVTestUtils.CPX_ALLELE),
+                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+        final Integer length2 = cpxIntervals.get(0).getInterval().size();
+        final SVCallRecord cpx2 = new SVCallRecord("cpx2", contigA, posA, null,
+                contigB, posB, null,
+                GATKSVVCFConstants.StructuralVariantAnnotationType.CPX,
+                subtype,
+                cpxIntervals,
+                length2, Collections.emptyList(), Collections.singletonList(SVTestUtils.PESR_ALGORITHM),
+                Lists.newArrayList(Allele.REF_N, SVTestUtils.CPX_ALLELE),
+                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+        Assert.assertEquals(linkage.areClusterable(cpx1, cpx2).getResult(), expected);
+    }
+
+    @Test
+    public void testClusterTogetherVaryParameters() {
+        final SVCallRecord call1 = new SVCallRecord("call1", "chr1", 1000, true,
+                "chr1", 2001, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, Collections.emptyList(),
+                1002, Collections.emptyList(), Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM), Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+        final SVCallRecord call2 = new SVCallRecord("call2", "chr1", 1100, true,
+                "chr1", 2101, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, Collections.emptyList(),
+                1002, Collections.emptyList(), Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM), Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
+        // Cluster with default parameters
+        Assert.assertTrue(linkage.areClusterable(call1, call2).getResult());
+        final ClusteringParameters exactMatchParameters = ClusteringParameters.createDepthParameters(1.0, 0, 0, 1.0);
+        final CanonicalSVLinkage<SVCallRecord> exactMatchLinkage = SVTestUtils.getNewDefaultLinkage();
+        exactMatchLinkage.setDepthOnlyParams(exactMatchParameters);
+        // Do not cluster requiring exact overlap
+        Assert.assertFalse(exactMatchLinkage.areClusterable(call1, call2).getResult());
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/sv/cluster/SVClusterEngineTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/sv/cluster/SVClusterEngineTest.java
@@ -9,7 +9,6 @@ import org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants;
 import org.broadinstitute.hellbender.tools.sv.SVCallRecord;
 import org.broadinstitute.hellbender.tools.sv.SVCallRecordUtils;
 import org.broadinstitute.hellbender.tools.sv.SVTestUtils;
-import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.variant.VariantContextGetters;
 import org.testng.Assert;
 import org.testng.TestException;
@@ -29,34 +28,22 @@ public class SVClusterEngineTest {
 
     private final SVClusterEngine engine = SVTestUtils.defaultSingleLinkageEngine;
 
-    private static final ClusteringParameters depthOnlyParametersSizeSimilarity = ClusteringParameters.createDepthParameters(0.1, 0.5, 10000000, 0);
-    private static final ClusteringParameters mixedParametersSizeSimilarity = ClusteringParameters.createMixedParameters(0.1, 0.5, 5000, 0);
-    private static final ClusteringParameters evidenceParametersSizeSimilarity = ClusteringParameters.createPesrParameters(0.1, 0.5, 5000, 0);
-    private final CanonicalSVLinkage<SVCallRecord> linkageSizeSimilarity = new CanonicalSVLinkage<>(SVTestUtils.hg38Dict, false);
-    private final SVClusterEngine engineSizeSimilarity = new SVClusterEngine(SVClusterEngine.CLUSTERING_TYPE.SINGLE_LINKAGE, SVTestUtils.defaultCollapser::collapse, linkageSizeSimilarity, SVTestUtils.hg38Dict);
-
-    // Assign length according to coordinate scheme
-    private static Integer inferLength(final String contigA, final int posA, final String contigB, final int posB) {
-        if (contigA.equals(contigB)) {
-            if (posA == posB) {
-                // no interval
-                return null;
-            } else {
-                // intrachromosomal and intervaled
-                return posB - posA;
-            }
-        } else {
-            // interchromosomal
-            return null;
-        }
-    }
+    private static final String SAMPLE_1_NAME = "sample1";
+    private static final String SAMPLE_2_NAME = "sample2";
+    private static final String SAMPLE_3_NAME = "sample3";
+    private static final String SAMPLE_4_NAME = "sample4";
 
     @BeforeTest
     public void initializeClusterEngine() {
         engine.addAndFlush(SVTestUtils.call1);
-        linkageSizeSimilarity.setDepthOnlyParams(depthOnlyParametersSizeSimilarity);
-        linkageSizeSimilarity.setMixedParams(mixedParametersSizeSimilarity);
-        linkageSizeSimilarity.setEvidenceParams(evidenceParametersSizeSimilarity);
+    }
+
+    @Test
+    public void testLinkage() {
+        Assert.assertTrue(engine.getLinkage().areClusterable(SVTestUtils.depthOnly, SVTestUtils.depthAndStuff).getResult());
+        Assert.assertFalse(engine.getLinkage().areClusterable(SVTestUtils.depthOnly, SVTestUtils.inversion).getResult());
+        Assert.assertFalse(engine.getLinkage().areClusterable(SVTestUtils.call1, SVTestUtils.call2).getResult());
+        Assert.assertTrue(engine.getLinkage().areClusterable(SVTestUtils.call1, SVTestUtils.overlapsCall1).getResult());
     }
 
     @Test
@@ -96,576 +83,6 @@ public class SVClusterEngineTest {
         final List<Allele> collapsedAlleles = subtypedFlattened.getGenotypes().stream().map(Genotype::getAlleles)
                 .flatMap(Collection::stream).distinct().sorted().collect(Collectors.toList());
         Assert.assertEquals(subtypedFlattened.getAlleles(), collapsedAlleles);
-    }
-
-    @Test
-    public void testClusterTogether() {
-        Assert.assertTrue(engine.getLinkage().areClusterable(SVTestUtils.depthOnly, SVTestUtils.depthAndStuff));
-        Assert.assertFalse(engine.getLinkage().areClusterable(SVTestUtils.depthOnly, SVTestUtils.inversion));
-        Assert.assertFalse(engine.getLinkage().areClusterable(SVTestUtils.call1, SVTestUtils.call2));
-        Assert.assertTrue(engine.getLinkage().areClusterable(SVTestUtils.call1, SVTestUtils.overlapsCall1));
-    }
-
-    @DataProvider(name = "testClusterTogetherWithSizeSimilarityDataProvider")
-    public Object[][] testClusterTogetherWithSizeSimilarityDataProvider() {
-        return new Object[][]{
-                {1001, 2000, 1001, 2000, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, true},
-                {1001, 2000, 1501, 2000, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, true},
-                {1001, 2000, 1900, 2900, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, true},
-                // Fails size similarity
-                {1001, 2000, 1502, 2000, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, false},
-                {1001, 2000, 1901, 2399, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, false},
-                // Fails reciprocal overlap
-                {1001, 2000, 1902, 2900, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, false}
-        };
-    }
-
-    @Test(dataProvider= "testClusterTogetherWithSizeSimilarityDataProvider")
-    public void testClusterTogetherWithSizeSimilarity(final int start1, final int end1,
-                                                      final int start2, final int end2,
-                                                      final GATKSVVCFConstants.StructuralVariantAnnotationType svtype,
-                                                      final boolean expectedResult) {
-        // PESR
-        final SVCallRecord record1 = SVTestUtils.newPESRCallRecordWithIntervalAndType(start1, end1, svtype);
-        final SVCallRecord record2 = SVTestUtils.newPESRCallRecordWithIntervalAndType(start2, end2, svtype);
-        Assert.assertEquals(engineSizeSimilarity.getLinkage().areClusterable(record1, record2), expectedResult);
-        Assert.assertEquals(engineSizeSimilarity.getLinkage().areClusterable(record2, record1), expectedResult);
-
-        // Depth only
-        final SVCallRecord record3 = SVTestUtils.newDepthCallRecordWithIntervalAndType(start1, end1, svtype);
-        final SVCallRecord record4 = SVTestUtils.newDepthCallRecordWithIntervalAndType(start2, end2, svtype);
-        Assert.assertEquals(engineSizeSimilarity.getLinkage().areClusterable(record3, record4), expectedResult);
-        Assert.assertEquals(engineSizeSimilarity.getLinkage().areClusterable(record4, record3), expectedResult);
-    }
-
-    @DataProvider(name = "testClusterTogetherWithSizeSimilarityInsertionsDataProvider")
-    public Object[][] testClusterTogetherWithSizeSimilarityInsertionsDataProvider() {
-        return new Object[][]{
-                {1000, 1000, 1000, 1000, true},
-                {1000, 1000, 1000, 500, true},
-                {1000, 1000, 1000, 2000, true},
-                {1000, 1000, 100, 1000, true},
-                {1000, 1000, 1900, 1000, true},
-                // Fails reciprocal overlap
-                {1000, 1000, 99, 1000, false},
-                {1000, 1000, 1901, 1000, false},
-                // Fails size similarity
-                {1000, 1000, 1000, 499, false},
-                {1000, 2001, 1000, 1000, false},
-        };
-    }
-
-    @Test(dataProvider= "testClusterTogetherWithSizeSimilarityInsertionsDataProvider")
-    public void testClusterTogetherWithSizeSimilarityInsertions(final int start1, final int length1,
-                                                                final int start2, final int length2,
-                                                                final boolean expectedResult) {
-        final SVCallRecord record1 = SVTestUtils.newInsertionWithPositionAndLength(start1, length1);
-        final SVCallRecord record2 = SVTestUtils.newInsertionWithPositionAndLength(start2, length2);
-        Assert.assertEquals(engineSizeSimilarity.getLinkage().areClusterable(record1, record2), expectedResult);
-        Assert.assertEquals(engineSizeSimilarity.getLinkage().areClusterable(record2, record1), expectedResult);
-    }
-
-    @Test(expectedExceptions = { IllegalArgumentException.class })
-    public void testClusterTogetherInvalidInterval() {
-        // End position beyond contig end after padding
-        final SVCallRecord deletion1 = new SVCallRecord("test_del", "chr1", 1000, true, "chr1", 248956423 + SVTestUtils.defaultEvidenceParameters.getWindow(), false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
-                null, Collections.emptyList(),
-                null, Collections.emptyList(), Collections.singletonList(SVTestUtils.PESR_ALGORITHM),
-                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL),
-                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-        final SVCallRecord deletion2 = new SVCallRecord("test_del", "chr1", 1000, true, "chr1", 248956422, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
-                null, Collections.emptyList(),
-                null, Collections.emptyList(), Collections.singletonList(SVTestUtils.PESR_ALGORITHM),
-                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL),
-                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-        engine.getLinkage().areClusterable(deletion1, deletion2);
-        Assert.fail("Expected exception not thrown");
-    }
-
-    @Test
-    public void testGetClusteringIntervalEdge() {
-        //edge case - end of contig
-        Assert.assertTrue(engine.getLinkage().getMaxClusterableStartingPosition(SVTestUtils.rightEdgeCall) <= SVTestUtils.chr1Length);
-    }
-
-    @DataProvider(name = "maxPositionIntervals")
-    public Object[][] recordPairs() {
-        return new Object[][]{
-                {100, 200},
-                {50000, 500000},
-                {1, 1},
-                {1, 2}
-        };
-    }
-
-    @Test(dataProvider= "maxPositionIntervals")
-    public void testGetMaxClusterableStartingPosition(final int start, final int end) {
-        testGetMaxClusterableStartingPositionWithAlgorithm(start, end, GATKSVVCFConstants.DEPTH_ALGORITHM);
-        testGetMaxClusterableStartingPositionWithAlgorithm(start, end, SVTestUtils.PESR_ALGORITHM);
-    }
-
-    private void testGetMaxClusterableStartingPositionWithAlgorithm(final int start, final int end, final String algorithm) {
-        final SVCallRecord call1 = new SVCallRecord("call1", "chr1", start, true, "chr1", end, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
-                null, Collections.emptyList(),
-                end - start + 1, Collections.emptyList(), Collections.singletonList(algorithm),
-                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL),
-                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-        final int maxClusterableStart = engine.getLinkage().getMaxClusterableStartingPosition(call1);
-
-        final int call2Start = maxClusterableStart;
-        final SVCallRecord call2Depth = new SVCallRecord("call2", "chr1", call2Start, true, "chr1", call2Start + call1.getLength() - 1, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
-                null, Collections.emptyList(),
-                call1.getLength(), Collections.emptyList(), Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM),
-                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL),
-                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-        final SVCallRecord call2Pesr = new SVCallRecord("call2", "chr1", call2Start, true, "chr1", call2Start + call1.getLength() - 1, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
-                null, Collections.emptyList(),
-                call1.getLength(), Collections.emptyList(), SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
-                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL),
-                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-        Assert.assertTrue(engine.getLinkage().areClusterable(call1, call2Depth) || engine.getLinkage().areClusterable(call1, call2Pesr));
-
-        final int call3Start = maxClusterableStart + 1;
-        final SVCallRecord call3Depth = new SVCallRecord("call2", "chr1", call3Start, true, "chr1", call3Start + call1.getLength() - 1, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
-                null, Collections.emptyList(),
-                call1.getLength(), Collections.emptyList(), Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM),
-                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL),
-                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-        final SVCallRecord call3Pesr = new SVCallRecord("call2", "chr1", call3Start, true, "chr1", call3Start + call1.getLength() - 1, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
-                null, Collections.emptyList(),
-                call1.getLength(), Collections.emptyList(), SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
-                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL),
-                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-        Assert.assertFalse(engine.getLinkage().areClusterable(call1, call3Depth) || engine.getLinkage().areClusterable(call1, call3Pesr));
-    }
-
-    @Test
-    public void testGetClusteringIntervalLists() {
-        //test overloaded function with List
-        final List<SVCallRecord> pesrClusterList = new ArrayList<>();
-        pesrClusterList.add(SVTestUtils.depthAndStuff);
-        final int pesrCluster1 = engine.getLinkage().getMaxClusterableStartingPosition(pesrClusterList);
-        Assert.assertTrue(pesrCluster1 >= SVTestUtils.depthAndStuff.getPositionA() + SVTestUtils.defaultEvidenceParameters.getWindow());
-        Assert.assertTrue(pesrCluster1 >= SVTestUtils.depthAndStuff.getPositionA() + SVTestUtils.defaultMixedParameters.getWindow());
-        //add an upstream variant
-        pesrClusterList.add(SVTestUtils.depthAndStuff2);
-        final int pesrCluster2 = engine.getLinkage().getMaxClusterableStartingPosition(pesrClusterList);
-        Assert.assertTrue(pesrCluster2 >= pesrCluster1);
-        //add a downstream variant
-        pesrClusterList.add(SVTestUtils.depthAndStuff3);
-        final int pesrCluster3 = engine.getLinkage().getMaxClusterableStartingPosition(pesrClusterList);
-        Assert.assertTrue(pesrCluster3 >= SVTestUtils.depthAndStuff3.getPositionA() + SVTestUtils.defaultEvidenceParameters.getWindow());
-        Assert.assertTrue(pesrCluster3 >= SVTestUtils.depthAndStuff3.getPositionA() + SVTestUtils.defaultMixedParameters.getWindow());
-    }
-
-    @Test
-    public void testIsDepthOnlyCall() {
-        Assert.assertTrue(SVTestUtils.call1.isDepthOnly());
-        Assert.assertFalse(SVTestUtils.depthAndStuff.isDepthOnly());
-        Assert.assertFalse(SVTestUtils.inversion.isDepthOnly());
-    }
-
-    @DataProvider(name = "clusterTogetherVaryPositionsProvider")
-    public Object[][] clusterTogetherVaryPositionsProvider() {
-        return new Object[][]{
-                {500, 1001, 1001, 1502, false},  // abutting
-                {500, 1001, 500, 1001, true},  // exactly equal
-                {500, 1001, 600, 1101, true},  // barely meet reciprocal overlap
-                {500, 1001, 601, 1102, false}, // call2 shifted slightly up
-                {500, 1000, 600, 1101, false}, // call1 slightly larger
-                {500, 501, 500, 501, true}, // tiny but equal
-                {500, 501, 500, 502, false}, // tiny but call2 twice as big
-                {500, 500, 500, 500, true}, // 0-length and equal
-                {500, 500, 501, 501, false}, // 0-length and not equal
-                {1, SVTestUtils.chr1Length, 1, SVTestUtils.chr1Length, true}, // really big
-                {1, 10001, 1, 10001, true}, // left contig edge
-                {SVTestUtils.chr1Length - 10000, SVTestUtils.chr1Length, SVTestUtils.chr1Length - 10000, SVTestUtils.chr1Length, true}, // right contig edge
-                {100000, 200000, 101001, 201001, false}, // window test fail
-                {100000, 200000, 101000, 201000, true} // window test success
-        };
-    }
-
-    @Test(dataProvider= "clusterTogetherVaryPositionsProvider")
-    public void testClusterTogetherVaryPositions(final int start1, final int end1, final int start2, final int end2, final boolean result) {
-        final SVCallRecord call1 = new SVCallRecord("call1", "chr1", start1, true,
-                "chr1", end1, false,
-                GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, Collections.emptyList(), end1 - start1 + 1, Collections.emptyList(), SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
-                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL, Allele.SV_SIMPLE_DUP),
-                SVTestUtils.threeGenotypes, Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-        final SVCallRecord call2 = new SVCallRecord("call2", "chr1", start2, true,
-                "chr1", end2, false,
-                GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, Collections.emptyList(), end2 - start2 + 1, Collections.emptyList(), Lists.newArrayList(GATKSVVCFConstants.DEPTH_ALGORITHM),
-                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL, Allele.SV_SIMPLE_DUP),
-                SVTestUtils.threeGenotypes, Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-        Assert.assertEquals(engine.getLinkage().areClusterable(call1, call2), result);
-    }
-
-    @Test
-    public void testClusterTogetherVaryTypes() {
-        for (final GATKSVVCFConstants.StructuralVariantAnnotationType type1 : GATKSVVCFConstants.StructuralVariantAnnotationType.values()) {
-            // Pass in null strands to let them be determined automatically
-            final SVCallRecord call1 = new SVCallRecord("call1", "chr1", 1000, SVTestUtils.getValidTestStrandA(type1),
-                    "chr1", 2001, SVTestUtils.getValidTestStrandB(type1), type1, null, Collections.emptyList(),
-                    SVTestUtils.getLength(1000, 2001, type1), Collections.emptyList(), Lists.newArrayList(GATKSVVCFConstants.DEPTH_ALGORITHM),
-                    Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-            for (final GATKSVVCFConstants.StructuralVariantAnnotationType type2 : GATKSVVCFConstants.StructuralVariantAnnotationType.values()) {
-                final SVCallRecord call2 = new SVCallRecord("call2", "chr1", 1000, SVTestUtils.getValidTestStrandA(type2),
-                        "chr1", 2001, SVTestUtils.getValidTestStrandB(type2), type2, null, Collections.emptyList(),
-                        SVTestUtils.getLength(1000, 2001, type2), Collections.emptyList(), Lists.newArrayList(GATKSVVCFConstants.DEPTH_ALGORITHM),
-                        Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-                // Should only cluster together if same type, except CNVs
-                if ((type1 == GATKSVVCFConstants.StructuralVariantAnnotationType.CNV && call2.isSimpleCNV()) ||
-                        (type2 == GATKSVVCFConstants.StructuralVariantAnnotationType.CNV && call1.isSimpleCNV())) {
-                    Assert.assertTrue(engine.getLinkage().areClusterable(call1, call2));
-                } else {
-                    Assert.assertEquals(engine.getLinkage().areClusterable(call1, call2), type1 == type2);
-                }
-            }
-        }
-    }
-
-    @Test
-    public void testClusterTogetherVaryStrands() {
-        final List<Boolean> bools = Lists.newArrayList(Boolean.TRUE, Boolean.FALSE);
-        for (final Boolean strand1A : bools) {
-            for (final Boolean strand1B : bools) {
-                final SVCallRecord call1 = new SVCallRecord("call1", "chr1", 1000, strand1A,
-                        "chr1", 2001, strand1B, GATKSVVCFConstants.StructuralVariantAnnotationType.BND, null, Collections.emptyList(),
-                        null, Collections.emptyList(), Lists.newArrayList(GATKSVVCFConstants.DEPTH_ALGORITHM),
-                        Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-                for (final Boolean strand2A : bools) {
-                    for (final Boolean strand2B : bools) {
-                        final SVCallRecord call2 = new SVCallRecord("call2", "chr1", 1000, strand2A,
-                                "chr1", 2001, strand2B, GATKSVVCFConstants.StructuralVariantAnnotationType.BND, null, Collections.emptyList(),
-                                null, Collections.emptyList(), Lists.newArrayList(GATKSVVCFConstants.DEPTH_ALGORITHM),
-                                Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-                        // Should only cluster if strands match
-                        Assert.assertEquals(engine.getLinkage().areClusterable(call1, call2), strand1A == strand2A && strand1B == strand2B);
-                    }
-                }
-            }
-        }
-    }
-
-    @Test
-    public void testClusterTogetherVaryContigs() {
-        final List<String> contigs = Lists.newArrayList("chr1", "chrX");
-        for (int i = 0; i < contigs.size(); i++) {
-            final String contig1A = contigs.get(i);
-            for (int j = i; j < contigs.size(); j++) {
-                final String contig1B = contigs.get(j);
-                final SVCallRecord call1 = new SVCallRecord("call1", contig1A, 1000, true,
-                        contig1B, 2001, false, GATKSVVCFConstants.StructuralVariantAnnotationType.BND, null, Collections.emptyList(),
-                        null, Collections.emptyList(), SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
-                        Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-                for (int k = 0; k < contigs.size(); k++) {
-                    final String contig2A = contigs.get(k);
-                    for (int m = k; m < contigs.size(); m++) {
-                        final String contig2B = contigs.get(m);
-                        final SVCallRecord call2 = new SVCallRecord("call2", contig2A, 1000, true,
-                                contig2B, 2001, false, GATKSVVCFConstants.StructuralVariantAnnotationType.BND, null, Collections.emptyList(),
-                                null, Collections.emptyList(), SVTestUtils.PESR_ONLY_ALGORITHM_LIST,
-                                Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-                        // Should only cluster if contigs match
-                        Assert.assertEquals(engine.getLinkage().areClusterable(call1, call2), contig1A.equals(contig2A) && contig1B.equals(contig2B));
-                    }
-                }
-            }
-        }
-    }
-
-    @Test
-    public void testClusterTogetherVaryAlgorithms() {
-        final List<List<String>> algorithmsList = Lists.newArrayList(
-                Arrays.asList(GATKSVVCFConstants.DEPTH_ALGORITHM),
-                Arrays.asList(GATKSVVCFConstants.DEPTH_ALGORITHM, SVTestUtils.PESR_ALGORITHM),
-                SVTestUtils.PESR_ONLY_ALGORITHM_LIST
-        );
-        for (final List<String> algorithms1 : algorithmsList) {
-            final SVCallRecord call1 = new SVCallRecord("call1", "chr1", 1000, true,
-                    "chr1", 2001, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, Collections.emptyList(),
-                    1002, Collections.emptyList(), algorithms1, Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-            for (final List<String> algorithms2 : algorithmsList) {
-                final SVCallRecord call2 = new SVCallRecord("call2", "chr1", 1000, true,
-                        "chr1", 2001, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, Collections.emptyList(),
-                        1002, Collections.emptyList(), algorithms2, Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-                // All combinations should cluster
-                Assert.assertTrue(engine.getLinkage().areClusterable(call1, call2));
-            }
-        }
-    }
-
-    @Test
-    public void testClusterTogetherCNVs() {
-        final SVCallRecord cnv1 = SVTestUtils.makeRecord("cnv1", "chr1", 1001, null,
-                "chr1", 2001, null, GATKSVVCFConstants.StructuralVariantAnnotationType.CNV,
-                null, SVTestUtils.DEPTH_ONLY_ALGORITHM_LIST,
-                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL, Allele.SV_SIMPLE_DUP),
-                Collections.emptyList());
-
-        final SVCallRecord cnv2 = SVTestUtils.makeRecord("cnv2", "chr1", 1001, null,
-                "chr1", 2001, null, GATKSVVCFConstants.StructuralVariantAnnotationType.CNV,
-                null, SVTestUtils.DEPTH_ONLY_ALGORITHM_LIST,
-                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL, Allele.SV_SIMPLE_DUP),
-                Collections.emptyList());
-
-        final SVCallRecord del1 = SVTestUtils.makeRecord("del1", "chr1", 1001, null,
-                "chr1", 2001, null, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
-                null, SVTestUtils.DEPTH_ONLY_ALGORITHM_LIST,
-                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL),
-                Collections.emptyList());
-
-        final SVCallRecord dup1 = SVTestUtils.makeRecord("dup1", "chr1", 1001, null,
-                "chr1", 2001, null, GATKSVVCFConstants.StructuralVariantAnnotationType.DUP,
-                null, SVTestUtils.DEPTH_ONLY_ALGORITHM_LIST,
-                Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DUP),
-                Collections.emptyList());
-
-        Assert.assertTrue(engine.getLinkage().areClusterable(cnv1, cnv2));
-        Assert.assertTrue(engine.getLinkage().areClusterable(cnv1, del1));
-        Assert.assertTrue(engine.getLinkage().areClusterable(cnv1, dup1));
-        Assert.assertFalse(engine.getLinkage().areClusterable(del1, dup1));
-    }
-
-    @DataProvider(name = "testMatchCNVNoGTData")
-    public Object[][] testMatchCNVNoGTData() {
-        return new Object[][]{
-                // Empty
-                {0, new int[]{}, new int[]{}, true},
-                // Both equal
-                {0, new int[]{0}, new int[]{0}, true},
-                {1, new int[]{1}, new int[]{1}, true},
-                {2, new int[]{2}, new int[]{2}, true},
-                {2, new int[]{3}, new int[]{3}, true},
-                // Unequal
-                {2, new int[]{1}, new int[]{2}, false},
-                {2, new int[]{2}, new int[]{1}, false},
-                // Equal multiple
-                {2, new int[]{2, 2}, new int[]{2, 2}, true},
-                {2, new int[]{4, 2}, new int[]{4, 2}, true},
-                // Unequal multiple
-                {2, new int[]{2, 2}, new int[]{2, 1}, false},
-                {2, new int[]{0, 2}, new int[]{1, 1}, false},
-                {2, new int[]{3, 2}, new int[]{2, 2}, false},
-                {2, new int[]{6, 2}, new int[]{4, 2}, false},
-        };
-    }
-
-    @Test(dataProvider= "testMatchCNVNoGTData")
-    public void testMatchCNVNoGT(final int ploidy, final int[] copyNumbers1, final int[] copyNumbers2, final boolean expected) {
-        final List<Allele> alleles = Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_CNV);
-        final GATKSVVCFConstants.StructuralVariantAnnotationType svtype = GATKSVVCFConstants.StructuralVariantAnnotationType.CNV;
-        // Create genotypes with copy number attribute (and no GT)
-        final SVCallRecord recordCN1 = getCNVRecordWithCN(ploidy, alleles, svtype, copyNumbers1, GATKSVVCFConstants.COPY_NUMBER_FORMAT);
-        final SVCallRecord recordCN2 = getCNVRecordWithCN(ploidy, alleles, svtype, copyNumbers2, GATKSVVCFConstants.COPY_NUMBER_FORMAT);
-
-        // With sample overlap
-        final ClusteringParameters depthOnlyParams = ClusteringParameters.createDepthParameters(0.8, 0, 10000000, 1);
-        final CanonicalSVLinkage<SVCallRecord> linkage = new CanonicalSVLinkage<>(SVTestUtils.hg38Dict, false);
-        linkage.setDepthOnlyParams(depthOnlyParams);
-
-        Assert.assertEquals(linkage.areClusterable(recordCN1, recordCN2), expected);
-
-        final SVCallRecord recordRDCN1 = getCNVRecordWithCN(ploidy, alleles, svtype, copyNumbers1, GATKSVVCFConstants.DEPTH_GENOTYPE_COPY_NUMBER_FORMAT);
-        final SVCallRecord recordRDCN2 = getCNVRecordWithCN(ploidy, alleles, svtype, copyNumbers2, GATKSVVCFConstants.DEPTH_GENOTYPE_COPY_NUMBER_FORMAT);
-        Assert.assertEquals(linkage.areClusterable(recordRDCN1, recordRDCN2), expected);
-    }
-
-    @DataProvider(name = "testClusterTogetherIntervaledComplexData")
-    public Object[][] testClusterTogetherIntervaledComplexData() {
-        return new Object[][]{
-                // exact match
-                {"chr1", 1000, "chr1", 2000,
-                        GATKSVVCFConstants.ComplexVariantSubtype.delINV,
-                        Arrays.asList(
-                            new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 1100, 1500)),
-                            new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.INV, new SimpleInterval("chr1", 1600, 1900))
-                        ),
-                        true
-                },
-                // match within parameters
-                {"chr1", 1100, "chr1", 1900,
-                        GATKSVVCFConstants.ComplexVariantSubtype.delINV,
-                        Arrays.asList(
-                            new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 1150, 1550)),
-                            new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.INV, new SimpleInterval("chr1", 1650, 1800))
-                        ),
-                        true
-                },
-                // different contigs
-                {"chr2", 1000, "chr2", 2000,
-                        GATKSVVCFConstants.ComplexVariantSubtype.delINV,
-                        Arrays.asList(
-                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 1100, 1500)),
-                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.INV, new SimpleInterval("chr1", 1600, 1900))
-                        ),
-                        false
-                },
-                // different coordinates
-                {"chr1", 1600, "chr1", 2400,
-                        GATKSVVCFConstants.ComplexVariantSubtype.delINV,
-                        Arrays.asList(
-                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 1100, 1500)),
-                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.INV, new SimpleInterval("chr1", 1600, 1900))
-                        ),
-                        false
-                },
-                // different subtypes
-                {"chr1", 1000, "chr1", 2000,
-                        GATKSVVCFConstants.ComplexVariantSubtype.delINVdel,
-                        Arrays.asList(
-                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 1100, 1500)),
-                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.INV, new SimpleInterval("chr1", 1600, 1900))
-                        ),
-                        false
-                },
-                // different number of intervals
-                {"chr1", 1000, "chr1", 2000,
-                        GATKSVVCFConstants.ComplexVariantSubtype.delINV,
-                        Arrays.asList(
-                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 1100, 1500))
-                        ),
-                        false
-                },
-                // different cpx intervals
-                {"chr1", 1000, "chr1", 2000,
-                        GATKSVVCFConstants.ComplexVariantSubtype.delINV,
-                        Arrays.asList(
-                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 800, 1100)),
-                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.INV, new SimpleInterval("chr1", 1600, 1900))
-                        ),
-                        false
-                },
-                // second cpx interval type is different
-                {"chr1", 1000, "chr1", 2000,
-                        GATKSVVCFConstants.ComplexVariantSubtype.delINV,
-                        Arrays.asList(
-                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 1100, 1500)),
-                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP, new SimpleInterval("chr1", 1600, 1900))
-                        ),
-                        false
-                },
-        };
-    }
-
-    @Test(dataProvider= "testClusterTogetherIntervaledComplexData")
-    public void testClusterTogetherIntervaledComplex(final String contigA, final int posA, final String contigB, final int posB,
-                                                     final GATKSVVCFConstants.ComplexVariantSubtype subtype,
-                                                     final List<SVCallRecord.ComplexEventInterval> cpxIntervals, final boolean expected) {
-        final SVCallRecord cpx1 = new SVCallRecord("cpx1", "chr1", 1000, null,
-                "chr1", 2000, null,
-                GATKSVVCFConstants.StructuralVariantAnnotationType.CPX,
-                GATKSVVCFConstants.ComplexVariantSubtype.delINV,
-                Arrays.asList(SVCallRecord.ComplexEventInterval.decode("DEL_chr1:1100-1500", SVTestUtils.hg38Dict), SVCallRecord.ComplexEventInterval.decode("INV_chr1:1600-1900", SVTestUtils.hg38Dict)),
-                1000, Collections.emptyList(), Collections.singletonList(SVTestUtils.PESR_ALGORITHM),
-                Lists.newArrayList(Allele.REF_N, SVTestUtils.CPX_ALLELE),
-                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-        final Integer length2 = inferLength(contigA, posA, contigB, posB);
-        final SVCallRecord cpx2 = new SVCallRecord("cpx2", contigA, posA, null,
-                contigB, posB, null,
-                GATKSVVCFConstants.StructuralVariantAnnotationType.CPX,
-                subtype,
-                cpxIntervals,
-                length2, Collections.emptyList(), Collections.singletonList(SVTestUtils.PESR_ALGORITHM),
-                Lists.newArrayList(Allele.REF_N, SVTestUtils.CPX_ALLELE),
-                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-        Assert.assertEquals(engine.getLinkage().areClusterable(cpx1, cpx2), expected);
-    }
-
-    @DataProvider(name = "testClusterTogetherInsertedComplexData")
-    public Object[][] testClusterTogetherInsertedComplexData() {
-        return new Object[][]{
-                // exact match
-                {"chr1", 1000, "chr1", 1000,
-                        GATKSVVCFConstants.ComplexVariantSubtype.dDUP,
-                        Arrays.asList(
-                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP, new SimpleInterval("chr1", 6000, 8000))
-                        ),
-                        true
-                },
-                // close match
-                {"chr1", 1010, "chr1", 1010,
-                        GATKSVVCFConstants.ComplexVariantSubtype.dDUP,
-                        Arrays.asList(
-                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP, new SimpleInterval("chr1", 6200, 7990))
-                        ),
-                        true
-                },
-                // not match by coordinates
-                {"chr1", 2000, "chr1", 3000,
-                        GATKSVVCFConstants.ComplexVariantSubtype.dDUP,
-                        Arrays.asList(
-                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP, new SimpleInterval("chr1", 6200, 7990))
-                        ),
-                        false
-                },
-                // not match by subtype
-                {"chr1", 1000, "chr1", 1000,
-                        GATKSVVCFConstants.ComplexVariantSubtype.dDUP_iDEL,
-                        Arrays.asList(
-                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP, new SimpleInterval("chr1", 6000, 8000))
-                        ),
-                        false
-                },
-                // not match by cpx interval
-                {"chr1", 1000, "chr1", 1000,
-                        GATKSVVCFConstants.ComplexVariantSubtype.dDUP,
-                        Arrays.asList(
-                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP, new SimpleInterval("chr1", 9000, 11000))
-                        ),
-                        false
-                },
-                // different cpx interval type
-                {"chr1", 1000, "chr1", 1000,
-                        GATKSVVCFConstants.ComplexVariantSubtype.dDUP,
-                        Arrays.asList(
-                                new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.INV, new SimpleInterval("chr1", 6000, 8000))
-                        ),
-                        false
-                },
-        };
-    }
-
-    @Test(dataProvider= "testClusterTogetherInsertedComplexData")
-    public void testClusterTogetherInsertedComplex(final String contigA, final int posA, final String contigB, final int posB,
-                                                   final GATKSVVCFConstants.ComplexVariantSubtype subtype,
-                                                   final List<SVCallRecord.ComplexEventInterval> cpxIntervals, final boolean expected) {
-        final SVCallRecord cpx1 = new SVCallRecord("cpx1", "chr1", 1000, null,
-                "chr1", 1000, null,
-                GATKSVVCFConstants.StructuralVariantAnnotationType.CPX,
-                GATKSVVCFConstants.ComplexVariantSubtype.dDUP,
-                Arrays.asList(new SVCallRecord.ComplexEventInterval(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP, new SimpleInterval("chr1", 6000, 8000))),
-                2000, Collections.emptyList(), Collections.singletonList(SVTestUtils.PESR_ALGORITHM),
-                Lists.newArrayList(Allele.REF_N, SVTestUtils.CPX_ALLELE),
-                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-        final Integer length2 = cpxIntervals.get(0).getInterval().size();
-        final SVCallRecord cpx2 = new SVCallRecord("cpx2", contigA, posA, null,
-                contigB, posB, null,
-                GATKSVVCFConstants.StructuralVariantAnnotationType.CPX,
-                subtype,
-                cpxIntervals,
-                length2, Collections.emptyList(), Collections.singletonList(SVTestUtils.PESR_ALGORITHM),
-                Lists.newArrayList(Allele.REF_N, SVTestUtils.CPX_ALLELE),
-                Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-        Assert.assertEquals(engine.getLinkage().areClusterable(cpx1, cpx2), expected);
-    }
-
-    @Test
-    public void testClusterTogetherVaryParameters() {
-        final SVClusterEngine testEngine1 = SVTestUtils.getNewDefaultSingleLinkageEngine();
-        final SVCallRecord call1 = new SVCallRecord("call1", "chr1", 1000, true,
-                "chr1", 2001, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, Collections.emptyList(),
-                1002, Collections.emptyList(), Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM), Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-        final SVCallRecord call2 = new SVCallRecord("call2", "chr1", 1100, true,
-                "chr1", 2101, false, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, Collections.emptyList(),
-                1002, Collections.emptyList(), Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM), Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
-        // Cluster with default parameters
-        Assert.assertTrue(testEngine1.getLinkage().areClusterable(call1, call2));
-        final ClusteringParameters exactMatchParameters = ClusteringParameters.createDepthParameters(1.0, 0, 0, 1.0);
-        final CanonicalSVLinkage<SVCallRecord> exactMatchLinkage = SVTestUtils.getNewDefaultLinkage();
-        exactMatchLinkage.setDepthOnlyParams(exactMatchParameters);
-        // Do not cluster requiring exact overlap
-        Assert.assertFalse(exactMatchLinkage.areClusterable(call1, call2));
     }
 
 
@@ -831,11 +248,11 @@ public class SVClusterEngineTest {
         }
 
         // Create genotypes with copy number attribute (and no GT)
-        final SVCallRecord recordCN = getCNVRecordWithCN(ploidy, alleles, svtype, copyNumbers, GATKSVVCFConstants.COPY_NUMBER_FORMAT);
+        final SVCallRecord recordCN = SVTestUtils.getCNVRecordWithCN(ploidy, alleles, svtype, copyNumbers, GATKSVVCFConstants.COPY_NUMBER_FORMAT);
         final Set<String> resultWithCopyNumber =  recordCN.getCarrierSampleSet();
         Assert.assertEquals(resultWithCopyNumber, expectedResult);
 
-        final SVCallRecord recordRDCN = getCNVRecordWithCN(ploidy, alleles, svtype, copyNumbers, GATKSVVCFConstants.DEPTH_GENOTYPE_COPY_NUMBER_FORMAT);
+        final SVCallRecord recordRDCN = SVTestUtils.getCNVRecordWithCN(ploidy, alleles, svtype, copyNumbers, GATKSVVCFConstants.DEPTH_GENOTYPE_COPY_NUMBER_FORMAT);
         final Set<String> resultWithRDCopyNumber =  recordRDCN.getCarrierSampleSet();
         Assert.assertEquals(resultWithRDCopyNumber, expectedResult);
 
@@ -853,22 +270,6 @@ public class SVClusterEngineTest {
         final Set<String> resultWithGenotype = recordWithGenotype.getCarrierSampleSet();
 
         Assert.assertEquals(resultWithGenotype, expectedResult);
-    }
-
-    private SVCallRecord getCNVRecordWithCN(final int ploidy, List<Allele> alleles, final GATKSVVCFConstants.StructuralVariantAnnotationType svtype,
-                                            final int[] copyNumbers, final String cnField) {
-        // Create genotypes with copy number attribute (and no GT)
-        final List<Genotype> genotypesWithCopyNumber = IntStream.range(0, copyNumbers.length)
-                .mapToObj(i -> new GenotypeBuilder(String.valueOf(i))
-                        .attribute(cnField, copyNumbers[i])
-                        .attribute(GATKSVVCFConstants.EXPECTED_COPY_NUMBER_FORMAT, ploidy)
-                        .alleles(SVTestUtils.buildHomAlleleListWithPloidy(Allele.NO_CALL, ploidy))
-                        .make())
-                .collect(Collectors.toList());
-        return new SVCallRecord("", "chr1", 1000, SVTestUtils.getValidTestStrandA(svtype),
-                "chr1", 1999, SVTestUtils.getValidTestStrandB(svtype), svtype, null, Collections.emptyList(),
-                1000, Collections.emptyList(), Collections.singletonList(GATKSVVCFConstants.DEPTH_ALGORITHM),
-                alleles, GenotypesContext.copy(genotypesWithCopyNumber), Collections.emptyMap(), Collections.emptySet(), null, SVTestUtils.hg38Dict);
     }
 
     @Test
@@ -891,4 +292,45 @@ public class SVClusterEngineTest {
         output.addAll(engine.flush());
         Assert.assertEquals(output.size(), 2926);
     }
+
+    @DataProvider(name = "testSampleOverlapData")
+    public Object[][] testSampleOverlapData() {
+        return new Object[][]{
+                {new String[]{}, new String[]{}, 0, true},
+                {new String[]{}, new String[]{}, 1, true},
+                {new String[]{SAMPLE_1_NAME}, new String[]{}, 0, true},
+                {new String[]{SAMPLE_1_NAME}, new String[]{}, 0.1, false},
+                {new String[]{SAMPLE_1_NAME}, new String[]{SAMPLE_1_NAME}, 1, true},
+                {new String[]{SAMPLE_1_NAME, SAMPLE_2_NAME}, new String[]{SAMPLE_1_NAME}, 0, true},
+                {new String[]{SAMPLE_1_NAME, SAMPLE_2_NAME}, new String[]{SAMPLE_3_NAME}, 0, true},
+                {new String[]{SAMPLE_1_NAME, SAMPLE_2_NAME}, new String[]{SAMPLE_1_NAME}, 0.5, true},
+                {new String[]{SAMPLE_1_NAME, SAMPLE_2_NAME}, new String[]{SAMPLE_2_NAME}, 0.5, true},
+                {new String[]{SAMPLE_1_NAME, SAMPLE_2_NAME}, new String[]{SAMPLE_3_NAME}, 0.5, false},
+                {new String[]{SAMPLE_1_NAME, SAMPLE_2_NAME}, new String[]{SAMPLE_1_NAME}, 1, false},
+                {new String[]{SAMPLE_1_NAME, SAMPLE_2_NAME}, new String[]{SAMPLE_1_NAME, SAMPLE_2_NAME}, 1, true},
+                {new String[]{SAMPLE_1_NAME, SAMPLE_2_NAME}, new String[]{SAMPLE_3_NAME, SAMPLE_4_NAME}, 0.1, false},
+                {new String[]{SAMPLE_1_NAME, SAMPLE_2_NAME, SAMPLE_3_NAME}, new String[]{SAMPLE_1_NAME, SAMPLE_3_NAME, SAMPLE_4_NAME}, 0.5, true},
+                {new String[]{SAMPLE_1_NAME, SAMPLE_2_NAME, SAMPLE_3_NAME}, new String[]{SAMPLE_1_NAME, SAMPLE_3_NAME, SAMPLE_4_NAME}, 1, false},
+        };
+    }
+
+    @Test(dataProvider= "testSampleOverlapData")
+    public void testSampleOverlap(final String[] samplesA, final String[] samplesB, final double threshold, final boolean expected) {
+        final Set<String> setA = Stream.of(samplesA).collect(Collectors.toUnmodifiableSet());
+        final Set<String> setB = Stream.of(samplesB).collect(Collectors.toUnmodifiableSet());
+        final List<String> allSamples = List.of(SAMPLE_1_NAME, SAMPLE_2_NAME, SAMPLE_3_NAME, SAMPLE_4_NAME);
+        final SVCallRecord recordA = SVTestUtils.makeRecordWithCarriers(allSamples, setA);
+        final SVCallRecord recordB = SVTestUtils.makeRecordWithCarriers(allSamples, setB);
+        final CanonicalSVLinkage<SVCallRecord> linkage = SVTestUtils.getNewDefaultLinkage();
+        linkage.setEvidenceParams(ClusteringParameters.createPesrParameters(0.5, 0.5, 100, threshold));
+        Assert.assertEquals(linkage.areClusterable(recordA, recordB).getResult(), expected);
+        Assert.assertEquals(linkage.areClusterable(recordB, recordA).getResult(), expected);
+
+        // Test complex event code path
+        final SVCallRecord complexA = SVTestUtils.makeComplexRecordWithCarriers(allSamples, setA);
+        final SVCallRecord complexB = SVTestUtils.makeComplexRecordWithCarriers(allSamples, setB);
+        Assert.assertEquals(linkage.areClusterable(complexA, complexB).getResult(), expected);
+        Assert.assertEquals(linkage.areClusterable(complexB, complexA).getResult(), expected);
+    }
+
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/sv/concordance/SVConcordanceAnnotatorTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/sv/concordance/SVConcordanceAnnotatorTest.java
@@ -334,7 +334,7 @@ public class SVConcordanceAnnotatorTest {
         final GenotypeBuilder builder = new GenotypeBuilder().alleles(Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL));
         final SVCallRecord evalRecord = SVTestUtils.newNamedDeletionRecordWithAttributesAndGenotypes("eval", Collections.singletonList(builder.make()), evalAttr);
         final SVCallRecord truthRecord = SVTestUtils.newNamedDeletionRecordWithAttributesAndGenotypes("truth", Collections.singletonList(builder.make()), Collections.emptyMap());
-        final ClosestSVFinder.ClosestPair pair = new ClosestSVFinder.ClosestPair(evalRecord, truthRecord);
+        final ClosestSVFinder.ClosestPair pair = new ClosestSVFinder.ClosestPair(0L, evalRecord, truthRecord);
         final SVCallRecord result = new SVConcordanceAnnotator().annotate(pair);
         Assert.assertTrue(result.getAttributes().containsKey(VCFConstants.ALLELE_NUMBER_KEY));
         Assert.assertTrue(result.getAttributes().containsKey(VCFConstants.ALLELE_COUNT_KEY));
@@ -349,7 +349,7 @@ public class SVConcordanceAnnotatorTest {
         final GenotypeBuilder builder = new GenotypeBuilder().alleles(Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL));
         final SVCallRecord evalRecord = SVTestUtils.newNamedDeletionRecordWithAttributesAndGenotypes("eval", Collections.singletonList(builder.make()), Collections.emptyMap());
         final SVCallRecord truthRecord = SVTestUtils.newNamedDeletionRecordWithAttributesAndGenotypes("truth", Collections.singletonList(builder.make()), Collections.emptyMap());
-        final ClosestSVFinder.ClosestPair pair = new ClosestSVFinder.ClosestPair(evalRecord, truthRecord);
+        final ClosestSVFinder.ClosestPair pair = new ClosestSVFinder.ClosestPair(0L, evalRecord, truthRecord);
         final SVCallRecord result = new SVConcordanceAnnotator().annotate(pair);
         Assert.assertTrue(result.getAttributes().containsKey(VCFConstants.ALLELE_NUMBER_KEY));
         Assert.assertTrue(result.getAttributes().containsKey(VCFConstants.ALLELE_COUNT_KEY));
@@ -368,7 +368,7 @@ public class SVConcordanceAnnotatorTest {
         final GenotypeBuilder builder = new GenotypeBuilder().alleles(Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL));
         final SVCallRecord evalRecord = SVTestUtils.newNamedDeletionRecordWithAttributesAndGenotypes("eval", Collections.singletonList(builder.make()), Collections.emptyMap());
         final SVCallRecord truthRecord = SVTestUtils.newNamedDeletionRecordWithAttributesAndGenotypes("truth", Collections.singletonList(builder.make()), truthAttr);
-        final ClosestSVFinder.ClosestPair pair = new ClosestSVFinder.ClosestPair(evalRecord, truthRecord);
+        final ClosestSVFinder.ClosestPair pair = new ClosestSVFinder.ClosestPair(0L, evalRecord, truthRecord);
         final SVCallRecord result = new SVConcordanceAnnotator().annotate(pair);
         Assert.assertTrue(result.getAttributes().containsKey(GATKSVVCFConstants.TRUTH_ALLELE_NUMBER_INFO));
         Assert.assertTrue(result.getAttributes().containsKey(GATKSVVCFConstants.TRUTH_ALLELE_COUNT_INFO));
@@ -383,7 +383,7 @@ public class SVConcordanceAnnotatorTest {
         final GenotypeBuilder builder = new GenotypeBuilder().alleles(Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL));
         final SVCallRecord evalRecord = SVTestUtils.newNamedDeletionRecordWithAttributesAndGenotypes("eval", Collections.singletonList(builder.make()), Collections.emptyMap());
         final SVCallRecord truthRecord = SVTestUtils.newNamedDeletionRecordWithAttributesAndGenotypes("truth", Collections.singletonList(builder.make()), Collections.emptyMap());
-        final ClosestSVFinder.ClosestPair pair = new ClosestSVFinder.ClosestPair(evalRecord, truthRecord);
+        final ClosestSVFinder.ClosestPair pair = new ClosestSVFinder.ClosestPair(0L, evalRecord, truthRecord);
         final SVCallRecord result = new SVConcordanceAnnotator().annotate(pair);
         Assert.assertTrue(result.getAttributes().containsKey(GATKSVVCFConstants.TRUTH_ALLELE_NUMBER_INFO));
         Assert.assertTrue(result.getAttributes().containsKey(GATKSVVCFConstants.TRUTH_ALLELE_COUNT_INFO));
@@ -403,7 +403,7 @@ public class SVConcordanceAnnotatorTest {
         final GenotypeBuilder builder = new GenotypeBuilder().alleles(Lists.newArrayList(Allele.REF_N, Allele.SV_SIMPLE_DEL));
         final SVCallRecord evalRecord = SVTestUtils.newNamedDeletionRecordWithAttributesAndGenotypes("eval", Collections.singletonList(builder.make()), Collections.emptyMap());
         final SVCallRecord truthRecord = SVTestUtils.newNamedDeletionRecordWithAttributesAndGenotypes("truth", Collections.singletonList(builder.make()), Collections.emptyMap());
-        final ClosestSVFinder.ClosestPair pair = new ClosestSVFinder.ClosestPair(evalRecord, truthRecord);
+        final ClosestSVFinder.ClosestPair pair = new ClosestSVFinder.ClosestPair(0L, evalRecord, truthRecord);
         final SVCallRecord result = new SVConcordanceAnnotator().annotate(pair);
         Assert.assertTrue(result.getAttributes().containsKey(GATKSVVCFConstants.TRUTH_ALLELE_NUMBER_INFO));
         Assert.assertTrue(result.getAttributes().containsKey(GATKSVVCFConstants.TRUTH_ALLELE_COUNT_INFO));

--- a/src/test/java/org/broadinstitute/hellbender/tools/sv/concordance/StratifiedConcordanceEngineTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/sv/concordance/StratifiedConcordanceEngineTest.java
@@ -1,0 +1,285 @@
+package org.broadinstitute.hellbender.tools.sv.concordance;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import htsjdk.variant.variantcontext.VariantContext;
+import org.apache.commons.math3.util.Combinations;
+import org.broadinstitute.hellbender.testutils.BaseTest;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants;
+import org.broadinstitute.hellbender.tools.sv.SVCallRecord;
+import org.broadinstitute.hellbender.tools.sv.SVTestUtils;
+import org.broadinstitute.hellbender.tools.sv.cluster.ClusteringParameters;
+import org.broadinstitute.hellbender.tools.sv.cluster.SVClusterEngineArgumentsCollection;
+import org.broadinstitute.hellbender.tools.sv.stratify.SVStratificationEngine;
+import org.broadinstitute.hellbender.tools.sv.stratify.SVStratificationEngineArgumentsCollection;
+import org.broadinstitute.hellbender.tools.walkers.sv.SVStratify;
+import org.broadinstitute.hellbender.tools.walkers.validation.Concordance;
+import org.broadinstitute.hellbender.tools.walkers.validation.ConcordanceState;
+import org.broadinstitute.hellbender.utils.MathUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class StratifiedConcordanceEngineTest extends BaseTest {
+
+    private static final SVCallRecord TEST_VARIANT_1 = SVTestUtils.newCallRecordWithCoordinatesAndType("record1", "chr1", 1000, "chr1", 2000, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL);
+    
+    private static final String STRATIFICATION_1 = "strat1";
+    private static final String STRATIFICATION_2 = "strat2";
+    private static final String STRATIFICATION_3 = "strat3";
+    private static final String STRATIFICATION_4 = "strat4";
+    private static final String TRACK_A = "trackA";
+    private static final String TRACK_B = "trackB";
+    private static final String TRACK_C = "trackC";
+    private static final String TRACK_D = "trackD";
+
+    private static StratifiedConcordanceEngine createConcordanceEngine() {
+
+        final SVStratificationEngine stratificationEngine = new SVStratificationEngine(SVTestUtils.hg38Dict);
+        // Diagram of the interval tracks on 1000-2000 (note there are additional intervals past 2000). Track D is empty.
+        //          -----|----------------|--------|--------|--------|----------------|-------
+        //             1000             1200     1300     1400     1500             2000
+        // TRACK A       XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+        // TRACK B                        XXXXXXXXXXXXXXXXXX
+        // TRACK C                                  XXXXXXXXXXXXXXXXX
+        // TRACK D
+        stratificationEngine.addTrack(TRACK_A, Arrays.asList(new SimpleInterval("chr1", 1000, 2000), new SimpleInterval("chr1", 3000, 4000)));
+        stratificationEngine.addTrack(TRACK_B, Arrays.asList(new SimpleInterval("chr1", 1200, 1400), new SimpleInterval("chr1", 5000, 6000)));
+        stratificationEngine.addTrack(TRACK_C, Arrays.asList(new SimpleInterval("chr1", 1300, 1500), new SimpleInterval("chr1", 7000, 8000)));
+        stratificationEngine.addTrack(TRACK_D, Collections.emptyList());
+        stratificationEngine.addStratification(STRATIFICATION_1, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, 100, 5000, Sets.newHashSet(TRACK_A));
+        stratificationEngine.addStratification(STRATIFICATION_2, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, 100, 5000, Sets.newHashSet(TRACK_B));
+        stratificationEngine.addStratification(STRATIFICATION_3, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, 100, 5000, Sets.newHashSet(TRACK_C));
+        stratificationEngine.addStratification(STRATIFICATION_4, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, 100, 5000, Sets.newHashSet(TRACK_D));
+
+        final Map<String, ClosestSVFinder> clusterEngineMap = new HashMap<>();
+        final SVConcordanceLinkage linkage1 = new SVConcordanceLinkage(SVTestUtils.hg38Dict);
+        linkage1.setDepthOnlyParams(ClusteringParameters.createDepthParameters(0, 0, 10, 0));
+        final SVConcordanceLinkage linkage2 = new SVConcordanceLinkage(SVTestUtils.hg38Dict);
+        linkage2.setDepthOnlyParams(ClusteringParameters.createDepthParameters(0, 0, 20, 0));
+        final SVConcordanceLinkage linkage3 = new SVConcordanceLinkage(SVTestUtils.hg38Dict);
+        linkage3.setDepthOnlyParams(ClusteringParameters.createDepthParameters(0, 0, 30, 0));
+        final SVConcordanceLinkage linkage4 = new SVConcordanceLinkage(SVTestUtils.hg38Dict);
+        linkage4.setDepthOnlyParams(ClusteringParameters.createDepthParameters(0, 0, 0, 0));
+
+        final SVConcordanceAnnotator collapser = new SVConcordanceAnnotator();
+        clusterEngineMap.put(STRATIFICATION_1, new ClosestSVFinder(linkage1, collapser::annotate, SVTestUtils.hg38Dict));
+        clusterEngineMap.put(STRATIFICATION_2, new ClosestSVFinder(linkage2, collapser::annotate, SVTestUtils.hg38Dict));
+        clusterEngineMap.put(STRATIFICATION_3, new ClosestSVFinder(linkage3, collapser::annotate, SVTestUtils.hg38Dict));
+        clusterEngineMap.put(STRATIFICATION_4, new ClosestSVFinder(linkage4, collapser::annotate, SVTestUtils.hg38Dict));
+
+        final SVClusterEngineArgumentsCollection defaultClusteringArgs = new SVClusterEngineArgumentsCollection();
+        defaultClusteringArgs.depthBreakendWindow = 0;
+        defaultClusteringArgs.depthOverlapFraction = 0;
+        defaultClusteringArgs.depthSizeSimilarity = 0;
+
+        final SVStratificationEngineArgumentsCollection stratArgs = new SVStratificationEngineArgumentsCollection();
+        stratArgs.numBreakpointOverlaps = 1;
+        stratArgs.overlapFraction = 0;
+
+        return new StratifiedConcordanceEngine(clusterEngineMap, stratificationEngine, stratArgs, defaultClusteringArgs, collapser, SVTestUtils.hg38Dict);
+    }
+
+    @Test
+    public void testIsEmpty() {
+        final StratifiedConcordanceEngine engine = createConcordanceEngine();
+        Assert.assertTrue(engine.isEmpty());
+        engine.addTruthVariant(TEST_VARIANT_1);
+        // Empty if only contains truth variants
+        Assert.assertTrue(engine.isEmpty());
+        engine.addEvalVariant(TEST_VARIANT_1);
+        Assert.assertFalse(engine.isEmpty());
+        engine.flush(true);
+        Assert.assertTrue(engine.isEmpty());
+    }
+
+    @DataProvider(name = "testStratificationData")
+    public Object[][] testStratificationData() {
+        return new Object[][]{
+                {100, 200, Collections.emptyList()},
+                {1000, 2000, Lists.newArrayList(STRATIFICATION_1)},
+                {1000, 1010, Collections.emptyList()}, // too small
+                {1000, 2001, Lists.newArrayList(STRATIFICATION_1)},
+                {999, 2000, Lists.newArrayList(STRATIFICATION_1)},
+                {999, 2001, Collections.emptyList()},
+                {4500, 5500, Lists.newArrayList(STRATIFICATION_2)},
+                {4500, 7500, Lists.newArrayList(STRATIFICATION_3)},
+                {6500, 8500, Collections.emptyList()},
+                {500, 1250, Lists.newArrayList(STRATIFICATION_1, STRATIFICATION_2)},
+                {500, 1450, Lists.newArrayList(STRATIFICATION_1, STRATIFICATION_3)},
+                {500, 1350, Lists.newArrayList(STRATIFICATION_1, STRATIFICATION_2, STRATIFICATION_3)},
+        };
+    }
+
+    @Test(dataProvider= "testStratificationData")
+    public void testSingleRecord(final int positionA, final int positionB, final List<String> expectedNonDefault) {
+        final StratifiedConcordanceEngine engine = createConcordanceEngine();
+        final SVCallRecord record = SVTestUtils.newDeletionRecordWithCoordinates("record1", "chr1", positionA, positionB);
+        engine.addEvalVariant(record);
+        final Collection<VariantContext> result = engine.flush(true);
+        Assert.assertEquals(result.size(), 1);
+        final VariantContext outputRecord = result.iterator().next();
+        Assert.assertNotNull(outputRecord);
+        final List<String> observed = outputRecord.getAttributeAsStringList(GATKSVVCFConstants.STRATUM_INFO_KEY, "");
+        final List<String> expected = new ArrayList<>(expectedNonDefault.size() + 1);
+        expected.addAll(expectedNonDefault);
+        expected.add(SVStratify.DEFAULT_STRATUM);
+        Assert.assertEquals(observed, expected.stream().sorted().collect(Collectors.toUnmodifiableList()));
+    }
+
+    @Test
+    public void testSoftFlush() {
+        final StratifiedConcordanceEngine engine = createConcordanceEngine();
+        final SVCallRecord eval1 = SVTestUtils.newDeletionRecordWithCoordinates("eval1", "chr1", 1100, 1900);
+        final SVCallRecord eval2 = SVTestUtils.newDeletionRecordWithCoordinates("eval2", "chr1", 1300, 1900);
+        final SVCallRecord eval3 = SVTestUtils.newDeletionRecordWithCoordinates("eval3", "chr1", 4000, 5000);
+        final SVCallRecord truth1 = SVTestUtils.newDeletionRecordWithCoordinates("truth1", "chr1", 1200, 1900);
+        final SVCallRecord truth2 = SVTestUtils.newDeletionRecordWithCoordinates("truth2", "chr1", 4000, 5000);
+        engine.addEvalVariant(eval1);
+        engine.addTruthVariant(truth1);
+        engine.addEvalVariant(eval2);
+        engine.addTruthVariant(truth2);
+        engine.addEvalVariant(eval3);
+        final List<VariantContext> result = engine.flush(false).stream().sorted(Comparator.comparingInt(VariantContext::getStart)).collect(Collectors.toUnmodifiableList());
+
+        Assert.assertEquals(result.size(), 2);
+        final VariantContext outputRecord1 = result.get(0);
+        final VariantContext outputRecord2 = result.get(1);
+        Assert.assertNotNull(outputRecord1);
+        Assert.assertNotNull(outputRecord2);
+        Assert.assertEquals(outputRecord1.getID(), eval1.getId());
+        Assert.assertEquals(outputRecord2.getID(), eval2.getId());
+    }
+
+
+    @DataProvider(name = "testConcordanceSimpleData")
+    public Object[][] testConcordanceSimpleData() {
+        return new Object[][]{
+                // default strat exact
+                {100, 400, 100, 400, true},
+                // default strat not within tolerance
+                {100, 400, 101, 400, false},
+                {100, 100, 100, 399, false},
+                // strat 1 exact match
+                {1100, 1900, 1100, 1900, true},
+                // strat 1 within 10 bp
+                {1100, 1900, 1105, 1905, true},
+                // strat 1 within 10 bp
+                {1100, 1900, 1105, 1910, true},
+                // strat 1 and default, not within tolerance
+                {1100, 1900, 1105, 1911, false},
+                // strat 2, not within default/strat 1 tolerance
+                {1210, 1900, 1225, 1900, true},
+                // strat 3, not within default/strat 1/2 tolerance
+                {1310, 1900, 1335, 1900, true}
+        };
+    }
+
+    @Test(dataProvider= "testConcordanceSimpleData")
+    public void testConcordanceSimple(final int evalPos, final int evalEnd, final int truthPos, final int truthEnd, final boolean truePositive) {
+        final StratifiedConcordanceEngine engine = createConcordanceEngine();
+        final SVCallRecord eval = SVTestUtils.newDeletionRecordWithCoordinates("eval1", "chr1", evalPos, evalEnd);
+        final SVCallRecord truth = SVTestUtils.newDeletionRecordWithCoordinates("truth1", "chr1", truthPos, truthEnd);
+        engine.addEvalVariant(eval);
+        engine.addTruthVariant(truth);
+        final Collection<VariantContext> result = engine.flush(true);
+
+        Assert.assertEquals(result.size(), 1);
+        final VariantContext outputRecord = result.iterator().next();
+        Assert.assertNotNull(outputRecord);
+        Assert.assertEquals(outputRecord.getID(), eval.getId());
+        Assert.assertEquals(outputRecord.getAttribute(Concordance.TRUTH_STATUS_VCF_ATTRIBUTE), truePositive ? ConcordanceState.TRUE_POSITIVE.getAbbreviation() : ConcordanceState.FALSE_POSITIVE.getAbbreviation());
+        Assert.assertEquals(outputRecord.getAttribute(GATKSVVCFConstants.TRUTH_VARIANT_ID_INFO), truePositive ? truth.getId() : null);
+    }
+
+
+    @DataProvider(name = "testConcordanceMultiData")
+    public Object[][] testConcordanceMultiData() {
+        return new Object[][]{
+                // default strat exact
+                {100, 400, 100, 400, 101, 401, true},
+                {101, 401, 100, 400, 101, 401, false},
+                // strat 1 match first
+                {1100, 1900, 1100, 1900, 1101, 1900, true},
+                // strat 1 match second
+                {1101, 1900, 1100, 1900, 1101, 1900, false},
+                // strat 2 match first
+                {1310, 1900, 1310, 1900, 1311, 1900, true},
+                // strat 2 match second
+                {1310, 1900, 1310, 2000, 1311, 1900, false},
+                // strat 3 match first
+                {1410, 1900, 1435, 1900, 1450, 1900, true},
+                // strat 3 match second
+                {1410, 1900, 1410, 1850, 1410, 1925, false},
+                // matches all strats but fails matching in 3, but 2 is still found
+                {1410, 1900, 1410, 1920, 1410, 1950, true},
+                {1410, 1900, 1410, 1920, 1410, 1921, true},
+                {1410, 1900, 1410, 1950, 1410, 1920, false},
+                {1410, 1900, 1410, 1921, 1410, 1920, false},
+        };
+    }
+
+    @Test(dataProvider= "testConcordanceMultiData")
+    public void testConcordanceMulti(final int evalPos, final int evalEnd, final int truth1Pos, final int truth1End, final int truth2Pos, final int truth2End, final boolean truth1Match) {
+        final StratifiedConcordanceEngine engine = createConcordanceEngine();
+        final SVCallRecord eval = SVTestUtils.newDeletionRecordWithCoordinates("eval1", "chr1", evalPos, evalEnd);
+        final SVCallRecord truth1 = SVTestUtils.newDeletionRecordWithCoordinates("truth1", "chr1", truth1Pos, truth1End);
+        final SVCallRecord truth2 = SVTestUtils.newDeletionRecordWithCoordinates("truth2", "chr1", truth2Pos, truth2End);
+        if (evalPos < truth1Pos) {
+            engine.addEvalVariant(eval);
+            engine.addTruthVariant(truth1);
+        } else {
+            engine.addTruthVariant(truth1);
+            engine.addEvalVariant(eval);
+        }
+        engine.addTruthVariant(truth2);
+        final Collection<VariantContext> result = engine.flush(true);
+
+        Assert.assertEquals(result.size(), 1);
+        final VariantContext outputRecord = result.iterator().next();
+        Assert.assertNotNull(outputRecord);
+        Assert.assertEquals(outputRecord.getID(), eval.getId());
+        Assert.assertEquals(outputRecord.getAttribute(GATKSVVCFConstants.TRUTH_VARIANT_ID_INFO), truth1Match ? truth1.getId() : truth2.getId());
+    }
+
+    // Tests all combinations of matching from 3 groups
+    @Test
+    public void testItemTracker() {
+        // In order of priority (most priority to least)
+        final List<String> groups = Lists.newArrayList(STRATIFICATION_1, STRATIFICATION_3, SVStratify.DEFAULT_STRATUM);
+        for (int k = 0; k < groups.size(); k++) {
+            final Combinations combinations = new Combinations(groups.size(), k);
+            for (int[] c : combinations) {
+                final StratifiedConcordanceEngine.ItemTracker itemTracker = new StratifiedConcordanceEngine.ItemTracker(groups);
+                Assert.assertEquals(itemTracker.getGroups().size(), groups.size());
+                Assert.assertTrue(new HashSet<>(groups).containsAll(itemTracker.getGroups()));
+                Assert.assertNull(itemTracker.getOutput());
+                final Set<Integer> combinationSet = Arrays.stream(c).boxed().collect(Collectors.toUnmodifiableSet());
+                for (int i = 0; i < groups.size(); i++) {
+                    final String group = groups.get(i);
+                    final Map<String, Object> attr = new HashMap<>();
+                    attr.put(Concordance.TRUTH_STATUS_VCF_ATTRIBUTE, combinationSet.contains(i) ? ConcordanceState.TRUE_POSITIVE.getAbbreviation() : ConcordanceState.FALSE_POSITIVE.getAbbreviation());
+                    attr.put(GATKSVVCFConstants.TRUTH_VARIANT_ID_INFO, "var_" + group);
+                    final SVCallRecord record = SVTestUtils.newDeletionRecordWithAttributes(attr);
+                    Assert.assertFalse(itemTracker.allEjected());
+                    itemTracker.eject(group, record);
+                }
+                Assert.assertTrue(itemTracker.allEjected());
+                final SVCallRecord out = itemTracker.getOutput();
+                if (c.length == 0) {
+                    Assert.assertEquals(out.getAttributes().get(Concordance.TRUTH_STATUS_VCF_ATTRIBUTE), ConcordanceState.FALSE_POSITIVE.getAbbreviation());
+                } else {
+                    // Highest priority group is expected
+                    final int minIndex = c[MathUtils.minElementIndex(c)];
+                    Assert.assertEquals(out.getAttributes().get(Concordance.TRUTH_STATUS_VCF_ATTRIBUTE), ConcordanceState.TRUE_POSITIVE.getAbbreviation());
+                    final String minGroup = groups.get(minIndex);
+                    Assert.assertEquals(out.getAttributes().get(GATKSVVCFConstants.TRUTH_VARIANT_ID_INFO), "var_" + minGroup);
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/sv/stratify/SVStratificationEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/sv/stratify/SVStratificationEngineUnitTest.java
@@ -26,13 +26,13 @@ public class SVStratificationEngineUnitTest extends GATKBaseTest {
     private static final List<Locatable> CONTEXT_1_INTERVALS = Lists.newArrayList(new SimpleInterval("chr1", 1000, 2000));
     private static final List<Locatable> CONTEXT_2_INTERVALS = Lists.newArrayList(new SimpleInterval("chr2", 1000, 2000));
     
-    private static SVStatificationEngine makeDefaultEngine() {
-        return new SVStatificationEngine(SVTestUtils.hg38Dict);
+    private static SVStratificationEngine makeDefaultEngine() {
+        return new SVStratificationEngine(SVTestUtils.hg38Dict);
     }
 
     @Test
     public void testAddContext() {
-        final SVStatificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine engine = makeDefaultEngine();
         engine.addTrack(CONTEXT_1_NAME, CONTEXT_1_INTERVALS);
         Assert.assertNotNull(engine.getTrackIntervals(CONTEXT_1_NAME));
         Assert.assertNull(engine.getTrackIntervals(CONTEXT_2_NAME));
@@ -40,26 +40,26 @@ public class SVStratificationEngineUnitTest extends GATKBaseTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testAddDuplicateContext() {
-        final SVStatificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine engine = makeDefaultEngine();
         engine.addTrack(CONTEXT_1_NAME, CONTEXT_1_INTERVALS);
         engine.addTrack(CONTEXT_1_NAME, CONTEXT_2_INTERVALS);
     }
 
     @Test
     public void testNoContexts() {
-        final SVStatificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine engine = makeDefaultEngine();
         Assert.assertTrue(engine.getStrata().isEmpty());
     }
 
     @Test
     public void testAddStratification() {
-        final SVStatificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine engine = makeDefaultEngine();
         engine.addTrack(CONTEXT_1_NAME, CONTEXT_1_INTERVALS);
         engine.addStratification("strat", GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, 50, 500, Collections.singleton(CONTEXT_1_NAME));
-        final Collection<SVStatificationEngine.Stratum> stratificationCollection = engine.getStrata();
+        final Collection<SVStratificationEngine.Stratum> stratificationCollection = engine.getStrata();
         Assert.assertNotNull(stratificationCollection);
         Assert.assertEquals(stratificationCollection.size(), 1);
-        final SVStatificationEngine.Stratum stratification = stratificationCollection.iterator().next();
+        final SVStratificationEngine.Stratum stratification = stratificationCollection.iterator().next();
         Assert.assertNotNull(stratification);
         Assert.assertEquals(stratification.getSvType(), GATKSVVCFConstants.StructuralVariantAnnotationType.DEL);
         Assert.assertNotNull(stratification.getMinSize());
@@ -72,31 +72,31 @@ public class SVStratificationEngineUnitTest extends GATKBaseTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testAddStratificationBadMinSize() {
-        final SVStatificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine engine = makeDefaultEngine();
         engine.addStratification("strat", GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, -1, 500, Collections.emptySet());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testAddStratificationBadMaxSize() {
-        final SVStatificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine engine = makeDefaultEngine();
         engine.addStratification("strat", GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, -1, Collections.emptySet());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testAddStratificationBadMaxSizeInfinity() {
-        final SVStatificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine engine = makeDefaultEngine();
         engine.addStratification("strat", GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, null, Integer.MAX_VALUE, Collections.emptySet());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testAddStratificationMaxEqualToMin() {
-        final SVStatificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine engine = makeDefaultEngine();
         engine.addStratification("strat", GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, 50, 50, Collections.emptySet());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testAddStratificationMaxLessThanMin() {
-        final SVStatificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine engine = makeDefaultEngine();
         engine.addStratification("strat", GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, 50, 49, Collections.emptySet());
     }
 
@@ -105,7 +105,7 @@ public class SVStratificationEngineUnitTest extends GATKBaseTest {
         final Map<String, List<Locatable>> map = new HashMap<>();
         map.put(CONTEXT_1_NAME, CONTEXT_1_INTERVALS);
         map.put(CONTEXT_2_NAME, CONTEXT_2_INTERVALS);
-        final SVStatificationEngine engine = SVStatificationEngine.create(map, CONFIG_FILE_PATH, SVTestUtils.hg38Dict);
+        final SVStratificationEngine engine = SVStratificationEngine.create(map, CONFIG_FILE_PATH, SVTestUtils.hg38Dict);
         Assert.assertNotNull(engine);
         Assert.assertNotNull(engine.getTrackIntervals(CONTEXT_1_NAME));
         Assert.assertEquals(engine.getStrata().size(), 7);
@@ -196,14 +196,14 @@ public class SVStratificationEngineUnitTest extends GATKBaseTest {
         final Map<String, List<Locatable>> map = new HashMap<>();
         map.put(CONTEXT_1_NAME, CONTEXT_1_INTERVALS);
         map.put(CONTEXT_2_NAME, CONTEXT_2_INTERVALS);
-        final SVStatificationEngine engine = SVStatificationEngine.create(map, CONFIG_FILE_PATH, SVTestUtils.hg38Dict);
+        final SVStratificationEngine engine = SVStratificationEngine.create(map, CONFIG_FILE_PATH, SVTestUtils.hg38Dict);
         final SVCallRecord record;
         if (svType == GATKSVVCFConstants.StructuralVariantAnnotationType.INS) {
             record = SVTestUtils.newCallRecordInsertionWithLengthAndCoordinates(chromA, posA, svlen);
         } else {
             record = SVTestUtils.newCallRecordWithCoordinatesAndType("record", chromA, posA, chromB, posB, svType);
         }
-        final Collection<SVStatificationEngine.Stratum> result = engine.getMatches(record, 0.5, 0, 2);
+        final Collection<SVStratificationEngine.Stratum> result = engine.getMatches(record, 0.5, 0, 2);
         if (expectedStratName == null) {
             Assert.assertTrue(result.isEmpty());
         } else {
@@ -215,7 +215,7 @@ public class SVStratificationEngineUnitTest extends GATKBaseTest {
     // Not supported
     @Test(expectedExceptions = GATKException.class)
     public void testGetMatchVariantsCpx() {
-        final SVStatificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine engine = makeDefaultEngine();
         engine.addTrack(CONTEXT_1_NAME, CONTEXT_1_INTERVALS);
         engine.addTrack("context3", Lists.newArrayList(new SimpleInterval("chr1", 1500, 2500)));
         engine.addStratification("strat1", GATKSVVCFConstants.StructuralVariantAnnotationType.CPX, 50, 500, Collections.singleton("context1"));
@@ -227,51 +227,51 @@ public class SVStratificationEngineUnitTest extends GATKBaseTest {
 
     @Test
     public void testGetMatchVariantsMultiple() {
-        final SVStatificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine engine = makeDefaultEngine();
         engine.addTrack(CONTEXT_1_NAME, CONTEXT_1_INTERVALS);
         engine.addTrack("context3", Lists.newArrayList(new SimpleInterval("chr1", 1500, 2500)));
         engine.addStratification("strat1", GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, 50, 500, Collections.singleton("context1"));
         engine.addStratification("strat2", GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, 50, 500, Collections.singleton("context3"));
         final SVCallRecord record = SVTestUtils.newCallRecordWithCoordinatesAndType("record", "chr1", 1800, "chr1", 2100, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL);
-        final Collection<SVStatificationEngine.Stratum> result = engine.getMatches(record, 0.5, 0, 2);
-        final List<String> names = result.stream().map(SVStatificationEngine.Stratum::getName).collect(Collectors.toList());
+        final Collection<SVStratificationEngine.Stratum> result = engine.getMatches(record, 0.5, 0, 2);
+        final List<String> names = result.stream().map(SVStratificationEngine.Stratum::getName).collect(Collectors.toList());
         Assert.assertTrue(names.contains("strat1"));
         Assert.assertTrue(names.contains("strat2"));
     }
 
     @Test
     public void testGetMatchVariantsNullContexts() {
-        final SVStatificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine engine = makeDefaultEngine();
         engine.addTrack(CONTEXT_1_NAME, CONTEXT_1_INTERVALS);
         engine.addStratification("strat1", GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, 50, 500, Collections.emptySet());
         final SVCallRecord record = SVTestUtils.newCallRecordWithCoordinatesAndType("record", "chr2", 1800, "chr2", 2100, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL);
-        final Collection<SVStatificationEngine.Stratum> result = engine.getMatches(record, 0.5, 0, 2);
-        final List<String> names = result.stream().map(SVStatificationEngine.Stratum::getName).collect(Collectors.toList());
+        final Collection<SVStratificationEngine.Stratum> result = engine.getMatches(record, 0.5, 0, 2);
+        final List<String> names = result.stream().map(SVStratificationEngine.Stratum::getName).collect(Collectors.toList());
         Assert.assertEquals(names.size(), 1);
         Assert.assertEquals(names.get(0), "strat1");
     }
 
     @Test
     public void testGetMatchVariantsNoEngineContexts() {
-        final SVStatificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine engine = makeDefaultEngine();
         engine.addStratification("strat1", GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, 50, 500, Collections.emptySet());
         final SVCallRecord record = SVTestUtils.newCallRecordWithCoordinatesAndType("record", "chr2", 1800, "chr2", 2100, GATKSVVCFConstants.StructuralVariantAnnotationType.DEL);
-        final Collection<SVStatificationEngine.Stratum> result = engine.getMatches(record, 0.5, 0, 2);
-        final List<String> names = result.stream().map(SVStatificationEngine.Stratum::getName).collect(Collectors.toList());
+        final Collection<SVStratificationEngine.Stratum> result = engine.getMatches(record, 0.5, 0, 2);
+        final List<String> names = result.stream().map(SVStratificationEngine.Stratum::getName).collect(Collectors.toList());
         Assert.assertEquals(names.size(), 1);
         Assert.assertEquals(names.get(0), "strat1");
     }
 
     @Test
     public void testTestAddStratificationInnerClass() {
-        final SVStatificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine engine = makeDefaultEngine();
         engine.addTrack(CONTEXT_1_NAME, CONTEXT_1_INTERVALS);
-        final SVStatificationEngine.Stratum stratification = engine.new Stratum("strat", GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, 50, 500, Collections.singleton(CONTEXT_1_NAME));
+        final SVStratificationEngine.Stratum stratification = engine.new Stratum("strat", GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, 50, 500, Collections.singleton(CONTEXT_1_NAME));
         engine.addStratification(stratification);
-        final Collection<SVStatificationEngine.Stratum> stratificationCollection = engine.getStrata();
+        final Collection<SVStratificationEngine.Stratum> stratificationCollection = engine.getStrata();
         Assert.assertNotNull(stratificationCollection);
         Assert.assertEquals(stratificationCollection.size(), 1);
-        final SVStatificationEngine.Stratum stratificationOut = stratificationCollection.iterator().next();
+        final SVStratificationEngine.Stratum stratificationOut = stratificationCollection.iterator().next();
         Assert.assertNotNull(stratificationOut);
         Assert.assertEquals(stratificationOut.getSvType(), GATKSVVCFConstants.StructuralVariantAnnotationType.DEL);
         Assert.assertNotNull(stratificationOut.getMinSize());
@@ -284,8 +284,8 @@ public class SVStratificationEngineUnitTest extends GATKBaseTest {
 
     @Test
     public void testMatchesType() {
-        final SVStatificationEngine engine = makeDefaultEngine();
-        final SVStatificationEngine.Stratum strat = engine.new Stratum(
+        final SVStratificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine.Stratum strat = engine.new Stratum(
                 "strat",
                 GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
                 100, 500,
@@ -297,8 +297,8 @@ public class SVStratificationEngineUnitTest extends GATKBaseTest {
 
     @Test
     public void testMatchesSizeSimple() {
-        final SVStatificationEngine engine = makeDefaultEngine();
-        final SVStatificationEngine.Stratum strat = engine.new Stratum(
+        final SVStratificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine.Stratum strat = engine.new Stratum(
                 "strat",
                 GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
                 100, 500,
@@ -312,8 +312,8 @@ public class SVStratificationEngineUnitTest extends GATKBaseTest {
 
     @Test
     public void testMatchesSizeNoMin() {
-        final SVStatificationEngine engine = makeDefaultEngine();
-        final SVStatificationEngine.Stratum strat = engine.new Stratum(
+        final SVStratificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine.Stratum strat = engine.new Stratum(
                 "strat",
                 GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
                 null, 500,
@@ -327,8 +327,8 @@ public class SVStratificationEngineUnitTest extends GATKBaseTest {
 
     @Test
     public void testMatchesSizeNoMax() {
-        final SVStatificationEngine engine = makeDefaultEngine();
-        final SVStatificationEngine.Stratum strat = engine.new Stratum(
+        final SVStratificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine.Stratum strat = engine.new Stratum(
                 "strat",
                 GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
                 50, null,
@@ -341,8 +341,8 @@ public class SVStratificationEngineUnitTest extends GATKBaseTest {
 
     @Test
     public void testMatchesSizeNoMinOrMax() {
-        final SVStatificationEngine engine = makeDefaultEngine();
-        final SVStatificationEngine.Stratum strat = engine.new Stratum(
+        final SVStratificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine.Stratum strat = engine.new Stratum(
                 "strat",
                 GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
                 null, null,
@@ -354,8 +354,8 @@ public class SVStratificationEngineUnitTest extends GATKBaseTest {
 
     @Test
     public void testMatchesSizeInsertion() {
-        final SVStatificationEngine engine = makeDefaultEngine();
-        final SVStatificationEngine.Stratum strat = engine.new Stratum(
+        final SVStratificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine.Stratum strat = engine.new Stratum(
                 "strat",
                 GATKSVVCFConstants.StructuralVariantAnnotationType.INS,
                 100, 500,
@@ -369,8 +369,8 @@ public class SVStratificationEngineUnitTest extends GATKBaseTest {
 
     @Test
     public void testMatchesSizeInsertionNullLength() {
-        final SVStatificationEngine engine = makeDefaultEngine();
-        final SVStatificationEngine.Stratum strat = engine.new Stratum(
+        final SVStratificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine.Stratum strat = engine.new Stratum(
                 "strat",
                 GATKSVVCFConstants.StructuralVariantAnnotationType.INS,
                 0, Integer.MAX_VALUE - 1,
@@ -381,8 +381,8 @@ public class SVStratificationEngineUnitTest extends GATKBaseTest {
 
     @Test
     public void testMatchesSizeInsertionNullLength2() {
-        final SVStatificationEngine engine = makeDefaultEngine();
-        final SVStatificationEngine.Stratum strat = engine.new Stratum(
+        final SVStratificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine.Stratum strat = engine.new Stratum(
                 "strat",
                 GATKSVVCFConstants.StructuralVariantAnnotationType.INS,
                 null, null,
@@ -393,8 +393,8 @@ public class SVStratificationEngineUnitTest extends GATKBaseTest {
 
     @Test
     public void testMatchesSizeBnd() {
-        final SVStatificationEngine engine = makeDefaultEngine();
-        final SVStatificationEngine.Stratum strat = engine.new Stratum(
+        final SVStratificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine.Stratum strat = engine.new Stratum(
                 "strat",
                 GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                 null, null,
@@ -424,9 +424,9 @@ public class SVStratificationEngineUnitTest extends GATKBaseTest {
     public void testMatchesContextDel(final String chrom, final int start, final int end,
                                       final double overlapFraction, final int numBreakpointOverlaps,
                                       final boolean expected) {
-        final SVStatificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine engine = makeDefaultEngine();
         engine.addTrack(CONTEXT_1_NAME, CONTEXT_1_INTERVALS);
-        final SVStatificationEngine.Stratum strat = engine.new Stratum(
+        final SVStratificationEngine.Stratum strat = engine.new Stratum(
                 "strat",
                 GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                 null, null,
@@ -450,9 +450,9 @@ public class SVStratificationEngineUnitTest extends GATKBaseTest {
     public void testMatchesContextIns(final String chrom, final int start, final int length,
                                       final double overlapFraction, final int numBreakpointOverlaps,
                                       final boolean expected) {
-        final SVStatificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine engine = makeDefaultEngine();
         engine.addTrack(CONTEXT_1_NAME, CONTEXT_1_INTERVALS);
-        final SVStatificationEngine.Stratum strat = engine.new Stratum(
+        final SVStratificationEngine.Stratum strat = engine.new Stratum(
                 "strat",
                 GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                 null, null,
@@ -481,9 +481,9 @@ public class SVStratificationEngineUnitTest extends GATKBaseTest {
     @Test(dataProvider = "testMatchesContextBndData")
     public void testMatchesContextBnd(final String chromA, final int posA, final String chromB, final int posB,
                                       final int numBreakpointOverlapsInterchrom, final boolean expected) {
-        final SVStatificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine engine = makeDefaultEngine();
         engine.addTrack(CONTEXT_1_NAME, CONTEXT_1_INTERVALS);
-        final SVStatificationEngine.Stratum strat = engine.new Stratum(
+        final SVStratificationEngine.Stratum strat = engine.new Stratum(
                 "strat",
                 GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                 null, null,
@@ -514,9 +514,9 @@ public class SVStratificationEngineUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "testCountAnyContextOverlapData")
     public void testCountAnyContextOverlap(final String chrom, final int start, final int end, final int expected) {
-        final SVStatificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine engine = makeDefaultEngine();
         engine.addTrack(CONTEXT_1_NAME, CONTEXT_1_INTERVALS);
-        final SVStatificationEngine.Stratum strat = engine.new Stratum(
+        final SVStratificationEngine.Stratum strat = engine.new Stratum(
                 "strat",
                 GATKSVVCFConstants.StructuralVariantAnnotationType.BND,
                 null, null,
@@ -536,9 +536,9 @@ public class SVStratificationEngineUnitTest extends GATKBaseTest {
 
     @Test
     public void testGetters() {
-        final SVStatificationEngine engine = makeDefaultEngine();
+        final SVStratificationEngine engine = makeDefaultEngine();
         engine.addTrack(CONTEXT_1_NAME, CONTEXT_1_INTERVALS);
-        final SVStatificationEngine.Stratum strat = engine.new Stratum(
+        final SVStratificationEngine.Stratum strat = engine.new Stratum(
                 "strat",
                 GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
                 50, 500,

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVConcordanceIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVConcordanceIntegrationTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.walkers.sv;
 
+import com.google.common.collect.Lists;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextBuilder;
@@ -17,11 +18,13 @@ import org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants;
 import org.broadinstitute.hellbender.tools.sv.SVCallRecord;
 import org.broadinstitute.hellbender.tools.sv.SVCallRecordUtils;
 import org.broadinstitute.hellbender.tools.sv.SVTestUtils;
+import org.broadinstitute.hellbender.tools.sv.cluster.CanonicalSVLinkage;
 import org.broadinstitute.hellbender.tools.sv.cluster.ClusteringParameters;
 import org.broadinstitute.hellbender.tools.sv.cluster.SVClusterEngineArgumentsCollection;
 import org.broadinstitute.hellbender.tools.sv.concordance.ClosestSVFinder;
 import org.broadinstitute.hellbender.tools.sv.concordance.SVConcordanceAnnotator;
 import org.broadinstitute.hellbender.tools.sv.concordance.SVConcordanceLinkage;
+import org.broadinstitute.hellbender.tools.sv.stratify.SVStratificationEngineArgumentsCollection;
 import org.broadinstitute.hellbender.tools.walkers.validation.Concordance;
 import org.broadinstitute.hellbender.tools.walkers.validation.ConcordanceState;
 import org.broadinstitute.hellbender.utils.MathUtilsUnitTest;
@@ -85,15 +88,16 @@ public class SVConcordanceIntegrationTest extends CommandLineProgramTest {
 
         final ClosestSVFinder finder = new ClosestSVFinder(linkage, annotator::annotate, dictionary);
         final List<SVCallRecord> expectedRecords = new ArrayList<>(inputEvalVariants.size());
-        final Set<Map.Entry<Long, SVCallRecord>> truthRecords = new HashSet<>();
+        final Map<Long, SVCallRecord> truthRecords = new HashMap<>();
         Long itemId = 0L;
         for (final SVCallRecord record : inputTruthVariants) {
-            truthRecords.add(new AbstractMap.SimpleImmutableEntry<>(itemId++, record));
+            truthRecords.put(itemId++, record);
         }
+        Long nextId = 0L;
         for (final SVCallRecord evalRecord : inputEvalVariants) {
-            final Map.Entry<Long, SVCallRecord> closestRecord = finder.getClosestItem(evalRecord, truthRecords);
+            final ClosestSVFinder.LinkageConcordanceRecord closestRecord = finder.getClosestItem(evalRecord, truthRecords);
             final ClosestSVFinder.ClosestPair cluster =
-                    new ClosestSVFinder.ClosestPair(evalRecord, closestRecord == null ? null : closestRecord.getValue());
+                    new ClosestSVFinder.ClosestPair(nextId++, evalRecord, closestRecord == null ? null : closestRecord.record(), new CanonicalSVLinkage.CanonicalLinkageResult(true, null, null, null, null));
             expectedRecords.add(annotator.annotate(cluster));
         }
 
@@ -113,6 +117,7 @@ public class SVConcordanceIntegrationTest extends CommandLineProgramTest {
         Assert.assertEquals(outputVariants.size(), idSortedInputEvalVariants.size());
         Assert.assertEquals(outputVariants.size(), expectedVariants.size());
         final Set<String> checkedVariantsSet = new HashSet<>();
+        int numTP = 0;
         for (int i = 0; i < outputVariants.size(); i++) {
             final VariantContext outputVariant = outputVariants.get(i);
             final VariantContext expectedVariant = expectedVariants.get(i);
@@ -127,21 +132,114 @@ public class SVConcordanceIntegrationTest extends CommandLineProgramTest {
             Assert.assertEquals(outputVariant.getAttributeAsString(GATKSVVCFConstants.SVTYPE, "test_default"), expectedVariant.getAttributeAsString(GATKSVVCFConstants.SVTYPE, "expected_default"));
             checkTruthVariantId(outputVariant, expectedVariant);
             Assert.assertEquals(outputVariant.getAttributeAsString(Concordance.TRUTH_STATUS_VCF_ATTRIBUTE, "test_default"), expectedVariant.getAttributeAsString(Concordance.TRUTH_STATUS_VCF_ATTRIBUTE, "expected_default"));
+            Assert.assertEquals(outputVariant.getAttributeAsString(GATKSVVCFConstants.STRATUM_INFO_KEY, ""), SVStratify.DEFAULT_STRATUM);
+            if (outputVariant.getAttributeAsString(Concordance.TRUTH_STATUS_VCF_ATTRIBUTE, "").equals(ConcordanceState.TRUE_POSITIVE.getAbbreviation())) {
+                numTP++;
+            }
             if (outputVariant.getID().equals("ref_panel_1kg.chr22.final_cleanup_DEL_chr22_1")) {
                 checkVariant(outputVariant, expectedVariant, "ref_panel_1kg_raw_00000062",
-                        268./312, 66./312, checkedVariantsSet);
+                        268./312, 66./312, 0.760, 0.760, 44001, 99, checkedVariantsSet);
             } else if (outputVariant.getID().equals("ref_panel_1kg.chr22.final_cleanup_DEL_chr22_140")) {
                 checkVariant(outputVariant, expectedVariant, "ref_panel_1kg_raw_000017fc",
-                        310./312, 3./312, checkedVariantsSet);
+                        310./312, 3./312, 1., 1., 0, 0, checkedVariantsSet);
             } else if (outputVariant.getID().equals("ref_panel_1kg.chr22.final_cleanup_INS_chr22_100")) {
                 checkVariant(outputVariant, expectedVariant, "ref_panel_1kg_raw_00001b78",
-                        1., 1./312, checkedVariantsSet);
+                        1., 1./312, 1., 1., 0, 0, checkedVariantsSet);
             }
         }
+        Assert.assertEquals(numTP, 1104);
         Assert.assertEquals(checkedVariantsSet.size(), 3);
         Assert.assertTrue(checkedVariantsSet.contains("ref_panel_1kg.chr22.final_cleanup_DEL_chr22_1"));
         Assert.assertTrue(checkedVariantsSet.contains("ref_panel_1kg.chr22.final_cleanup_DEL_chr22_140"));
         Assert.assertTrue(checkedVariantsSet.contains("ref_panel_1kg.chr22.final_cleanup_INS_chr22_100"));
+    }
+
+    @Test
+    public void testRefPanelStratified() {
+        final File output = createTempFile("concord", ".vcf.gz");
+        final String evalVcfPath = getToolTestDataDir() + "ref_panel_1kg.cleaned.gatk.chr22_chrY.vcf.gz";
+
+        /**
+         * Test file produced from raw standardized VCFs from manta, melt, wham, and cnv callers with SVCluster parameters:
+         * --algorithm SINGLE_LINKAGE
+         * --pesr-interval-overlap 0.9
+         * --pesr-breakend-window 50
+         */
+        final String truthVcfPath = getToolTestDataDir() + "ref_panel_1kg.raw_calls.chr22_chrY.vcf.gz";
+
+        final String clusteringConfigFile = getToolTestDataDir() + "../GroupedSVCluster/stratified_cluster_params.tsv";
+        final String stratifyConfigFile = getToolTestDataDir() + "../GroupedSVCluster/stratified_cluster_strata.tsv";
+        final String segdupFile = getToolTestDataDir() + "../SVStratify/hg38.SegDup.chr22.bed";
+        final String segdupName = "SD";
+        final String repeatmaskerFile = getToolTestDataDir() + "../SVStratify/hg38.RM.chr22_subsampled.bed";
+        final String repeatmaskerName = "RM";
+
+        final ArgumentsBuilder args = new ArgumentsBuilder()
+                .addOutput(output)
+                .add(StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, GATKBaseTest.FULL_HG38_DICT)
+                .add(SVClusterEngineArgumentsCollection.DEPTH_SAMPLE_OVERLAP_FRACTION_NAME, 0)
+                .add(SVClusterEngineArgumentsCollection.DEPTH_INTERVAL_OVERLAP_FRACTION_NAME, 0.5)
+                .add(SVClusterEngineArgumentsCollection.DEPTH_BREAKEND_WINDOW_NAME, 10000000)
+                .add(SVClusterEngineArgumentsCollection.MIXED_SAMPLE_OVERLAP_FRACTION_NAME, 0)
+                .add(SVClusterEngineArgumentsCollection.MIXED_INTERVAL_OVERLAP_FRACTION_NAME, 0.1)
+                .add(SVClusterEngineArgumentsCollection.MIXED_BREAKEND_WINDOW_NAME, 2000)
+                .add(SVClusterEngineArgumentsCollection.PESR_SAMPLE_OVERLAP_FRACTION_NAME, 0)
+                .add(SVClusterEngineArgumentsCollection.PESR_INTERVAL_OVERLAP_FRACTION_NAME, 0.1)
+                .add(SVClusterEngineArgumentsCollection.PESR_BREAKEND_WINDOW_NAME, 500)
+                .add(AbstractConcordanceWalker.TRUTH_VARIANTS_LONG_NAME, truthVcfPath)
+                .add(AbstractConcordanceWalker.EVAL_VARIANTS_SHORT_NAME, evalVcfPath)
+                .add(GroupedSVCluster.CLUSTERING_CONFIG_FILE_LONG_NAME, clusteringConfigFile)
+                .add(SVStratificationEngineArgumentsCollection.STRATIFY_CONFIG_FILE_LONG_NAME, stratifyConfigFile)
+                .add(SVStratificationEngineArgumentsCollection.TRACK_NAME_FILE_LONG_NAME, segdupName)
+                .add(SVStratificationEngineArgumentsCollection.TRACK_INTERVAL_FILE_LONG_NAME, segdupFile)
+                .add(SVStratificationEngineArgumentsCollection.TRACK_NAME_FILE_LONG_NAME, repeatmaskerName)
+                .add(SVStratificationEngineArgumentsCollection.TRACK_INTERVAL_FILE_LONG_NAME, repeatmaskerFile);
+
+        runCommandLine(args, SVConcordance.class.getSimpleName());
+
+        final Pair<VCFHeader, List<VariantContext>> outputVcf = VariantContextTestUtils.readEntireVCFIntoMemory(output.getAbsolutePath());
+        final List<SVCallRecord> inputEvalVariants = VariantContextTestUtils.readEntireVCFIntoMemory(evalVcfPath).getValue()
+                .stream().map(v -> SVCallRecordUtils.create(v, SVTestUtils.hg38Dict)).collect(Collectors.toList());
+        final Comparator<VariantContext> idComparator = Comparator.comparing(VariantContext::getID);
+        final List<VariantContext> outputVariants = outputVcf.getValue().stream().sorted(idComparator).collect(Collectors.toList());
+        final List<VariantContext> idSortedInputEvalVariants = inputEvalVariants.stream()
+                .map(SVCallRecordUtils::getVariantBuilder)
+                .map(VariantContextBuilder::make)
+                .sorted(idComparator)
+                .collect(Collectors.toList());
+
+        Assert.assertEquals(outputVariants.size(), inputEvalVariants.size());
+        int numTP = 0;
+        final Set<String> checkedVariantsSet = new HashSet<>();
+        final Map<String, Integer> strataCounts = new HashMap<>();
+        for (int i = 0; i < outputVariants.size(); i++) {
+            final VariantContext outputVariant = outputVariants.get(i);
+            if (outputVariant.getAttributeAsString(Concordance.TRUTH_STATUS_VCF_ATTRIBUTE, "").equals(ConcordanceState.TRUE_POSITIVE.getAbbreviation())) {
+                numTP++;
+            }
+            final List<String> strata = outputVariant.getAttributeAsStringList(GATKSVVCFConstants.STRATUM_INFO_KEY, "");
+            for (final String stratum: strata) {
+                strataCounts.putIfAbsent(stratum, 0);
+                strataCounts.put(stratum, strataCounts.get(stratum) + 1);
+            }
+            Assert.assertEquals(outputVariant.getID(), idSortedInputEvalVariants.get(i).getID());
+            if (outputVariant.getID().equals("ref_panel_1kg.chr22.final_cleanup_DEL_chr22_12")) {
+                Assert.assertEquals(outputVariant.getAttributeAsStringList(GATKSVVCFConstants.STRATUM_INFO_KEY, ""),  Lists.newArrayList("DEL_50_5k_SD_RM", SVStratify.DEFAULT_STRATUM));
+                checkedVariantsSet.add(outputVariant.getID());
+                checkVariantOverlapMetrics(outputVariant, 0.659, 0.889, 46, 31);
+            } else if (outputVariant.getID().equals("ref_panel_1kg.chr22.final_cleanup_INS_chr22_36")) {
+                Assert.assertEquals(outputVariant.getAttributeAsStringList(GATKSVVCFConstants.STRATUM_INFO_KEY, ""), Lists.newArrayList("INS_small_SD", SVStratify.DEFAULT_STRATUM));
+                checkedVariantsSet.add(outputVariant.getID());
+                checkVariantOverlapMetrics(outputVariant, null, null, null, null);
+            }
+        }
+        Assert.assertEquals(checkedVariantsSet.size(), 2);
+        Assert.assertTrue(checkedVariantsSet.contains("ref_panel_1kg.chr22.final_cleanup_DEL_chr22_12"));
+        Assert.assertTrue(checkedVariantsSet.contains("ref_panel_1kg.chr22.final_cleanup_INS_chr22_36"));
+        Assert.assertEquals(numTP, 1104);
+        Assert.assertEquals(strataCounts.size(), 3);
+        Assert.assertEquals(strataCounts.get("INS_small_SD"), 27);
+        Assert.assertEquals(strataCounts.get("DEL_50_5k_SD_RM"), 93);
     }
 
     private static void checkTruthVariantId(final VariantContext actual, final VariantContext expected) {
@@ -152,7 +250,7 @@ public class SVConcordanceIntegrationTest extends CommandLineProgramTest {
 
     private static void checkVariant(final VariantContext actual, final VariantContext expected,
                                      final String expectedTruthId, final double expectedGenotypeConcordance,
-                                     final double expectedAF,
+                                     final double expectedAF, final double reciprocalOverlap, final double sizeSimliarity, final int startDist, final int endDist,
                                      final Set<String> checkedVariantsSet) {
         Assert.assertFalse(checkedVariantsSet.contains(actual.getID()));
         checkedVariantsSet.add(actual.getID());
@@ -163,7 +261,34 @@ public class SVConcordanceIntegrationTest extends CommandLineProgramTest {
         MathUtilsUnitTest.assertEqualsDoubleSmart(actual.getAttributeAsDouble(GATKSVVCFConstants.GENOTYPE_CONCORDANCE_INFO, -1.), expected.getAttributeAsDouble(GATKSVVCFConstants.GENOTYPE_CONCORDANCE_INFO, -1.), TOLERANCE);
         MathUtilsUnitTest.assertEqualsDoubleSmart(expected.getAttributeAsDouble(GATKSVVCFConstants.GENOTYPE_CONCORDANCE_INFO, -1.), expected.getAttributeAsDouble(GATKSVVCFConstants.GENOTYPE_CONCORDANCE_INFO, -1.), TOLERANCE);
         MathUtilsUnitTest.assertEqualsDoubleSmart(actual.getAttributeAsDouble(VCFConstants.ALLELE_FREQUENCY_KEY, -1.), expectedAF, TOLERANCE);
+        checkVariantOverlapMetrics(actual, reciprocalOverlap, sizeSimliarity, startDist, endDist);
         MathUtilsUnitTest.assertEqualsDoubleSmart(expected.getAttributeAsDoubleList(VCFConstants.ALLELE_FREQUENCY_KEY, -1.).get(0).doubleValue(), expectedAF, TOLERANCE);
+    }
+
+    private static void checkVariantOverlapMetrics(final VariantContext actual, final Double reciprocalOverlap, final Double sizeSimliarity, final Integer startDist, final Integer endDist) {
+        checkDoubleAttributeMaybeNull(actual, GATKSVVCFConstants.TRUTH_RECIPROCAL_OVERLAP_INFO, reciprocalOverlap);
+        checkDoubleAttributeMaybeNull(actual, GATKSVVCFConstants.TRUTH_SIZE_SIMILARITY_INFO, sizeSimliarity);
+        checkIntegerAttributeMaybeNull(actual, GATKSVVCFConstants.TRUTH_DISTANCE_START_INFO, startDist);
+        checkIntegerAttributeMaybeNull(actual, GATKSVVCFConstants.TRUTH_DISTANCE_END_INFO, endDist);
+    }
+
+    private static void checkDoubleAttributeMaybeNull(final VariantContext actualVariant, final String key, final Double expectedValue) {
+        final Object actual = actualVariant.getAttribute(key);
+        if (expectedValue == null) {
+            Assert.assertNull(actual);
+        } else if (actual == null) {
+            Assert.assertNull(expectedValue);
+        } else {
+            MathUtilsUnitTest.assertEqualsDoubleSmart(Double.valueOf((String)actual), expectedValue, TOLERANCE);
+        }
+    }
+
+    private static void checkIntegerAttributeMaybeNull(final VariantContext actualVariant, final String key, final Integer expectedValue) {
+        if (expectedValue == null) {
+            Assert.assertNull(actualVariant.getAttribute(key));
+        } else {
+            Assert.assertEquals(actualVariant.getAttributeAsInt(key, -1), expectedValue.intValue());
+        }
     }
 
     @Test
@@ -191,6 +316,100 @@ public class SVConcordanceIntegrationTest extends CommandLineProgramTest {
                 .add(SVClusterEngineArgumentsCollection.PESR_BREAKEND_WINDOW_NAME, 500)
                 .add(AbstractConcordanceWalker.TRUTH_VARIANTS_LONG_NAME, vcfPath)
                 .add(AbstractConcordanceWalker.EVAL_VARIANTS_SHORT_NAME, vcfPath);
+
+        runCommandLine(args, SVConcordance.class.getSimpleName());
+
+        final Pair<VCFHeader, List<VariantContext>> outputVcf = VariantContextTestUtils.readEntireVCFIntoMemory(output.getAbsolutePath());
+
+        final SAMSequenceDictionary dictionary = SVTestUtils.hg38Dict;
+        final ClusteringParameters depthParameters = ClusteringParameters.createDepthParameters(0.5, 0, 10000000, 0);
+        final ClusteringParameters mixedParameters = ClusteringParameters.createMixedParameters(0.1, 0, 2000, 0);
+        final ClusteringParameters pesrParameters = ClusteringParameters.createPesrParameters(0.1, 0, 500, 0);
+        final SVConcordanceLinkage linkage = new SVConcordanceLinkage(dictionary);
+        linkage.setDepthOnlyParams(depthParameters);
+        linkage.setMixedParams(mixedParameters);
+        linkage.setEvidenceParams(pesrParameters);
+
+        final Comparator<VariantContext> idComparator = Comparator.comparing(VariantContext::getID);
+        final List<VariantContext> inputVariants = VariantContextTestUtils.readEntireVCFIntoMemory(vcfPath).getValue()
+                .stream()
+                .sorted(idComparator)
+                .collect(Collectors.toList());
+        final List<VariantContext> outputVariants = outputVcf.getValue().stream().sorted(idComparator).collect(Collectors.toList());
+
+        Assert.assertEquals(outputVariants.size(), inputVariants.size());
+        for (int i = 0; i < outputVariants.size(); i++) {
+            final VariantContext outputVariant = outputVariants.get(i);
+            final VariantContext expectedVariant = inputVariants.get(i);
+            Assert.assertEquals(outputVariant.getID(), expectedVariant.getID());
+            Assert.assertEquals(outputVariant.getContig(), expectedVariant.getContig());
+            Assert.assertEquals(outputVariant.getStart(), expectedVariant.getStart());
+            Assert.assertEquals(outputVariant.getEnd(), expectedVariant.getEnd());
+            Assert.assertEquals(outputVariant.getAlleles(), expectedVariant.getAlleles());
+            Assert.assertEquals(outputVariant.getFilters(), expectedVariant.getFilters());
+            Assert.assertEquals(outputVariant.getPhredScaledQual(), expectedVariant.getPhredScaledQual());
+            final String svtype = outputVariant.getAttributeAsString(GATKSVVCFConstants.SVTYPE, "test_default");
+            Assert.assertEquals(svtype, expectedVariant.getAttributeAsString(GATKSVVCFConstants.SVTYPE, "expected_default"));
+            // check the variant matched itself with perfect concordance
+            Assert.assertEquals(outputVariant.getAttributeAsString(Concordance.TRUTH_STATUS_VCF_ATTRIBUTE, "test_default"), ConcordanceState.TRUE_POSITIVE.getAbbreviation());
+            Assert.assertEquals(outputVariant.getAttributeAsString(GATKSVVCFConstants.TRUTH_VARIANT_ID_INFO, ""), outputVariant.getID());
+            if (svtype.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.BND.name()) && !outputVariant.getContig().equals(outputVariant.getAttribute(GATKSVVCFConstants.CONTIG2_ATTRIBUTE))) {
+                // interchromosomal BNDs do not have reciprocal overlap or size similarity
+                checkVariantOverlapMetrics(outputVariant, null, null, 0, 0);
+            } else if (svtype.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.CPX.name())) {
+                // Unassigned for CPX types
+                checkVariantOverlapMetrics(outputVariant, null, null, null, null);
+            } else {
+                // otherwise we expect a perfect match
+                checkVariantOverlapMetrics(outputVariant, 1., 1., 0, 0);
+
+            }
+            if (svtype.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.CNV.toString())) {
+                MathUtilsUnitTest.assertEqualsDoubleSmart(outputVariant.getAttributeAsDouble(GATKSVVCFConstants.COPY_NUMBER_CONCORDANCE_INFO, -1.), 1.0, TOLERANCE);
+            } else {
+                MathUtilsUnitTest.assertEqualsDoubleSmart(outputVariant.getAttributeAsDouble(GATKSVVCFConstants.GENOTYPE_CONCORDANCE_INFO, -1.), 1.0, TOLERANCE);
+            }
+        }
+    }
+
+    @Test
+    public void testSelfStratified() {
+
+        // Run a vcf against itself and check that every variant matched itself
+
+        final File output = createTempFile("concord", ".vcf.gz");
+        final String vcfPath = getToolTestDataDir() + "ref_panel_1kg.cleaned.gatk.chr22_chrY.vcf.gz";
+
+        final String clusteringConfigFile = getToolTestDataDir() + "../GroupedSVCluster/stratified_cluster_params.tsv";
+        final String stratifyConfigFile = getToolTestDataDir() + "../GroupedSVCluster/stratified_cluster_strata.tsv";
+        final String segdupFile = getToolTestDataDir() + "../SVStratify/hg38.SegDup.chr22.bed";
+        final String segdupName = "SD";
+        final String repeatmaskerFile = getToolTestDataDir() + "../SVStratify/hg38.RM.chr22_subsampled.bed";
+        final String repeatmaskerName = "RM";
+
+        final ArgumentsBuilder args = new ArgumentsBuilder()
+                .addOutput(output)
+                .add(StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, GATKBaseTest.FULL_HG38_DICT)
+                .add(SVClusterEngineArgumentsCollection.DEPTH_SAMPLE_OVERLAP_FRACTION_NAME, 0)
+                .add(SVClusterEngineArgumentsCollection.DEPTH_INTERVAL_OVERLAP_FRACTION_NAME, 0.5)
+                .add(SVClusterEngineArgumentsCollection.DEPTH_SIZE_SIMILARITY_NAME, 0)
+                .add(SVClusterEngineArgumentsCollection.DEPTH_BREAKEND_WINDOW_NAME, 10000000)
+                .add(SVClusterEngineArgumentsCollection.MIXED_SAMPLE_OVERLAP_FRACTION_NAME, 0)
+                .add(SVClusterEngineArgumentsCollection.MIXED_INTERVAL_OVERLAP_FRACTION_NAME, 0.1)
+                .add(SVClusterEngineArgumentsCollection.MIXED_SIZE_SIMILARITY_NAME, 0)
+                .add(SVClusterEngineArgumentsCollection.MIXED_BREAKEND_WINDOW_NAME, 2000)
+                .add(SVClusterEngineArgumentsCollection.PESR_SAMPLE_OVERLAP_FRACTION_NAME, 0)
+                .add(SVClusterEngineArgumentsCollection.PESR_INTERVAL_OVERLAP_FRACTION_NAME, 0.1)
+                .add(SVClusterEngineArgumentsCollection.PESR_SIZE_SIMILARITY_NAME, 0)
+                .add(SVClusterEngineArgumentsCollection.PESR_BREAKEND_WINDOW_NAME, 500)
+                .add(AbstractConcordanceWalker.TRUTH_VARIANTS_LONG_NAME, vcfPath)
+                .add(AbstractConcordanceWalker.EVAL_VARIANTS_SHORT_NAME, vcfPath)
+                .add(GroupedSVCluster.CLUSTERING_CONFIG_FILE_LONG_NAME, clusteringConfigFile)
+                .add(SVStratificationEngineArgumentsCollection.STRATIFY_CONFIG_FILE_LONG_NAME, stratifyConfigFile)
+                .add(SVStratificationEngineArgumentsCollection.TRACK_NAME_FILE_LONG_NAME, segdupName)
+                .add(SVStratificationEngineArgumentsCollection.TRACK_INTERVAL_FILE_LONG_NAME, segdupFile)
+                .add(SVStratificationEngineArgumentsCollection.TRACK_NAME_FILE_LONG_NAME, repeatmaskerName)
+                .add(SVStratificationEngineArgumentsCollection.TRACK_INTERVAL_FILE_LONG_NAME, repeatmaskerFile);
 
         runCommandLine(args, SVConcordance.class.getSimpleName());
 
@@ -369,25 +588,5 @@ public class SVConcordanceIntegrationTest extends CommandLineProgramTest {
                 .add(AbstractConcordanceWalker.EVAL_VARIANTS_SHORT_NAME, evalVcfPath);
 
         runCommandLine(args, SVConcordance.class.getSimpleName());
-    }
-
-    @Test
-    public void testSelfUnsorted() {
-
-        // Run a vcf against itself but don't sort the output
-
-        final File output = createTempFile("concord", ".vcf");
-        final String evalVcfPath = getToolTestDataDir() + "ref_panel_1kg.cleaned.gatk.chr22_chrY.vcf.gz";
-        final String truthVcfPath = getToolTestDataDir() + "ref_panel_1kg.cleaned.gatk.chr22_chrY.vcf.gz";
-
-        final ArgumentsBuilder args = new ArgumentsBuilder()
-                .addOutput(output)
-                .add(StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, GATKBaseTest.FULL_HG38_DICT)
-                .add(AbstractConcordanceWalker.EVAL_VARIANTS_LONG_NAME, evalVcfPath)
-                .add(AbstractConcordanceWalker.TRUTH_VARIANTS_LONG_NAME, truthVcfPath)
-                .add(SVConcordance.UNSORTED_OUTPUT_LONG_NAME, true);
-
-        runCommandLine(args, SVConcordance.class.getSimpleName());
-        assertPerfectConcordance(output, evalVcfPath);
     }
 }


### PR DESCRIPTION
Adds variant stratification functionality, similar to `GroupedSVCluster`, to `SVConcordance`. This allows one to assign different clustering criteria to variants depending on the "eval" variant's type, size, and reference context. Unlike `GroupedSVCluster`, however, `SVConcordance` does not enforce mutual exclusivity among stratification groups. From the tool doc:
```
 * This tool also allows supports stratification of SVs into groups with specified matching criteria including SV type,
 * size range, and interval overlap. Please see the {@link GroupedSVCluster} tool documentation for further details
 * on how to specify stratification groups.
 *
 * Note that unlike {@link GroupedSVCluster}, this tool allows any variant to
 * match more than one stratification group. If this occurs, groups will be prioritized by their ordering in the input
 * stratification table, with groups appearing first receiving higher priority. While all matching groups will
 * be listed in the STRAT INFO field, the variant ID pertaining to the highest-priority group will be populated in
 * the TRUTH_VID field (groups with no matching variant are ignored). It is therefore recommended that the groups with
 * the most specific clustering criteria be listed as higher priority.
 *
 * The "default" stratification group, with clustering parameters specified directly through the clustering program
 * arguments (e.g. --depth-breakend-window, --pesr-interval-overlap, etc.), is always present and given lowest priority.
```

In addition, variants are now annotated with the following INFO fields:
- `STRAT`
- `TRUTH_RECIPROCAL_OVERLAP`
- `TRUTH_SIZE_SIMILARITY`
- `TRUTH_DISTANCE_START`
- `TRUTH_DISTANCE_END`

Minor:
- `SVConcordance` now uses a `SortingCollection` to emit records in sorted order
- Corrects `SVStatification` -> `SVStratification` class name typo