### PR TITLE
Sort CPX intervals by position in SVAnnotate

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateEngine.java
@@ -512,7 +512,8 @@ public class SVAnnotateEngine {
      * @return - List of SVSegments representing components of the complex SV represented in CPX_INTERVALS
      */
     @VisibleForTesting
-    protected static List<SVSegment> parseComplexIntervals(final List<String> cpxIntervals) {
+    protected static List<SVSegment> parseComplexIntervals(final List<String> cpxIntervals,
+                                                           final SAMSequenceDictionary sequenceDictionary) {
         final List<SVSegment> segments = new ArrayList<>(cpxIntervals.size() + 1);
         for (final String cpxInterval : cpxIntervals) {
             final String[] parsed = cpxInterval.split("_");
@@ -520,7 +521,7 @@ public class SVAnnotateEngine {
             final SimpleInterval interval = new SimpleInterval(parsed[1]);
             segments.add(new SVSegment(svTypeForInterval, interval));
         }
-        return segments;
+        return segments.stream().sorted(SVSegment.getSVSegmentComparator(sequenceDictionary)).collect(Collectors.toList());
     }
 
 
@@ -541,7 +542,7 @@ public class SVAnnotateEngine {
      */
     @VisibleForTesting
     protected static ArrayList<SVSegment> getComplexAnnotationIntervals(final List<SVSegment> cpxIntervals,
-                                                                   final GATKSVVCFConstants.ComplexVariantSubtype complexType) {
+                                                                        final GATKSVVCFConstants.ComplexVariantSubtype complexType) {
         final ArrayList<SVSegment> segments = new ArrayList<>(cpxIntervals.size());
         final List<SimpleInterval> dupIntervals = new ArrayList<>(cpxIntervals.size());
         SimpleInterval inversionIntervalToAdjust = null;
@@ -643,7 +644,8 @@ public class SVAnnotateEngine {
     protected static List<SVSegment> getSVSegments(final VariantContext variant,
                                                    final GATKSVVCFConstants.StructuralVariantAnnotationType overallSVType,
                                                    final int maxBreakendLen,
-                                                   final GATKSVVCFConstants.ComplexVariantSubtype complexType) {
+                                                   final GATKSVVCFConstants.ComplexVariantSubtype complexType,
+                                                   final SAMSequenceDictionary sequenceDictionary) {
         final List<SVSegment> intervals;
         final String chrom = variant.getContig();
         final int pos = variant.getStart();
@@ -657,7 +659,7 @@ public class SVAnnotateEngine {
             if (complexType == null) {
                 throw new UserException("Complex (CPX) variant must contain CPX_TYPE INFO field");
             }
-            intervals = getComplexAnnotationIntervals(parseComplexIntervals(cpxIntervals), complexType);
+            intervals = getComplexAnnotationIntervals(parseComplexIntervals(cpxIntervals, sequenceDictionary), complexType);
             // add sink site as INS for dDUP (encoded in CHROM and POS instead of INFO/CPX_INTERVALS)
             // no need to add sink site INS for INS_iDEL or dDUP_iDEL because DEL coordinates contain sink site
             if (complexType == GATKSVVCFConstants.ComplexVariantSubtype.dDUP) {
@@ -667,7 +669,7 @@ public class SVAnnotateEngine {
         } else if (overallSVType.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.CTX)) {
             // if SVTYPE is CTX and CPX_TYPE is CTX_INV, add INV from CTX_INTERVALS
             if (complexType == GATKSVVCFConstants.ComplexVariantSubtype.CTX_INV && !cpxIntervals.isEmpty()) {
-                intervals = getComplexAnnotationIntervals(parseComplexIntervals(cpxIntervals), complexType);
+                intervals = getComplexAnnotationIntervals(parseComplexIntervals(cpxIntervals, sequenceDictionary), complexType);
             } else {
                 intervals = new ArrayList<>(2);
             }
@@ -834,7 +836,8 @@ public class SVAnnotateEngine {
         final GATKSVVCFConstants.StructuralVariantAnnotationType overallSVType = getSVType(variant);
         final GATKSVVCFConstants.ComplexVariantSubtype complexType = SVCallRecordUtils.getComplexSubtype(variant);
         final boolean includesDispersedDuplication = includesDispersedDuplication(complexType, COMPLEX_SUBTYPES_WITH_DISPERSED_DUP);
-        final List<SVSegment> svSegmentsForGeneOverlaps = getSVSegments(variant, overallSVType, maxBreakendLen, complexType);
+        final List<SVSegment> svSegmentsForGeneOverlaps = getSVSegments(variant, overallSVType, maxBreakendLen,
+                complexType, sequenceDictionary);
 
         // annotate gene overlaps
         if (gtfIntervalTrees != null && gtfIntervalTrees.getTranscriptIntervalTree() != null) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateEngine.java
@@ -521,7 +521,7 @@ public class SVAnnotateEngine {
             final SimpleInterval interval = new SimpleInterval(parsed[1]);
             segments.add(new SVSegment(svTypeForInterval, interval));
         }
-        return segments.stream().sorted(SVSegment.getSVSegmentComparator(sequenceDictionary)).collect(Collectors.toList());
+        return segments.stream().sorted().collect(Collectors.toList());
     }
 
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateEngine.java
@@ -512,8 +512,7 @@ public class SVAnnotateEngine {
      * @return - List of SVSegments representing components of the complex SV represented in CPX_INTERVALS
      */
     @VisibleForTesting
-    protected static List<SVSegment> parseComplexIntervals(final List<String> cpxIntervals,
-                                                           final SAMSequenceDictionary sequenceDictionary) {
+    protected static List<SVSegment> parseComplexIntervals(final List<String> cpxIntervals) {
         final List<SVSegment> segments = new ArrayList<>(cpxIntervals.size() + 1);
         for (final String cpxInterval : cpxIntervals) {
             final String[] parsed = cpxInterval.split("_");
@@ -644,8 +643,7 @@ public class SVAnnotateEngine {
     protected static List<SVSegment> getSVSegments(final VariantContext variant,
                                                    final GATKSVVCFConstants.StructuralVariantAnnotationType overallSVType,
                                                    final int maxBreakendLen,
-                                                   final GATKSVVCFConstants.ComplexVariantSubtype complexType,
-                                                   final SAMSequenceDictionary sequenceDictionary) {
+                                                   final GATKSVVCFConstants.ComplexVariantSubtype complexType) {
         final List<SVSegment> intervals;
         final String chrom = variant.getContig();
         final int pos = variant.getStart();
@@ -659,7 +657,7 @@ public class SVAnnotateEngine {
             if (complexType == null) {
                 throw new UserException("Complex (CPX) variant must contain CPX_TYPE INFO field");
             }
-            intervals = getComplexAnnotationIntervals(parseComplexIntervals(cpxIntervals, sequenceDictionary), complexType);
+            intervals = getComplexAnnotationIntervals(parseComplexIntervals(cpxIntervals), complexType);
             // add sink site as INS for dDUP (encoded in CHROM and POS instead of INFO/CPX_INTERVALS)
             // no need to add sink site INS for INS_iDEL or dDUP_iDEL because DEL coordinates contain sink site
             if (complexType == GATKSVVCFConstants.ComplexVariantSubtype.dDUP) {
@@ -669,7 +667,7 @@ public class SVAnnotateEngine {
         } else if (overallSVType.equals(GATKSVVCFConstants.StructuralVariantAnnotationType.CTX)) {
             // if SVTYPE is CTX and CPX_TYPE is CTX_INV, add INV from CTX_INTERVALS
             if (complexType == GATKSVVCFConstants.ComplexVariantSubtype.CTX_INV && !cpxIntervals.isEmpty()) {
-                intervals = getComplexAnnotationIntervals(parseComplexIntervals(cpxIntervals, sequenceDictionary), complexType);
+                intervals = getComplexAnnotationIntervals(parseComplexIntervals(cpxIntervals), complexType);
             } else {
                 intervals = new ArrayList<>(2);
             }
@@ -836,8 +834,7 @@ public class SVAnnotateEngine {
         final GATKSVVCFConstants.StructuralVariantAnnotationType overallSVType = getSVType(variant);
         final GATKSVVCFConstants.ComplexVariantSubtype complexType = SVCallRecordUtils.getComplexSubtype(variant);
         final boolean includesDispersedDuplication = includesDispersedDuplication(complexType, COMPLEX_SUBTYPES_WITH_DISPERSED_DUP);
-        final List<SVSegment> svSegmentsForGeneOverlaps = getSVSegments(variant, overallSVType, maxBreakendLen,
-                complexType, sequenceDictionary);
+        final List<SVSegment> svSegmentsForGeneOverlaps = getSVSegments(variant, overallSVType, maxBreakendLen, complexType);
 
         // annotate gene overlaps
         if (gtfIntervalTrees != null && gtfIntervalTrees.getTranscriptIntervalTree() != null) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVSegment.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVSegment.java
@@ -1,10 +1,13 @@
 package org.broadinstitute.hellbender.tools.walkers.sv;
 
+import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.util.Locatable;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants;
+import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 
+import java.util.Comparator;
 import java.util.Objects;
 
 // Mini class to package SV type and interval into one object
@@ -52,5 +55,32 @@ public class SVSegment implements Locatable {
     @Override
     public int hashCode() {
         return Objects.hash(intervalSVType, interval);
+    }
+
+    /**
+     * Get comparator for {@link SVSegment} objects. SVsegment is not implemented as a {@link Comparable} due to the
+     * need for a common sequence dictionary.
+     * @param dictionary SAMSequenceDictionary pertaining to both objects
+     * @param <T> object class
+     * @return comparator
+     */
+    public static <T extends SVSegment> Comparator<T> getSVSegmentComparator(final SAMSequenceDictionary dictionary) {
+        return (o1, o2) -> compareSVSegments(o1, o2, dictionary);
+    }
+
+    /**
+     * Compares two SVSegments using sequence dictionary based on contig, then start position, then end position, then SV type
+     * @param first SVSegment
+     * @param second SVSegment
+     * @param dictionary SAMSequenceDictionary to dictate comparison order
+     * @return 0 if first and second are equal, a negative value if first < second, or a positive value if first > second
+     */
+    public static int compareSVSegments(final SVSegment first, final SVSegment second, final SAMSequenceDictionary dictionary) {
+        Utils.nonNull(first);
+        Utils.nonNull(second);
+        final Comparator<Locatable> locatableComparator = IntervalUtils.getDictionaryOrderComparator(dictionary);
+        final int comparePositions = locatableComparator.compare(first.getInterval(), second.getInterval());
+        if (comparePositions != 0) return comparePositions;
+        return first.getIntervalSVType().compareTo(second.getIntervalSVType());
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVSegment.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVSegment.java
@@ -1,17 +1,14 @@
 package org.broadinstitute.hellbender.tools.walkers.sv;
 
-import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.util.Locatable;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants;
-import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
 
-import java.util.Comparator;
 import java.util.Objects;
 
 // Mini class to package SV type and interval into one object
-public class SVSegment implements Locatable {
+public class SVSegment implements Locatable, Comparable<SVSegment> {
     protected final GATKSVVCFConstants.StructuralVariantAnnotationType intervalSVType;
     protected final SimpleInterval interval;
 
@@ -58,29 +55,21 @@ public class SVSegment implements Locatable {
     }
 
     /**
-     * Get comparator for {@link SVSegment} objects. SVsegment is not implemented as a {@link Comparable} due to the
-     * need for a common sequence dictionary.
-     * @param dictionary SAMSequenceDictionary pertaining to both objects
-     * @param <T> object class
-     * @return comparator
-     */
-    public static <T extends SVSegment> Comparator<T> getSVSegmentComparator(final SAMSequenceDictionary dictionary) {
-        return (o1, o2) -> compareSVSegments(o1, o2, dictionary);
-    }
-
-    /**
-     * Compares two SVSegments using sequence dictionary based on contig, then start position, then end position, then SV type
-     * @param first SVSegment
-     * @param second SVSegment
-     * @param dictionary SAMSequenceDictionary to dictate comparison order
+     * Compares to another SVSegment using contig (alphabetical), then start position, then end position, then SV type
+     * @param that SVSegment
      * @return 0 if first and second are equal, a negative value if first < second, or a positive value if first > second
      */
-    public static int compareSVSegments(final SVSegment first, final SVSegment second, final SAMSequenceDictionary dictionary) {
-        Utils.nonNull(first);
-        Utils.nonNull(second);
-        final Comparator<Locatable> locatableComparator = IntervalUtils.getDictionaryOrderComparator(dictionary);
-        final int comparePositions = locatableComparator.compare(first.getInterval(), second.getInterval());
-        if (comparePositions != 0) return comparePositions;
-        return first.getIntervalSVType().compareTo(second.getIntervalSVType());
+    public int compareTo(final SVSegment that) {
+        Utils.nonNull(that);
+
+        int result = this.getContig().compareTo(that.getContig());
+        if ( result == 0 ) {
+            result = Integer.compare(this.getStart(), that.getStart());
+            if ( result == 0 ) {
+                result = Integer.compare(this.getEnd(), that.getEnd());
+                if ( result == 0 ) result = this.getIntervalSVType().compareTo(that.getIntervalSVType());
+            }
+        }
+        return result;
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateEngineUnitTest.java
@@ -294,16 +294,16 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
                                 new SimpleInterval("chr1", 248129213, 248520217)}) },
                 { GATKSVVCFConstants.ComplexVariantSubtype.dDUP_iDEL, "DUP_chr2:131488885-131489335,INV_chr2:131488885-131489335,DEL_chr2:130185450-130185720",
                         createListOfSVSegmentsDifferentTypes(new GATKSVVCFConstants.StructuralVariantAnnotationType[]{
-                                GATKSVVCFConstants.StructuralVariantAnnotationType.DUP,
-                                GATKSVVCFConstants.StructuralVariantAnnotationType.DEL},
-                        new SimpleInterval[]{new SimpleInterval("chr2", 131488885,131489335),
-                                new SimpleInterval("chr2", 130185450,130185720)}) },
+                                GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
+                                GATKSVVCFConstants.StructuralVariantAnnotationType.DUP},
+                        new SimpleInterval[]{new SimpleInterval("chr2", 130185450,130185720),
+                                new SimpleInterval("chr2", 131488885,131489335)}) },
                 { GATKSVVCFConstants.ComplexVariantSubtype.dDUP_iDEL, "DUP_chr3:95751919-95752156,DEL_chr3:95746923-95749272",
                         createListOfSVSegmentsDifferentTypes(new GATKSVVCFConstants.StructuralVariantAnnotationType[]{
-                                GATKSVVCFConstants.StructuralVariantAnnotationType.DUP,
-                                GATKSVVCFConstants.StructuralVariantAnnotationType.DEL},
-                        new SimpleInterval[]{new SimpleInterval("chr3", 95751919,95752156),
-                                new SimpleInterval("chr3", 95746923,95749272)}) },
+                                GATKSVVCFConstants.StructuralVariantAnnotationType.DEL,
+                                GATKSVVCFConstants.StructuralVariantAnnotationType.DUP},
+                        new SimpleInterval[]{new SimpleInterval("chr3", 95746923,95749272),
+                                new SimpleInterval("chr3", 95751919,95752156)}) },
                 { GATKSVVCFConstants.ComplexVariantSubtype.INS_iDEL, "DEL_chr3:60521333-60521483",
                         createListOfSVSegmentsDifferentTypes(new GATKSVVCFConstants.StructuralVariantAnnotationType[]{
                                 GATKSVVCFConstants.StructuralVariantAnnotationType.DEL},
@@ -354,7 +354,8 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
             final String cpxIntervalsString,
             final List<SVSegment> expectedSVSegments
     ) {
-        final List<SVSegment> cpxIntervals = SVAnnotateEngine.parseComplexIntervals(Arrays.asList(cpxIntervalsString.split(",")));
+        final SAMSequenceDictionary sequenceDictionary = SVAnnotateUnitTest.createSequenceDictionary(Arrays.asList("chr1", "chr2", "chr3"));
+        final List<SVSegment> cpxIntervals = SVAnnotateEngine.parseComplexIntervals(Arrays.asList(cpxIntervalsString.split(",")), sequenceDictionary);
         final List<SVSegment> actualSegments = SVAnnotateEngine.getComplexAnnotationIntervals(cpxIntervals,
                 complexType);
         assertSegmentListEqual(actualSegments, expectedSVSegments);
@@ -389,7 +390,8 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
         SVAnnotateEngine svAnnotateEngine = new SVAnnotateEngine(gtfTrees, null, sequenceDictionary,
                 -1);
 
-        final List<SVSegment> cpxIntervals = SVAnnotateEngine.parseComplexIntervals(Arrays.asList(cpxIntervalsString.split(",")));
+        final List<SVSegment> cpxIntervals = SVAnnotateEngine.parseComplexIntervals(Arrays.asList(cpxIntervalsString.split(",")),
+                sequenceDictionary);
         final List<SVSegment> cpxSegments = SVAnnotateEngine.getComplexAnnotationIntervals(cpxIntervals, complexType);
         for (final SVSegment cpxSegment: cpxSegments) {
             svAnnotateEngine.annotateGeneOverlaps(cpxSegment.getInterval(), cpxSegment.getIntervalSVType(), true,
@@ -753,15 +755,18 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
             final List<SVSegment> expectedSVSegments,
             final List<SVSegment> expectedSVSegmentsWithBNDOverlap
     ) {
+        final SAMSequenceDictionary sequenceDictionary = SVAnnotateUnitTest.createSequenceDictionary(
+                Arrays.asList("chr2", "chr4", "chr8", "chr19", "chr22", "chrX"));
+
         GATKSVVCFConstants.StructuralVariantAnnotationType actualSVType = SVAnnotateEngine.getSVType(variant);
         Assert.assertEquals(actualSVType, expectedSVType);
 
         final List<SVSegment> actualSegments = SVAnnotateEngine.getSVSegments(variant,
-                actualSVType, -1, complexType);
+                actualSVType, -1, complexType, sequenceDictionary);
         assertSegmentListEqual(actualSegments, expectedSVSegments);
 
         final List<SVSegment> actualSegmentsWithBNDOverlap = SVAnnotateEngine.getSVSegments(variant,
-                actualSVType, 15000, complexType);
+                actualSVType, 15000, complexType, sequenceDictionary);
         assertSegmentListEqual(actualSegmentsWithBNDOverlap,
                 expectedSVSegmentsWithBNDOverlap != null ? expectedSVSegmentsWithBNDOverlap : expectedSVSegments);
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateEngineUnitTest.java
@@ -354,8 +354,7 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
             final String cpxIntervalsString,
             final List<SVSegment> expectedSVSegments
     ) {
-        final SAMSequenceDictionary sequenceDictionary = SVAnnotateUnitTest.createSequenceDictionary(Arrays.asList("chr1", "chr2", "chr3"));
-        final List<SVSegment> cpxIntervals = SVAnnotateEngine.parseComplexIntervals(Arrays.asList(cpxIntervalsString.split(",")), sequenceDictionary);
+        final List<SVSegment> cpxIntervals = SVAnnotateEngine.parseComplexIntervals(Arrays.asList(cpxIntervalsString.split(",")));
         final List<SVSegment> actualSegments = SVAnnotateEngine.getComplexAnnotationIntervals(cpxIntervals,
                 complexType);
         assertSegmentListEqual(actualSegments, expectedSVSegments);
@@ -390,8 +389,7 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
         SVAnnotateEngine svAnnotateEngine = new SVAnnotateEngine(gtfTrees, null, sequenceDictionary,
                 -1);
 
-        final List<SVSegment> cpxIntervals = SVAnnotateEngine.parseComplexIntervals(Arrays.asList(cpxIntervalsString.split(",")),
-                sequenceDictionary);
+        final List<SVSegment> cpxIntervals = SVAnnotateEngine.parseComplexIntervals(Arrays.asList(cpxIntervalsString.split(",")));
         final List<SVSegment> cpxSegments = SVAnnotateEngine.getComplexAnnotationIntervals(cpxIntervals, complexType);
         for (final SVSegment cpxSegment: cpxSegments) {
             svAnnotateEngine.annotateGeneOverlaps(cpxSegment.getInterval(), cpxSegment.getIntervalSVType(), true,
@@ -755,18 +753,15 @@ public class SVAnnotateEngineUnitTest extends GATKBaseTest {
             final List<SVSegment> expectedSVSegments,
             final List<SVSegment> expectedSVSegmentsWithBNDOverlap
     ) {
-        final SAMSequenceDictionary sequenceDictionary = SVAnnotateUnitTest.createSequenceDictionary(
-                Arrays.asList("chr2", "chr4", "chr8", "chr19", "chr22", "chrX"));
-
         GATKSVVCFConstants.StructuralVariantAnnotationType actualSVType = SVAnnotateEngine.getSVType(variant);
         Assert.assertEquals(actualSVType, expectedSVType);
 
         final List<SVSegment> actualSegments = SVAnnotateEngine.getSVSegments(variant,
-                actualSVType, -1, complexType, sequenceDictionary);
+                actualSVType, -1, complexType);
         assertSegmentListEqual(actualSegments, expectedSVSegments);
 
         final List<SVSegment> actualSegmentsWithBNDOverlap = SVAnnotateEngine.getSVSegments(variant,
-                actualSVType, 15000, complexType, sequenceDictionary);
+                actualSVType, 15000, complexType);
         assertSegmentListEqual(actualSegmentsWithBNDOverlap,
                 expectedSVSegmentsWithBNDOverlap != null ? expectedSVSegmentsWithBNDOverlap : expectedSVSegments);
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVSegmentUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVSegmentUnitTest.java
@@ -1,0 +1,117 @@
+package org.broadinstitute.hellbender.tools.walkers.sv;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import org.broadinstitute.hellbender.GATKBaseTest;
+import org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+public class SVSegmentUnitTest extends GATKBaseTest {
+
+    @DataProvider(name="svSegmentPairs")
+    public Object[][] getSVSegmentPairs() {
+        return new Object[][] {
+                // same SV type, different interval
+                {
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 100, 200)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 50, 150)),
+                        1
+                },
+                // different SV type, use intervals
+                {
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 100, 200)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP, new SimpleInterval("chr1", 50, 150)),
+                        1
+                },
+                // same interval, use SV type
+                {
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 100, 200)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP, new SimpleInterval("chr1", 100, 200)),
+                        -1
+                },
+                // same segment
+                {
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 100, 200)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 100, 200)),
+                        0
+                },
+                // different contig, same coordinates/SV type
+                {
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 100, 200)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr2", 100, 200)),
+                        -1
+                },
+                // different end coordinate only
+                {
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 100, 200)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 100, 300)),
+                        -1
+                },
+                // different start coordinate only
+                {
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.INV, new SimpleInterval("chr1", 100, 200)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.INV, new SimpleInterval("chr1", 99, 200)),
+                        1
+                },
+        };
+    }
+
+
+    @Test(dataProvider = "svSegmentPairs")
+    public void testCompareSVSegments(
+            final SVSegment first,
+            final SVSegment second,
+            final int expectedComparisonValue)
+    {
+        final SAMSequenceDictionary dictionary =
+                SVAnnotateUnitTest.createSequenceDictionary(Arrays.asList("chr1", "chr2", "chr3", "chr4"));
+        final int actualComparisonValue = SVSegment.compareSVSegments(first, second, dictionary);
+        Assert.assertEquals(actualComparisonValue, expectedComparisonValue);
+    }
+
+
+    @DataProvider(name="svSegmentList")
+    public Object[][] getSVSegmentList() {
+        return new Object[][] {
+                {
+                    Arrays.asList(
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 100, 200)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 50, 150)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP, new SimpleInterval("chr1", 50, 150)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 100, 200)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr2", 100, 200)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 100, 300)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.INV, new SimpleInterval("chr1", 99, 200))
+
+                    ), Arrays.asList(
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 50, 150)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DUP, new SimpleInterval("chr1", 50, 150)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.INV, new SimpleInterval("chr1", 99, 200)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 100, 200)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 100, 200)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 100, 300)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr2", 100, 200))
+                )
+                },
+
+        };
+    }
+
+    @Test(dataProvider = "svSegmentList")
+    public void testSVSegmentComparator(
+            final List<SVSegment> unsorted,
+            final List<SVSegment> expectedOrder)
+    {
+        final SAMSequenceDictionary dictionary =
+                SVAnnotateUnitTest.createSequenceDictionary(Arrays.asList("chr1", "chr2", "chr3", "chr4"));
+        final List<SVSegment> actualOrder = unsorted.stream().sorted(SVSegment.getSVSegmentComparator(dictionary)).collect(Collectors.toList());
+        Assert.assertEquals(actualOrder, expectedOrder);
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVSegmentUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVSegmentUnitTest.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.hellbender.tools.walkers.sv;
 
-import htsjdk.samtools.SAMSequenceDictionary;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.tools.spark.sv.utils.GATKSVVCFConstants;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
@@ -48,6 +47,12 @@ public class SVSegmentUnitTest extends GATKBaseTest {
                         new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr2", 100, 200)),
                         -1
                 },
+                // different contig, same coordinates/SV type, alphabetical order
+                {
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 100, 200)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr11", 100, 200)),
+                        -1
+                },
                 // different end coordinate only
                 {
                         new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 100, 200)),
