### PR TITLE
Optional blacklist VCF to for labeling artifacts in Permutect weak-labeling mode

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/PermutectDatasetEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/PermutectDatasetEngine.java
@@ -136,10 +136,9 @@ public class PermutectDatasetEngine implements AutoCloseable {
 
         // the variant has already been annotated, so we have POPAF, AD, and in-PON status
         final double[] popafs = VariantContextGetters.getAttributeAsDoubleArray(vc, GATKVCFConstants.POPULATION_AF_KEY);
-        //final double[] altPopulationAFs = MathUtils.applyToArray(popafs, x -> Math.pow(10, -x ));
         final double[] tumorLods = Mutect2FilteringEngine.getTumorLogOdds(vc);
         // the PoN is NOT for calling! We only use it to assign some unlabeled data as artifacts in training
-        final boolean inPon = vc.hasAttribute(GATKVCFConstants.IN_PON_KEY);
+        final boolean isBlacklisted = vc.hasAttribute(GATKVCFConstants.IN_PON_KEY);
 
         // These ADs, which later make up the pre-downsampling depths, come from the genotype AD field applied by Mutect2.
         // This means that uninformative reads are not discarded; rather the expected non-integral ADs are rounded to
@@ -207,7 +206,7 @@ public class PermutectDatasetEngine implements AutoCloseable {
                     // unnecessary, and it gives the model too few high-AF variant examples on which to learn calibration.
                     unmatchedQueue.poll(); // just to pop off a value
                     altDownsampleMap.put(altAllele, random.nextInt(5, 20));
-                } else if (tumorLods[n] > 5.0 && inPon) {   // being in pon turns what would otherwise be unlabeled into artifact
+                } else if (tumorLods[n] > 5.0 && isBlacklisted) {   // being in pon turns what would otherwise be unlabeled into artifact
                     labels.add(Label.ARTIFACT);
                 } else if (tumorLods[n] > 4.0 && tumorAF < 0.3) {
                     labels.add(Label.UNLABELED);


### PR DESCRIPTION
@LeeTL1220 Small change for Permutect data here, usually irrelevant.  In most use cases, it will be possible to train with a GIAB truth VCF to label data.  When there is not, this PR allows users to optionally specify a PoN as a hint that unlabeled data are probably actually artifacts.

This should not in any way be interpreted as Permutect using a PoN for variant calling.  It has zero effect on our DREAM and Linseq evaluations, which use an NA12878 sample for training.