### PR TITLE
Output exit result to stderr instead of stdout to allow pipelines

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/Main.java
+++ b/src/main/java/org/broadinstitute/hellbender/Main.java
@@ -241,7 +241,7 @@ public class Main {
      */
     protected void handleResult(final Object result) {
         if (result != null) {
-            System.out.println("Tool returned:\n" + result);
+            System.err.println("Tool returned:\n" + result);
         }
     }
 


### PR DESCRIPTION
fix #5790, #7080

Hi!

The exit codes from picard tools are written to stdout which messes up pipelines. In my case, I want to be able to pipe MarkDuplicates to output using `-O /dev/stdout` but the stream gets messed up by this message. Now instead, the message is directed to stderr. 

