### PR TITLE
Fix Batch root detection for new symlink [VS-1647]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -326,7 +326,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - rc-vs-1576-avro-update
+             - vs_1647_batch_root_detection_fixups
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
@@ -630,14 +630,14 @@ task AnnotateVCF {
 
             # Find where the reference disk should have been mounted on this VM.  Note this is referred to as a "candidate
             # mount point" because we do not actually confirm this is a reference disk until the following code block.
-            if [[ -e /cromwell_root/gcs_delocalization.sh ]]
-            then
-              # PAPI mount points
-              CANDIDATE_MOUNT_POINT=$(lsblk | grep -v cromwell_root | sed -E -n 's!.*(/mnt/[a-f0-9]+).*!\1!p')
-            elif [[ -e /mnt/disks/cromwell_root/gcs_delocalization.sh ]]
+            if [[ -e /mnt/disks/cromwell_root/gcs_delocalization.sh ]]
             then
               # GCP Batch mount points
               CANDIDATE_MOUNT_POINT=$(lsblk | grep -v cromwell_root | sed -E -n 's!.*(/mnt/disks/[a-f0-9]+).*!\1!p')
+            elif [[ -e /cromwell_root/gcs_delocalization.sh ]]
+            then
+              # PAPI mount points
+              CANDIDATE_MOUNT_POINT=$(lsblk | grep -v cromwell_root | sed -E -n 's!.*(/mnt/[a-f0-9]+).*!\1!p')
             else
               >&2 echo "Could not find a mounted volume that looks like a reference disk, exiting."
               exit 1

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -78,12 +78,12 @@ task GetToolVersions {
     set -o errexit -o nounset -o pipefail -o xtrace
 
     # Scrape out various workflow / workspace info from the localization and delocalization scripts.
-    if [[ -e /cromwell_root/gcs_delocalization.sh ]]
-    then
-      CROMWELL_ROOT=/cromwell_root
-    elif [[ -e /mnt/disks/cromwell_root/gcs_delocalization.sh ]]
+    if [[ -e /mnt/disks/cromwell_root/gcs_delocalization.sh ]]
     then
       CROMWELL_ROOT=/mnt/disks/cromwell_root
+    elif [[ -e /cromwell_root/gcs_delocalization.sh ]]
+    then
+      CROMWELL_ROOT=/cromwell_root
     else
       echo "Could not find Cromwell root under /cromwell_root (PAPI v2) or /mnt/disks/cromwell_root (GCP Batch), exiting."
       exit 1


### PR DESCRIPTION
Cromwell now creates a `/cromwell_root` => `/mnt/disks/cromwell_root` symlink that was breaking our root detection, and VAT-making in general. Flip the order of the path checks to look for `/mnt/disks/cromwell_root` first.

Passing integration test [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration%20mcovarr/submission_history/433c41fa-befd-4315-8399-dbcca96d1f45).