### PR TITLE
Exclude logback-classic to fix logger configuration warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -167,6 +167,7 @@ if (versionOverridden) {
 
 configurations.configureEach {
     configurations*.exclude group: 'org.slf4j', module: 'slf4j-jdk14' //exclude this to prevent slf4j complaining about to many slf4j bindings
+    configurations*.exclude group: 'ch.qos.logback', module: 'logback-classic' //exclude this to prevent slf4j complaining about to many slf4j bindings
     configurations*.exclude group: 'com.google.guava', module: 'guava-jdk5'
     configurations*.exclude group: 'junit', module: 'junit'
 
@@ -358,7 +359,6 @@ dependencies {
         implementation 'org.apache.commons:commons-compress:1.26.0'
         implementation 'org.apache.ivy:ivy:2.5.2'
         implementation 'org.apache.commons:commons-text:1.10.0' because 'of https://nvd.nist.gov/vuln/detail/CVE-2022-42889'
-        implementation 'ch.qos.logback:logback-classic:1.5.13'
         implementation 'ch.qos.logback:logback-core:1.5.13'
         implementation 'org.apache.avro:avro:1.12.0'
         implementation 'io.airlift:aircompressor:0.27'


### PR DESCRIPTION
@KevinCLydon This should fix the warning you noticed.