### PR TITLE
Potential fix for code scanning alert no. 15: Implicit narrowing conversion in compound assignment

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/MathUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/MathUtils.java
@@ -524,7 +524,7 @@ public final class MathUtils {
 
     public static long sum(final long[] x) {
         Utils.nonNull(x);
-        int total = 0;
+        long total = 0;
         for (long v : x)
             total += v;
         return total;


### PR DESCRIPTION
Potential fix for [https://github.com/broadinstitute/gatk/security/code-scanning/15](https://github.com/broadinstitute/gatk/security/code-scanning/15)

To fix the problem, we need to change the type of the `total` variable from `int` to `long`. This will ensure that the sum of the `long` values in the array is correctly stored without any implicit narrowing conversion. The change should be made in the `sum(final long[] x)` method in the `MathUtils` class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
