### PR TITLE
Upgrade to Hail 0.2.134 [VS-1660]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -238,7 +238,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1615_hetvar_vcfs
+             - vs_1660_upgrade_hail_0_2_134
          tags:
              - /.*/
    - name: GvsCreateVATFilesFromBigQuery

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -164,6 +164,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - vs_1660_upgrade_hail_0_2_134
        tags:
          - /.*/
    - name: GvsMergeAndRescoreVDSes

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -341,7 +341,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_VS-1654_UseLegacySQLEveryWhere
+             - vs_1660_upgrade_hail_0_2_134
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -183,6 +183,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - vs_1660_upgrade_hail_0_2_134
        tags:
          - /.*/
    - name: GvsExtractCallset

--- a/scripts/variantstore/scripts/build_base.Dockerfile
+++ b/scripts/variantstore/scripts/build_base.Dockerfile
@@ -15,7 +15,7 @@
 # 435.0.0 is the most recent version of the Cloud SDK Docker image that uses Python 3.10. Newer versions use Python 3.11
 # and unfortunately some of our depdendencies are not currently compiling with that.
 #
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-alpine
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:522.0.0-alpine
 
 RUN apk update && apk upgrade
 RUN python3 -m ensurepip --upgrade

--- a/scripts/variantstore/scripts/build_base.Dockerfile
+++ b/scripts/variantstore/scripts/build_base.Dockerfile
@@ -15,7 +15,7 @@
 # 435.0.0 is the most recent version of the Cloud SDK Docker image that uses Python 3.10. Newer versions use Python 3.11
 # and unfortunately some of our depdendencies are not currently compiling with that.
 #
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:522.0.0-alpine
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-alpine
 
 RUN apk update && apk upgrade
 RUN python3 -m ensurepip --upgrade

