### PR TITLE
Update parquet to 1.15.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -360,6 +360,7 @@ dependencies {
         implementation 'org.apache.commons:commons-compress:1.26.0'
         implementation 'org.apache.ivy:ivy:2.5.2'
         implementation 'org.apache.commons:commons-text:1.10.0' because 'of https://nvd.nist.gov/vuln/detail/CVE-2022-42889'
+        implementation 'org.apache.parquet:parquet-hadoop:1.15.1' because 'of https://nvd.nist.gov/vuln/detail/CVE-2025-30065'
         implementation 'ch.qos.logback:logback-core:1.5.13'
         implementation 'org.apache.avro:avro:1.12.0'
         implementation 'io.airlift:aircompressor:0.27'


### PR DESCRIPTION
* fix for https://github.com/broadinstitute/gatk/issues/9140
* addresses security vulnerability
