### PR TITLE
Potential fix for code scanning alert no. 5: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
@@ -479,6 +479,9 @@ public final class IOUtils {
 
             // Get the path for the entry on disk and make sure it's OK:
             final Path extractedEntryPath = destDir.resolve(entry.getName()).normalize();
+            if (!extractedEntryPath.startsWith(destDir)) {
+                throw new IOException("Bad zip entry: " + entry.getName());
+            }
             ensurePathIsOkForOutput(extractedEntryPath, overwriteExistingFiles);
 
             // Now we can create the entry in our output location:


### PR DESCRIPTION
Potential fix for [https://github.com/broadinstitute/gatk/security/code-scanning/5](https://github.com/broadinstitute/gatk/security/code-scanning/5)

To fix the problem, we need to ensure that the extracted file paths are within the intended destination directory. This can be achieved by verifying that the normalized path of the extracted entry starts with the destination directory path. If the path does not start with the destination directory, an exception should be thrown.

1. Normalize the path of the extracted entry.
2. Check if the normalized path starts with the destination directory path.
3. If the check fails, throw an exception to prevent directory traversal.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