--- a/scripts/variantstore/scripts/build_build_base_docker.sh
+++ b/scripts/variantstore/scripts/build_build_base_docker.sh
@@ -7,7 +7,7 @@ if [ $# -lt 1 ]; then
 fi
 
 if [[ ! "$1" == *-build-base ]]; then
-    echo "Specified tag '$1' does end with '-build-base'."
+    echo "Specified tag '$1' does not end with '-build-base'."
     echo "build_build_base_docker.sh is intended for building build base images only."
     exit 1
 fi

--- a/scripts/variantstore/variant-annotations-table/GvsCreateVATFilesFromBigQuery.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsCreateVATFilesFromBigQuery.wdl
@@ -239,7 +239,7 @@ task MergeVatTSVs {
         bash ~{monitoring_script} > monitoring.log &
 
         apt-get update
-        apt-get install tabix
+        apt-get install --assume-yes tabix
 
         # custom function to prepend the current datetime to an echo statement "borrowed" from ExtractAnAcAfFromVCF
         echo_date () { echo "`date "+%Y/%m/%d %H:%M:%S"` $1"; }

--- a/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
@@ -344,11 +344,10 @@ task GenerateSitesOnlyVcf {
 
         account_name=$(gcloud config list account --format "value(core.account)")
 
-        # pip3 install --upgrade pip
-        apk add py3-pip
-
         python3 -m venv ./localvenv
         . ./localvenv/bin/activate
+
+        pip3 install --upgrade pip
 
         if [[ ! -z "~{hail_wheel}" ]]
         then
@@ -360,8 +359,7 @@ task GenerateSitesOnlyVcf {
         pip3 install --upgrade google-cloud-dataproc ijson
 
         # Generate a UUIDish random hex string of <8 hex chars (4 bytes)>-<4 hex chars (2 bytes)>
-        # hex="$(head -c4 < /dev/urandom | xxd -p)-$(head -c2 < /dev/urandom | xxd -p)"
-        hex=$(od  -vN 6 -An -tx1             /dev/urandom | tr -d " \n" ; echo)
+        hex="$(head -c4 < /dev/urandom | od -h -An | tr -d '[:space:]')-$(head -c2 < /dev/urandom | od -h -An | tr -d '[:space:]')"
 
         cluster_name="~{prefix}-${hex}"
         echo ${cluster_name} > cluster_name.txt

--- a/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
@@ -104,7 +104,7 @@ workflow GvsCreateVATfromVDS {
 
     call Utils.GetHailScripts {
         input:
-            variants_docker = variants_docker,
+            variants_docker = effective_variants_docker,
     }
 
     call Utils.GetReference {

--- a/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
@@ -153,7 +153,7 @@ workflow GvsCreateVATfromVDS {
                     region = region,
                     gcs_subnetwork_name = gcs_subnetwork_name,
                     leave_cluster_running_at_end = leave_hail_cluster_running_at_end,
-                    variants_docker = effective_variants_docker,
+                    variants_docker = effective_cloud_sdk_docker, # intentionally wrong
             }
         }
 
@@ -344,7 +344,8 @@ task GenerateSitesOnlyVcf {
         pip3 install --upgrade google-cloud-dataproc ijson
 
         # Generate a UUIDish random hex string of <8 hex chars (4 bytes)>-<4 hex chars (2 bytes)>
-        hex="$(head -c4 < /dev/urandom | xxd -p)-$(head -c2 < /dev/urandom | xxd -p)"
+        hex=$(od  -vN 6 -An -tx1             /dev/urandom | tr -d " \n" ; echo)
+        # hex="$(head -c4 < /dev/urandom | xxd -p)-$(head -c2 < /dev/urandom | xxd -p)"
 
         cluster_name="~{prefix}-${hex}"
         echo ${cluster_name} > cluster_name.txt

--- a/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
@@ -334,7 +334,7 @@ task GenerateSitesOnlyVcf {
         account_name=$(gcloud config list account --format "value(core.account)")
 
         # pip3 install --upgrade pip
-        apk install py3-pip
+        apk add py3-pip
 
         python3 -m venv ./localvenv
         . ./localvenv/bin/activate

--- a/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
@@ -333,7 +333,12 @@ task GenerateSitesOnlyVcf {
 
         account_name=$(gcloud config list account --format "value(core.account)")
 
-        pip3 install --upgrade pip
+        # pip3 install --upgrade pip
+        apk install py3-pip
+
+        python3 -m venv ./localvenv
+        . ./localvenv/bin/activate
+
         if [[ ! -z "~{hail_wheel}" ]]
         then
             pip3 install ~{hail_wheel}
@@ -344,8 +349,8 @@ task GenerateSitesOnlyVcf {
         pip3 install --upgrade google-cloud-dataproc ijson
 
         # Generate a UUIDish random hex string of <8 hex chars (4 bytes)>-<4 hex chars (2 bytes)>
-        hex=$(od  -vN 6 -An -tx1             /dev/urandom | tr -d " \n" ; echo)
         # hex="$(head -c4 < /dev/urandom | xxd -p)-$(head -c2 < /dev/urandom | xxd -p)"
+        hex=$(od  -vN 6 -An -tx1             /dev/urandom | tr -d " \n" ; echo)
 
         cluster_name="~{prefix}-${hex}"
         echo ${cluster_name} > cluster_name.txt

--- a/scripts/variantstore/wdl/GvsCreateVDS.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVDS.wdl
@@ -186,6 +186,10 @@ task CreateVds {
 
         account_name=$(gcloud config list account --format "value(core.account)")
 
+        apt install --assume-yes python3.11-venv
+        python3 -m venv ./localvenv
+        . ./localvenv/bin/activate
+
         pip3 install --upgrade pip
 
         if [[ ! -z "~{hail_wheel}" ]]

--- a/scripts/variantstore/wdl/GvsCreateVDS.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVDS.wdl
@@ -100,7 +100,7 @@ workflow GvsCreateVDS {
         }
     }
 
-    call GetHailScripts {
+    call Utils.GetHailScripts {
         input:
             variants_docker = effective_variants_docker,
     }
@@ -266,36 +266,5 @@ task CreateVds {
     output {
         String cluster_name = read_string("cluster_name.txt")
         Boolean done = true
-    }
-}
-
-task GetHailScripts {
-    input {
-        String variants_docker
-    }
-    meta {
-        # OK to cache this as the scripts are drawn from the stringified Docker image and as long as that stays the same
-        # the script content should also stay the same.
-    }
-    command <<<
-        # Prepend date, time and pwd to xtrace log entries.
-        PS4='\D{+%F %T} \w $ '
-        set -o errexit -o nounset -o pipefail -o xtrace
-
-        # Not sure why this is required but without it:
-        # Absolute path /app/run_in_hail_cluster.py doesn't appear to be under any mount points: local-disk 10 SSD
-
-        mkdir app
-        cp /app/*.py app
-    >>>
-    output {
-        File run_in_hail_cluster_script = "app/run_in_hail_cluster.py"
-        File hail_gvs_import_script = "app/hail_gvs_import.py"
-        File hail_gvs_util_script = "app/hail_gvs_util.py"
-        File gvs_import_script = "app/import_gvs.py"
-        File gvs_import_ploidy_script = "app/import_gvs_ploidy.py"
-    }
-    runtime {
-        docker: variants_docker
     }
 }

--- a/scripts/variantstore/wdl/GvsMergeAndRescoreVDSes.wdl
+++ b/scripts/variantstore/wdl/GvsMergeAndRescoreVDSes.wdl
@@ -115,7 +115,7 @@ workflow GvsMergeAndRescoreVDSes {
         }
     }
 
-    call GetHailScripts {
+    call Utils.GetHailScripts {
         input:
             variants_docker = effective_variants_docker,
     }
@@ -286,37 +286,5 @@ task MergeAndRescoreVDS {
     output {
         String cluster_name = read_string("cluster_name.txt")
         Boolean done = true
-    }
-}
-
-task GetHailScripts {
-    input {
-        String variants_docker
-    }
-    meta {
-        # OK to cache this as the scripts are drawn from the stringified Docker image and as long as that stays the same
-        # the script content should also stay the same.
-    }
-    command <<<
-        # Prepend date, time and pwd to xtrace log entries.
-        PS4='\D{+%F %T} \w $ '
-        set -o errexit -o nounset -o pipefail -o xtrace
-
-        # Not sure why this is required but without it:
-        # Absolute path /app/run_in_hail_cluster.py doesn't appear to be under any mount points: local-disk 10 SSD
-
-        mkdir app
-        cp /app/*.py app
-    >>>
-    output {
-        File run_in_hail_cluster_script = "app/run_in_hail_cluster.py"
-        File hail_gvs_import_script = "app/hail_gvs_import.py"
-        File hail_gvs_util_script = "app/hail_gvs_util.py"
-        File merge_and_rescore_script = "app/merge_and_rescore_vdses.py"
-        File gvs_import_script = "app/import_gvs.py"
-        File gvs_import_ploidy_script = "app/import_gvs_ploidy.py"
-    }
-    runtime {
-        docker: variants_docker
     }
 }

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -1424,3 +1424,38 @@ task CopyFile {
     cpu: 1
   }
 }
+
+task GetHailScripts {
+    input {
+        String variants_docker
+    }
+    meta {
+        # OK to cache this as the scripts are drawn from the stringified Docker image and as long as that stays the same
+        # the script content should also stay the same.
+    }
+    command <<<
+        # Prepend date, time and pwd to xtrace log entries.
+        PS4='\D{+%F %T} \w $ '
+        set -o errexit -o nounset -o pipefail -o xtrace
+
+        # Not sure why this is required but without it:
+        # Absolute path /app/run_in_hail_cluster.py doesn't appear to be under any mount points: local-disk 10 SSD
+
+        mkdir app
+        cp /app/*.py app
+    >>>
+    output {
+        File run_in_hail_cluster_script = "app/run_in_hail_cluster.py"
+        File hail_gvs_import_script = "app/hail_gvs_import.py"
+        File hail_gvs_util_script = "app/hail_gvs_util.py"
+        File merge_and_rescore_script = "app/merge_and_rescore_vdses.py"
+        File gvs_import_script = "app/import_gvs.py"
+        File gvs_import_ploidy_script = "app/import_gvs_ploidy.py"
+        File create_vat_inputs_script = "app/create_vat_inputs.py"
+        File hail_create_vat_input_script = "app/hail_create_vat_inputs.py"
+        File vds_validation_script = "app/vds_validation.py"
+    }
+    runtime {
+        docker: variants_docker
+    }
+}

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -497,7 +497,7 @@ task BuildGATKJar {
 
     # git and git-lfs
     apt-get -qq update
-    apt-get -qq install git git-lfs
+    apt-get -qq install --assume-yes git git-lfs
 
     # Temurin Java 17
     # https://adoptium.net/installation/linux/
@@ -506,7 +506,7 @@ task BuildGATKJar {
     wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc
     echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
     apt-get -qq update
-    apt-get -qq install temurin-17-jdk
+    apt-get -qq install --assume-yes temurin-17-jdk
 
     # GATK
     git clone https://github.com/broadinstitute/gatk.git --depth 1 --branch ~{git_branch_or_tag} --single-branch
@@ -627,7 +627,7 @@ task BuildGATKJarAndCreateDataset {
 
     # git and git-lfs
     apt-get -qq update
-    apt-get -qq install git git-lfs
+    apt-get -qq install --assume-yes git git-lfs
 
     # Temurin Java 17
     # https://adoptium.net/installation/linux/
@@ -636,7 +636,7 @@ task BuildGATKJarAndCreateDataset {
     wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc
     echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
     apt-get -qq update
-    apt-get -qq install temurin-17-jdk
+    apt-get -qq install --assume-yes temurin-17-jdk
 
     # GATK
     git clone https://github.com/broadinstitute/gatk.git --depth 1 --branch ~{git_branch_or_tag} --single-branch

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -56,7 +56,7 @@ task GetToolVersions {
   }
 
   File monitoring_script = "gs://gvs_quickstart_storage/cromwell_monitoring_script.sh"
-  String cloud_sdk_docker_decl = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-alpine"
+  String cloud_sdk_docker_decl = "gcr.io/google.com/cloudsdktool/cloud-sdk:522.0.0-alpine"
 
   # For GVS releases, set `version` to match the release branch name, e.g. gvs_<major>.<minor>.<patch>.
   # For non-release, leave the value at "unspecified".
@@ -128,7 +128,7 @@ task GetToolVersions {
     String cloud_sdk_docker = cloud_sdk_docker_decl #   Defined above as a declaration.
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
-    String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:435.0.0-slim"
+    String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:522.0.0-slim"
     String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-05-09-alpine-a47ccd7eabda"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2025-04-29-gatkbase-99aac5f90069"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -1452,7 +1452,7 @@ task GetHailScripts {
         File gvs_import_script = "app/import_gvs.py"
         File gvs_import_ploidy_script = "app/import_gvs_ploidy.py"
         File create_vat_inputs_script = "app/create_vat_inputs.py"
-        File hail_create_vat_input_script = "app/hail_create_vat_inputs.py"
+        File hail_create_vat_inputs_script = "app/hail_create_vat_inputs.py"
         File vds_validation_script = "app/vds_validation.py"
     }
     runtime {

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -123,7 +123,7 @@ task GetToolVersions {
     String gvs_version = read_string("version.txt")
     String git_hash = read_string("git_hash.txt")
     String cromwell_root = read_string("cromwell_root.txt")
-    String hail_version = "0.2.130.post1"
+    String hail_version = "0.2.134"
     String basic_docker = "ubuntu:22.04"
     String cloud_sdk_docker = cloud_sdk_docker_decl #   Defined above as a declaration.
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but

--- a/scripts/variantstore/wdl/GvsValidateVDS.wdl
+++ b/scripts/variantstore/wdl/GvsValidateVDS.wdl
@@ -139,6 +139,10 @@ task ValidateVds {
 
         account_name=$(gcloud config list account --format "value(core.account)")
 
+        apt install --assume-yes python3.11-venv
+        python3 -m venv ./localvenv
+        . ./localvenv/bin/activate
+
         pip3 install --upgrade pip
 
         if [[ ! -z "~{hail_wheel}" ]]

--- a/scripts/variantstore/wdl/GvsValidateVDS.wdl
+++ b/scripts/variantstore/wdl/GvsValidateVDS.wdl
@@ -77,7 +77,7 @@ workflow GvsValidateVDS {
 
     String effective_hail_version = select_first([hail_version, GetToolVersions.hail_version])
 
-    call GetHailScripts {
+    call Utils.GetHailScripts {
         input:
             variants_docker = effective_variants_docker,
     }
@@ -190,33 +190,5 @@ task ValidateVds {
     }
     output {
         String cluster_name = read_string("cluster_name.txt")
-    }
-}
-
-task GetHailScripts {
-    input {
-        String variants_docker
-    }
-    meta {
-        # OK to cache this as the scripts are drawn from the stringified Docker image and as long as that stays the same
-        # the script content should also stay the same.
-    }
-    command <<<
-        # Prepend date, time and pwd to xtrace log entries.
-        PS4='\D{+%F %T} \w $ '
-        set -o errexit -o nounset -o pipefail -o xtrace
-
-        # Not sure why this is required but without it:
-        # Absolute path /app/run_in_hail_cluster.py doesn't appear to be under any mount points: local-disk 10 SSD
-
-        mkdir app
-        cp /app/*.py app
-    >>>
-    output {
-        File run_in_hail_cluster_script = "app/run_in_hail_cluster.py"
-        File vds_validation_script = "app/vds_validation.py"
-    }
-    runtime {
-        docker: variants_docker
     }
 }

--- a/scripts/variantstore/wdl/test/GvsQuickstartHailIntegration.wdl
+++ b/scripts/variantstore/wdl/test/GvsQuickstartHailIntegration.wdl
@@ -208,7 +208,7 @@ task TieOutVds {
 
         # Versions of Hail near 0.2.117 demand Java 8 or Java 11, and refuse to run on Java 17. (This is because Google Dataproc is still on Java 11)
         # Temurin Java 8
-        apt-get -qq install wget apt-transport-https gnupg
+        apt-get -qq install --assume-yes wget apt-transport-https gnupg
         wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add -
         echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
         apt-get -qq update

--- a/scripts/variantstore/wdl/test/GvsQuickstartHailIntegration.wdl
+++ b/scripts/variantstore/wdl/test/GvsQuickstartHailIntegration.wdl
@@ -206,13 +206,17 @@ task TieOutVds {
 
         gcloud storage cp 'gs://hail-common/references/Homo_sapiens_assembly38.fasta*' ${REFERENCES_PATH}
 
-        # Versions of Hail near 0.2.117 demand Java 8 or Java 11, and refuse to run on Java 17. (This is because Google Dataproc is still on Java 11)
-        # Temurin Java 8
+        # Hail 0.2.134 appears to want at least Java 11.
+        # Temurin Java 11
         apt-get -qq install --assume-yes wget apt-transport-https gnupg
         wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add -
         echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
         apt-get -qq update
-        apt -qq install -y temurin-8-jdk
+        apt -qq install -y temurin-11-jdk
+
+        apt install --assume-yes python3.11-venv
+        python3 -m venv ./localvenv
+        . ./localvenv/bin/activate
 
         export PYSPARK_SUBMIT_ARGS='--driver-memory 16g --executor-memory 16g pyspark-shell'
         pip install --upgrade pip

--- a/scripts/variantstore/wdl/test/GvsTieOutVDS.wdl
+++ b/scripts/variantstore/wdl/test/GvsTieOutVDS.wdl
@@ -88,7 +88,7 @@ task TieOutVDS {
 
         # Versions of Hail near 0.2.117 demand Java 8 or Java 11, and refuse to run on Java 17. (This is because Google Dataproc is still on Java 11)
         # Temurin Java 8
-        apt-get -qq install wget apt-transport-https gnupg
+        apt-get -qq install --assume-yes wget apt-transport-https gnupg
         wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add -
         echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
         apt-get -qq update

--- a/scripts/variantstore/wdl/test/GvsTieOutVDS.wdl
+++ b/scripts/variantstore/wdl/test/GvsTieOutVDS.wdl
@@ -86,13 +86,13 @@ task TieOutVDS {
 
         gcloud storage cp 'gs://hail-common/references/Homo_sapiens_assembly38.fasta*' ${REFERENCES_PATH}
 
-        # Versions of Hail near 0.2.117 demand Java 8 or Java 11, and refuse to run on Java 17. (This is because Google Dataproc is still on Java 11)
-        # Temurin Java 8
+        # Hail 0.2.134 appears to want at least Java 11.
+        # Temurin Java 11
         apt-get -qq install --assume-yes wget apt-transport-https gnupg
         wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add -
         echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
         apt-get -qq update
-        apt -qq install --assume-yes temurin-8-jdk
+        apt -qq install --assume-yes temurin-11-jdk
 
         apt install --assume-yes python3.11-venv
         python3 -m venv ./localvenv

--- a/scripts/variantstore/wdl/test/GvsTieOutVDS.wdl
+++ b/scripts/variantstore/wdl/test/GvsTieOutVDS.wdl
@@ -92,7 +92,11 @@ task TieOutVDS {
         wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add -
         echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
         apt-get -qq update
-        apt -qq install -y temurin-8-jdk
+        apt -qq install --assume-yes temurin-8-jdk
+
+        apt install --assume-yes python3.11-venv
+        python3 -m venv ./localvenv
+        . ./localvenv/bin/activate
 
         export PYSPARK_SUBMIT_ARGS='--driver-memory 16g --executor-memory 16g pyspark-shell'
         pip install --upgrade pip


### PR DESCRIPTION
Successful run [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration%20mcovarr/submission_history/ae7a807b-5393-4b78-a5b2-f57f24c518bd).

Upgrading from Hail 0.2.130.post1 to 0.2.134 required upgrading our nearly 2-year-old version of the Google Cloud SDK images. The Dataproc client in the Google Cloud SDK version we had been using would not accept the arguments that the new `hailctl` gives it. This Google Cloud SDK upgrade turned out to be pretty disruptive as the Python versions on this image have been upgraded, and the new version does not allow for some of the constructs we were using. This newer Hail / Dataproc combo also required us to upgrade the version of Java we use for Hail from 8 to 11.