### PR TITLE
Do not strip ECN fields from truth records in SVConcordance

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVConcordance.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVConcordance.java
@@ -62,6 +62,11 @@ import java.util.stream.Collectors;
  * of the specific fields. For multi-allelic CNVs, only a copy state concordance metric is
  * annotated. Allele frequencies will be recalculated automatically if unavailable in the provided VCFs.
  *
+ * Minimum matching criteria can be specified as in {@link SVCluster} (e.g. reciprocal overlap). These serve to
+ * improve computational efficiency, but may be set to relaxed values that can be iterated on post hoc. Note that
+ * this set of parameters includes minimum sample overlap (Jaccard index of carrier samples), which should generally
+ * be set to 0 for concordance analysis.
+ *
  * This tool also allows supports stratification of the SVs into groups with specified matching criteria including SV type,
  * size range, and interval overlap. Please see the {@link GroupedSVCluster} tool documentation for further details
  * on how to specify stratification groups. Stratification only affects the criteria applied to each "eval" SV. In
@@ -306,6 +311,9 @@ public final class SVConcordance extends AbstractConcordanceWalker {
         final GenotypeBuilder builder = new GenotypeBuilder(genotype.getSampleName()).alleles(genotype.getAlleles());
         if (genotype.hasExtendedAttribute(GATKSVVCFConstants.COPY_NUMBER_FORMAT)) {
             builder.attribute(GATKSVVCFConstants.COPY_NUMBER_FORMAT, genotype.getExtendedAttribute(GATKSVVCFConstants.COPY_NUMBER_FORMAT));
+        }
+        if (genotype.hasExtendedAttribute(GATKSVVCFConstants.EXPECTED_COPY_NUMBER_FORMAT)) {
+            builder.attribute(GATKSVVCFConstants.EXPECTED_COPY_NUMBER_FORMAT, genotype.getExtendedAttribute(GATKSVVCFConstants.EXPECTED_COPY_NUMBER_FORMAT));
         }
         return builder.make();
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVConcordanceIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVConcordanceIntegrationTest.java
@@ -154,6 +154,30 @@ public class SVConcordanceIntegrationTest extends CommandLineProgramTest {
         Assert.assertTrue(checkedVariantsSet.contains("ref_panel_1kg.chr22.final_cleanup_INS_chr22_100"));
     }
 
+    // Regression test with non-zero sample overlap criteria, which require the ECN FORMAT field to be present after
+    //   stripping truth record genotypes of extra fields.
+    @Test
+    public void testRefPanelWithSampleOverlap() {
+        final File output = createTempFile("concord", ".vcf.gz");
+        final String evalVcfPath = getToolTestDataDir() + "ref_panel_1kg.cleaned.gatk.chr22_chrY.vcf.gz";
+        final String truthVcfPath = getToolTestDataDir() + "ref_panel_1kg.raw_calls.chr22_chrY.vcf.gz";
+        final ArgumentsBuilder args = new ArgumentsBuilder()
+                .addOutput(output)
+                .add(StandardArgumentDefinitions.SEQUENCE_DICTIONARY_NAME, GATKBaseTest.FULL_HG38_DICT)
+                .add(SVClusterEngineArgumentsCollection.DEPTH_SAMPLE_OVERLAP_FRACTION_NAME, 0.1)
+                .add(SVClusterEngineArgumentsCollection.DEPTH_INTERVAL_OVERLAP_FRACTION_NAME, 0.5)
+                .add(SVClusterEngineArgumentsCollection.DEPTH_BREAKEND_WINDOW_NAME, 10000000)
+                .add(SVClusterEngineArgumentsCollection.MIXED_SAMPLE_OVERLAP_FRACTION_NAME, 0.1)
+                .add(SVClusterEngineArgumentsCollection.MIXED_INTERVAL_OVERLAP_FRACTION_NAME, 0.1)
+                .add(SVClusterEngineArgumentsCollection.MIXED_BREAKEND_WINDOW_NAME, 2000)
+                .add(SVClusterEngineArgumentsCollection.PESR_SAMPLE_OVERLAP_FRACTION_NAME, 0.1)
+                .add(SVClusterEngineArgumentsCollection.PESR_INTERVAL_OVERLAP_FRACTION_NAME, 0.1)
+                .add(SVClusterEngineArgumentsCollection.PESR_BREAKEND_WINDOW_NAME, 500)
+                .add(AbstractConcordanceWalker.TRUTH_VARIANTS_LONG_NAME, truthVcfPath)
+                .add(AbstractConcordanceWalker.EVAL_VARIANTS_SHORT_NAME, evalVcfPath);
+        runCommandLine(args, SVConcordance.class.getSimpleName());
+    }
+
     @Test
     public void testRefPanelStratified() {
         final File output = createTempFile("concord", ".vcf.gz");


### PR DESCRIPTION
Fixes a bug where the tool fails when any sample overlap thresholds are non-zero. While this is not a normal use case (we rarely would need concordance metrics to be conditioned on carrier overlap), it results in an unclear assertion error where the `ECN` FORMAT field is not found in truth records after being stripped of extra fields to save memory.

This PR adds `ECN` back to the stripped-down truth records. Requiring sample overlap to be 0 was an alternative solution, but would complicate the tool's design. I have added a paragraph to the doc that recommends setting sample overlap to 0 in this tool.

Includes a regression test.