@@ -70,9 +75,7 @@ public class SVSegmentUnitTest extends GATKBaseTest {
             final SVSegment second,
             final int expectedComparisonValue)
     {
-        final SAMSequenceDictionary dictionary =
-                SVAnnotateUnitTest.createSequenceDictionary(Arrays.asList("chr1", "chr2", "chr3", "chr4"));
-        final int actualComparisonValue = SVSegment.compareSVSegments(first, second, dictionary);
+        final int actualComparisonValue = first.compareTo(second);
         Assert.assertEquals(actualComparisonValue, expectedComparisonValue);
     }
 
@@ -88,6 +91,7 @@ public class SVSegmentUnitTest extends GATKBaseTest {
                         new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 100, 200)),
                         new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr2", 100, 200)),
                         new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 100, 300)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr11", 100, 200)),
                         new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.INV, new SimpleInterval("chr1", 99, 200))
 
                     ), Arrays.asList(
@@ -97,6 +101,7 @@ public class SVSegmentUnitTest extends GATKBaseTest {
                         new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 100, 200)),
                         new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 100, 200)),
                         new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr1", 100, 300)),
+                        new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr11", 100, 200)),
                         new SVSegment(GATKSVVCFConstants.StructuralVariantAnnotationType.DEL, new SimpleInterval("chr2", 100, 200))
                 )
                 },
@@ -109,9 +114,7 @@ public class SVSegmentUnitTest extends GATKBaseTest {
             final List<SVSegment> unsorted,
             final List<SVSegment> expectedOrder)
     {
-        final SAMSequenceDictionary dictionary =
-                SVAnnotateUnitTest.createSequenceDictionary(Arrays.asList("chr1", "chr2", "chr3", "chr4"));
-        final List<SVSegment> actualOrder = unsorted.stream().sorted(SVSegment.getSVSegmentComparator(dictionary)).collect(Collectors.toList());
+        final List<SVSegment> actualOrder = unsorted.stream().sorted().collect(Collectors.toList());
         Assert.assertEquals(actualOrder, expectedOrder);
     }
 }


### PR DESCRIPTION
### Updates
SVAnnotate assumes CPX intervals are sorted by position. This caused an error (https://github.com/broadinstitute/gatk-sv/issues/808) when the order of the intervals was altered by SVConcordance. This PR adds SVSegment comparison methods and sorts CPX intervals by position during SVAnnotate to ensure consistent ordering.

### Testing
* Unit tests updated and executed
* Tested SVAnnotate locally and in the GATK-SV AnnotateVcf workflow on a filtered VCF which failed annotation using the version in main, and the tool/workflow completed successfully