### PR TITLE
Vs 1653 patch gq0 on merge

### DIFF
--- a/scripts/variantstore/scripts/merge_and_rescore_vdses.py
+++ b/scripts/variantstore/scripts/merge_and_rescore_vdses.py
@@ -137,6 +137,9 @@ def patch_variant_data(vd: hl.MatrixTable, site_filters: hl.Table, vets_filters:
         ),
         as_vets=vd.as_vets.map_values(lambda value: value.drop("yng_status")),
     )
+
+    vd = vd.annotate_entries(LGT=hl.parse_call(hl.or_missing((hl.is_missing(vd.GQ) | (vd.GQ != 0)), vd.LGT)))
+
     lgt = vd.LGT
     la = vd.LA
     allele_NO = vd.allele_NO

--- a/scripts/variantstore/scripts/merge_and_rescore_vdses.py
+++ b/scripts/variantstore/scripts/merge_and_rescore_vdses.py
@@ -138,7 +138,7 @@ def patch_variant_data(vd: hl.MatrixTable, site_filters: hl.Table, vets_filters:
         as_vets=vd.as_vets.map_values(lambda value: value.drop("yng_status")),
     )
 
-    vd = vd.annotate_entries(LGT=hl.parse_call(hl.or_missing((hl.is_missing(vd.GQ) | (vd.GQ != 0)), vd.LGT)))
+    vd = vd.annotate_entries(LGT=hl.or_missing((hl.is_missing(vd.GQ) | (vd.GQ != 0)), vd.LGT))
 
     lgt = vd.LGT
     la = vd.LA

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -129,7 +129,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-04-23-alpine-c5dc118088b4"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-05-08-alpine-ad920b1d78e2"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2025-04-22-gatkbase-015904355d4d"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"


### PR DESCRIPTION
The example below first selects a site of interest and shows that all samples have a called `LGT` genotype, despite the fact that `ERS4367796` has `GQ` 0. After applying the line of code from this PR, `ERS4367796` has an `LGT` of `NA`.

```
>>> def filter(vds):
...   vd = vds.variant_data
...   fvd = vd.filter_rows((vd.locus.contig == 'chr1') & (vd.locus.position == 1553619))
...   return fvd
...
>>> fvd = filter(vds)
>>> fvd.entries().show()
+---------------+-------------------------------+----------+-----------------------------------------------------------------+
| locus         | alleles                       | filters  | as_vets                                                         |
+---------------+-------------------------------+----------+-----------------------------------------------------------------+
| locus<GRCh38> | array<str>                    | set<str> | dict<str, struct{model: str, calibration_sensitivity: float64}> |
+---------------+-------------------------------+----------+-----------------------------------------------------------------+
| chr1:1553619  | ["CAAAAAAA","C","CAAAAAAAAA"] | {}       | {"C":("INDEL",2.62e-01),"CAAAAAAAAA":("INDEL",1.62e-01)}        |
| chr1:1553619  | ["CAAAAAAA","C","CAAAAAAAAA"] | {}       | {"C":("INDEL",2.62e-01),"CAAAAAAAAA":("INDEL",1.62e-01)}        |
| chr1:1553619  | ["CAAAAAAA","C","CAAAAAAAAA"] | {}       | {"C":("INDEL",2.62e-01),"CAAAAAAAAA":("INDEL",1.62e-01)}        |
+---------------+-------------------------------+----------+-----------------------------------------------------------------+

+--------------+-------+-------+-------+------+--------------+--------------+------+
| s            |    GQ |   RGQ |    PS | LGT  | LAD          | LA           |   FT |
+--------------+-------+-------+-------+------+--------------+--------------+------+
| str          | int32 | int32 | int64 | call | array<int32> | array<int32> | bool |
+--------------+-------+-------+-------+------+--------------+--------------+------+
| "ERS4367795" |    99 |   723 |    NA | 1/2  | [0,14,6]     | [0,1,2]      | True |
| "ERS4367796" |     0 |   579 |    NA | 0/1  | [0,14]       | [0,1]        | True |
| "ERS4367797" |    39 |   372 |    NA | 1/1  | [0,13]       | [0,2]        | True |
+--------------+-------+-------+-------+------+--------------+--------------+------+

>>> fvd = fvd.annotate_entries(LGT=hl.or_missing((hl.is_missing(fvd.GQ) | (fvd.GQ != 0)), fvd.LGT))
>>> fvd.entries().show()
+---------------+-------------------------------+----------+-----------------------------------------------------------------+
| locus         | alleles                       | filters  | as_vets                                                         |
+---------------+-------------------------------+----------+-----------------------------------------------------------------+
| locus<GRCh38> | array<str>                    | set<str> | dict<str, struct{model: str, calibration_sensitivity: float64}> |
+---------------+-------------------------------+----------+-----------------------------------------------------------------+
| chr1:1553619  | ["CAAAAAAA","C","CAAAAAAAAA"] | {}       | {"C":("INDEL",2.62e-01),"CAAAAAAAAA":("INDEL",1.62e-01)}        |
| chr1:1553619  | ["CAAAAAAA","C","CAAAAAAAAA"] | {}       | {"C":("INDEL",2.62e-01),"CAAAAAAAAA":("INDEL",1.62e-01)}        |
| chr1:1553619  | ["CAAAAAAA","C","CAAAAAAAAA"] | {}       | {"C":("INDEL",2.62e-01),"CAAAAAAAAA":("INDEL",1.62e-01)}        |
+---------------+-------------------------------+----------+-----------------------------------------------------------------+

+--------------+-------+-------+-------+------+--------------+--------------+------+
| s            |    GQ |   RGQ |    PS | LGT  | LAD          | LA           |   FT |
+--------------+-------+-------+-------+------+--------------+--------------+------+
| str          | int32 | int32 | int64 | call | array<int32> | array<int32> | bool |
+--------------+-------+-------+-------+------+--------------+--------------+------+
| "ERS4367795" |    99 |   723 |    NA | 1/2  | [0,14,6]     | [0,1,2]      | True |
| "ERS4367796" |     0 |   579 |    NA | NA   | [0,14]       | [0,1]        | True |
| "ERS4367797" |    39 |   372 |    NA | 1/1  | [0,13]       | [0,2]        | True |
+--------------+-------+-------+-------+------+--------------+--------------+------+

>>>
```