### PR TITLE
Vs 1616

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -174,7 +174,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             -
+             - VS-1616
          tags:
              - /.*/
    - name: GvsImportGenomes

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -174,7 +174,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - 
+             -
          tags:
              - /.*/
    - name: GvsImportGenomes

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -174,6 +174,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - 
          tags:
              - /.*/
    - name: GvsImportGenomes

--- a/scripts/variantstore/scripts/convert_weight_file_CSV_to_bed.py
+++ b/scripts/variantstore/scripts/convert_weight_file_CSV_to_bed.py
@@ -34,7 +34,7 @@ def load_contig_mapping(mapping_file):
 
 # Load the contig mapping file if provided, else use standard hg38 mappings
 if args.mapping_file:
-    contig_map = load_contig_mapping(args.mappingfile)
+    contig_map = load_contig_mapping(args.mapping_file)
 else:
     contig_map = hg38_contig_map
 

--- a/scripts/variantstore/scripts/convert_weight_file_CSV_to_bed.py
+++ b/scripts/variantstore/scripts/convert_weight_file_CSV_to_bed.py
@@ -10,7 +10,7 @@ argParser = argparse.ArgumentParser()
 argParser.add_argument("-s", "--bin-size", help="size of the bins in kb", type=int, default=1)
 argParser.add_argument("-i", "--infile", help="bed input file", type=str, default="49K_vet_weight_1k.csv")
 argParser.add_argument("-o", "--outfile", help="bed output file", type=str, default="gvs_vet_weights_1kb.bed")
-argParser.add_argument("-m", "--mappingfile", help="chromosome to integer mapping file", type=str)
+argParser.add_argument("-m", "--mapping-file", help="chromosome to integer mapping file", type=str)
 
 
 args = argParser.parse_args()
@@ -33,7 +33,7 @@ def load_contig_mapping(mapping_file):
     return contig_map
 
 # Load the contig mapping file if provided, else use standard hg38 mappings
-if args.mappingfile:
+if args.mapping_file:
     contig_map = load_contig_mapping(args.mappingfile)
 else:
     contig_map = hg38_contig_map

--- a/scripts/variantstore/scripts/convert_weight_file_CSV_to_bed.py
+++ b/scripts/variantstore/scripts/convert_weight_file_CSV_to_bed.py
@@ -20,7 +20,7 @@ binsize_kb = args.bin_size
 infile = args.infile
 outfile = args.outfile
 
-# Funtion to parse the contig mappings file
+# Function to parse the contig mappings file
 def load_contig_mapping(mapping_file):
     contig_map = {}
     with open(mapping_file, mode='r') as file:

--- a/scripts/variantstore/scripts/convert_weight_file_CSV_to_bed.py
+++ b/scripts/variantstore/scripts/convert_weight_file_CSV_to_bed.py
@@ -1,13 +1,16 @@
 import argparse
 import pandas as pd
+import csv
 
 location_offset = 1000000000000
+hg38_contig_map = {1: 'chr1', 2: 'chr2', 3: 'chr3', 4: 'chr4', 5: 'chr5', 6: 'chr6', 7: 'chr7', 8: 'chr8', 9: 'chr9', 10: 'chr10', 11: 'chr11', 12: 'chr12', 13: 'chr13', 14: 'chr14', 15: 'chr15', 16: 'chr16', 17: 'chr17', 18: 'chr18', 19: 'chr19', 20: 'chr20', 21: 'chr21', 22: 'chr22', 23: 'chrX', 24: 'chrY'}
 
 argParser = argparse.ArgumentParser()
 
 argParser.add_argument("-s", "--bin-size", help="size of the bins in kb", type=int, default=1)
 argParser.add_argument("-i", "--infile", help="bed input file", type=str, default="49K_vet_weight_1k.csv")
 argParser.add_argument("-o", "--outfile", help="bed output file", type=str, default="gvs_vet_weights_1kb.bed")
+argParser.add_argument("-m", "--mappingfile", help="chromosome to integer mapping file", type=str)
 
 
 args = argParser.parse_args()
@@ -17,11 +20,27 @@ binsize_kb = args.bin_size
 infile = args.infile
 outfile = args.outfile
 
-print(f"Input file is {infile}")
+# Funtion to parse the contig mappings file
+def load_contig_mapping(mapping_file):
+    contig_map = {}
+    with open(mapping_file, mode='r') as file:
+        reader = csv.reader(file, delimiter='\t')
+        for row in reader:
+            if len(row) == 2:
+                contig_map[int(row[1])] = row[0]
+            else:
+                raise ValueError(f"Invalid line format: {row}")
+    return contig_map
+
+# Load the contig mapping file if provided, else use standard hg38 mappings
+if args.mappingfile:
+    contig_map = load_contig_mapping(args.mappingfile)
+else:
+    contig_map = hg38_contig_map
 
 w = pd.read_csv(infile, dtype={'bin': int, 'entries':int})
 
-w['contig'] = "chr" + (w['bin'].astype(int) / location_offset).astype(int).astype(str).str.replace("23","X").replace("24","Y")
+w['contig'] = (w['bin'].astype(int) / location_offset).astype(int).map(contig_map)
 w['start_position'] = w['bin'].astype(int) - (w['bin'] / location_offset).astype(int) * location_offset
 w['end_position'] = w['start_position'] + binsize_kb*1000
 w['name'] = "."

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -167,7 +167,7 @@ workflow GvsExtractCallset {
   call Utils.SplitIntervals {
     input:
       intervals = effective_interval_list,
-      ref_fasta = GetReference.reference.reference_fasta,
+      ref_fasta = extract_reference,
       interval_weights_bed = ScaleXYBedValues.xy_scaled_bed,
       intervals_file_extension = intervals_file_extension,
       scatter_count = effective_scatter_count,

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -459,7 +459,7 @@ task ExtractTask {
         --vet-ranges-extract-fq-table ~{fq_ranges_cohort_vet_extract_table} \
         ~{"--vet-ranges-extract-table-version " + vet_extract_table_version} \
         --ref-ranges-extract-fq-table ~{fq_ranges_cohort_ref_extract_table} \
-        --ref-version 38 \
+        --ref-version CUSTOM \
         -R ~{reference} \
         -O ~{output_file} \
         --local-sort-max-records-in-ram ~{local_sort_max_records_in_ram} \

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -416,6 +416,7 @@ task ExtractTask {
   String cost_observability_line = if (write_cost_to_db == true) then "--cost-observability-tablename ~{cost_observability_tablename}" else ""
 
   String inferred_reference_state = if (drop_state == "NONE") then "ZERO" else drop_state
+  String ref_version = if (defined(custom_contig_mapping)) then "CUSTOM" else "38"
 
   command <<<
     # Prepend date, time and pwd to xtrace log entries.
@@ -459,7 +460,7 @@ task ExtractTask {
         --vet-ranges-extract-fq-table ~{fq_ranges_cohort_vet_extract_table} \
         ~{"--vet-ranges-extract-table-version " + vet_extract_table_version} \
         --ref-ranges-extract-fq-table ~{fq_ranges_cohort_ref_extract_table} \
-        --ref-version CUSTOM \
+        --ref-version ~{ref_version} \
         -R ~{reference} \
         -O ~{output_file} \
         --local-sort-max-records-in-ram ~{local_sort_max_records_in_ram} \

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -33,6 +33,10 @@ workflow GvsExtractCallset {
     File? interval_list
     File interval_weights_bed = "gs://gvs_quickstart_storage/weights/gvs_full_vet_weights_1kb_padded_orig.bed"
 
+    # for supporting custom references... for now. Later map the references and use the reference_name above
+    File? custom_reference
+    File? custom_contig_mapping
+
     File? target_interval_list
 
     String? basic_docker
@@ -106,7 +110,7 @@ workflow GvsExtractCallset {
 
   File effective_interval_list = select_first([interval_list, GetReference.reference.wgs_calling_interval_list])
 
-  call Utils.ScaleXYBedValues {
+  call Utils.ScaleXYBegdValues {
     input:
       interval_weights_bed = interval_weights_bed,
       x_bed_weight_scaling = x_bed_weight_scaling,

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -178,14 +178,13 @@ workflow GvsExtractCallset {
       gatk_override = gatk_override,
   }
 
-  call Utils.GetBQTableLastModifiedDatetime as FilterSetInfoTimestamp {
-    input:
-      project_id = project_id,
-      fq_table = "~{fq_filter_set_info_table}",
-      cloud_sdk_docker = effective_cloud_sdk_docker,
-  }
-
   if ( !do_not_filter_override ) {
+    call Utils.GetBQTableLastModifiedDatetime as FilterSetInfoTimestamp {
+      input:
+        project_id = project_id,
+        fq_table = "~{fq_filter_set_info_table}",
+        cloud_sdk_docker = effective_cloud_sdk_docker,
+    }
     call Utils.ValidateFilterSetName {
       input:
         project_id = query_project,

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -156,8 +156,8 @@ workflow GvsExtractCallset {
                                           else if effective_scatter_count <= 500 then 17 + extract_overhead_memory_override_gib
                                                else 9 + extract_overhead_memory_override_gib
 
-  # support a custom reference if one is provided
-  File extract_reference = if defined(custom_reference) then custom_reference else GetReference.reference.reference_fasta
+  # support a custom reference if one is provided.  There's gotta be a cleaner way
+  File extract_reference = if defined(custom_reference) then "~{custom_reference}" else GetReference.reference.reference_fasta
 
   # WDL 1.0 trick to set a variable ('none') to be undefined.
   if (false) {

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -156,8 +156,8 @@ workflow GvsExtractCallset {
                                           else if effective_scatter_count <= 500 then 17 + extract_overhead_memory_override_gib
                                                else 9 + extract_overhead_memory_override_gib
 
-  # support a custom reference if one is provided.  There's gotta be a cleaner way
-  File extract_reference = if defined(custom_reference) then "~{custom_reference}" else GetReference.reference.reference_fasta
+  # support a custom reference if one is provided.
+  File extract_reference = select_first([custom_reference,  GetReference.reference.reference_fasta])
 
   # WDL 1.0 trick to set a variable ('none') to be undefined.
   if (false) {

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -110,7 +110,7 @@ workflow GvsExtractCallset {
 
   File effective_interval_list = select_first([interval_list, GetReference.reference.wgs_calling_interval_list])
 
-  call Utils.ScaleXYBegdValues {
+  call Utils.ScaleXYBedValues {
     input:
       interval_weights_bed = interval_weights_bed,
       x_bed_weight_scaling = x_bed_weight_scaling,

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/ExtractTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/ExtractTool.java
@@ -133,7 +133,7 @@ public abstract class ExtractTool extends GATKTool {
         if (refVersion.equals("CUSTOM")) {
             // Look for the contig mapping files
             if (contigMappingFile == null) {
-                throw new IllegalArgumentException("Contig mapping file must be provided when using non-human references");
+                throw new IllegalArgumentException("Contig mapping file must be provided when using custom references");
             }
 
             ChromosomeEnum.setCustomContigMap(SchemaUtils.loadContigMappingFile(contigMappingFile));

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/ExtractTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/ExtractTool.java
@@ -141,7 +141,5 @@ public abstract class ExtractTool extends GATKTool {
             // Set reference version -- TODO remove this in the future, also, can we get ref version from the header?
             ChromosomeEnum.setRefVersion(refVersion);
         }
-
-//        ChromosomeEnum.setRefVersion(refVersion);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/ExtractTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/ExtractTool.java
@@ -79,6 +79,13 @@ public abstract class ExtractTool extends GATKTool {
     )
     protected Long maxLocation = null;
 
+    @Argument(
+            fullName = "contig-mapping-file",
+            doc = "Path to the contig mapping file",
+            optional = true
+    )
+    public String contigMappingFile = null;
+
     @Override
     public boolean requiresReference() {
         return true;
@@ -122,6 +129,19 @@ public abstract class ExtractTool extends GATKTool {
         //TODO verify what we really need here
         annotationEngine = new VariantAnnotatorEngine(makeVariantAnnotations(), null, Collections.emptyList(), false, false);
 
-        ChromosomeEnum.setRefVersion(refVersion);
+
+        if (refVersion.equals("CUSTOM")) {
+            // Look for the contig mapping files
+            if (contigMappingFile == null) {
+                throw new IllegalArgumentException("Contig mapping file must be provided when using non-human references");
+            }
+
+            ChromosomeEnum.setCustomContigMap(SchemaUtils.loadContigMappingFile(contigMappingFile));
+        } else {
+            // Set reference version -- TODO remove this in the future, also, can we get ref version from the header?
+            ChromosomeEnum.setRefVersion(refVersion);
+        }
+
+//        ChromosomeEnum.setRefVersion(refVersion);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/SchemaUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/SchemaUtils.java
@@ -3,9 +3,10 @@ package org.broadinstitute.hellbender.tools.gvs.common;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.util.Utf8;
 
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.*;
 
 public class SchemaUtils {
 
@@ -142,5 +143,27 @@ public class SchemaUtils {
         }
         return retVal;
     };
+
+    public static Map<String, Integer> loadContigMappingFile(String contigMappingFilePath) {
+        Map<String, Integer> contigMappings = new HashMap<>();
+
+        try (BufferedReader br = new BufferedReader(new FileReader(contigMappingFilePath))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                String[] parts = line.split("\t");
+                if (parts.length == 2) {
+                    String contig = parts[0];
+                    Integer id = Integer.parseInt(parts[1]);
+                    contigMappings.put(contig, id);
+                } else {
+                    throw new IllegalArgumentException("Invalid line format: " + line);
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Error reading contig mapping file", e);
+        }
+
+        return contigMappings;
+    }
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/SchemaUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/SchemaUtils.java
@@ -98,7 +98,7 @@ public class SchemaUtils {
     public static final long chromAdjustment = 1000000000000L;
 
     public static long encodeLocation(String chrom, int position) {
-        int chromosomeIndex = ChromosomeEnum.integerValueOfContig(chrom);
+        long chromosomeIndex = ChromosomeEnum.integerValueOfContig(chrom);
         return (long) chromosomeIndex * chromAdjustment + (long) position;
     }
 
@@ -110,7 +110,7 @@ public class SchemaUtils {
         Next 4 - state (16 values)
      */
     public static long encodeCompressedRefBlock(String chrom, long position, long length, long stateAsInt) {
-        int chromosomeIndex = ChromosomeEnum.integerValueOfContig(chrom);
+        long chromosomeIndex = ChromosomeEnum.integerValueOfContig(chrom);
         long packedBytes = ((0xFFFF & chromosomeIndex) << 48) |
                 ((0xFFFFFFFF & position) << 16) |
                 ((0xFFF & length) << 4) |

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/SchemaUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/SchemaUtils.java
@@ -99,7 +99,7 @@ public class SchemaUtils {
 
     public static long encodeLocation(String chrom, int position) {
         long chromosomeIndex = ChromosomeEnum.integerValueOfContig(chrom);
-        return (long) chromosomeIndex * chromAdjustment + (long) position;
+        return chromosomeIndex * chromAdjustment + (long) position;
     }
 
     /*

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/CreateVariantIngestFiles.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/CreateVariantIngestFiles.java
@@ -216,7 +216,8 @@ public final class CreateVariantIngestFiles extends VariantWalker {
             if (contigMappingFile == null) {
                 throw new IllegalArgumentException("Contig mapping file must be provided when using non-human references");
             }
-            contigMappings = loadContigMappingFile(contigMappingFile);
+            contigMappings = SchemaUtils.loadContigMappingFile(contigMappingFile);
+
             ChromosomeEnum.setCustomContigMap(contigMappings);
         } else {
             // Set reference version -- TODO remove this in the future, also, can we get ref version from the header?
@@ -480,28 +481,6 @@ public final class CreateVariantIngestFiles extends VariantWalker {
             }
         }
         return seqDictionary;
-    }
-
-    private Map<String, Integer> loadContigMappingFile(String contigMappingFilePath) {
-        Map<String, Integer> contigMappings = new HashMap<>();
-
-        try (BufferedReader br = new BufferedReader(new FileReader(contigMappingFilePath))) {
-            String line;
-            while ((line = br.readLine()) != null) {
-                String[] parts = line.split("\t");
-                if (parts.length == 2) {
-                    String contig = parts[0];
-                    Integer id = Integer.parseInt(parts[1]);
-                    contigMappings.put(contig, id);
-                } else {
-                    throw new IllegalArgumentException("Invalid line format: " + line);
-                }
-            }
-        } catch (IOException e) {
-            throw new RuntimeException("Error reading contig mapping file", e);
-        }
-
-        return contigMappings;
     }
 
 }


### PR DESCRIPTION
Updating extract to support kitty calling.

1. Relocated custom mapping parsing to SchemaUtils
2. Tweaked WDLs to accept custom mapping files in extract
3. Some cleanup in python scripts involved in creating the weighted bed file used in extract to handle custom contigs.

My only surprise in this is around having to pull calling the task `Utils.GetBQTableLastModifiedDatetime as FilterSetInfoTimestamp` inside of the conditional branch for ignoring filtering data.  I figured it would have already been there, but it predictably failed on my first attempt to run it while ignoring filter data.
