### PR TITLE
Bypass Terra Data Tables for Foxtrot [VS-1185][VS-1661][VS-1662][VS-1663]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -341,7 +341,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1665_variants_docker_base_image_update
+             - vs_1185_foxtrot_data_table
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -218,6 +218,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - vs_1185_foxtrot_data_table
          tags:
              - /.*/
    - name: GvsPrepareRangesCallset

--- a/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
+++ b/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
@@ -29,7 +29,7 @@
     this comes from the original unreblocked input files. Reblocked file names have historically looked something like
     `AB_A123456789_12345678901_1234567890_1.hard-filtered.gvcf.gz.reblocked.g.vcf.gz`.
   - Select out the fields of interest (`research_id`, `reblocked_gvcf`, `reblocked_gvcf_index`) from the sample list,
-    adjusting the arguments to `awk` as necessary:
+    adjusting the numerical arguments to `awk` as necessary:
       ```
       sed 1d foxtrot_sample_list.tsv | awk -F "\t" '{print $2"\t"$15"\t"$16}' > foxtrot_all_samples_fofn.txt
       ```
@@ -72,11 +72,9 @@ bq --apilog=false query --nouse_legacy_sql --project_id=aou-genomics-curation-pr
     SELECT f.research_id, f.reblocked_gvcf, f.reblocked_gvcf_index FROM
         `aou-genomics-curation-prod.foxtrot.foxtrot_all_samples_fofn` f LEFT OUTER JOIN
         `aou-genomics-curation-prod.foxtrot.sample_info` e ON f.research_id = e.sample_name
-        WHERE e.sample_name IS NULL'
+        WHERE f.withdrawn IS NULL and e.sample_name IS NULL'
 ```
   This FOFN will be used in the invocations of `GvsBulkIngestGenomes` workflow below.
-- **NOTE** If you want to create a large sample set after you have run the notebook, Terra provides (and recommends you use) this python [script](https://github.com/broadinstitute/firecloud-tools/tree/master/scripts/import_large_tsv) which allows you to upload a sample set to the workspace.
-- Make a note of the Google project ID ("aou-genomics-curation-prod"), dataset name (e.g. "aou_wgs" — if it does not exist be sure to create one before running any workflows) and callset identifier (e.g. "echo") as these will be inputs (`project_id`, `dataset_name` and `call_set_identifier`) to all or most of the GVS workflows. The [naming conventions for other aspects of GVS datasets are outlined here](https://docs.google.com/document/d/1pNtuv7uDoiOFPbwe4zx5sAGH7MyxwKqXkyrpNmBxeow).
 - Once the **non-control** samples have been fully ingested into BQ using the `GvsBulkIngestGenomes` workflow, the **control** samples can be manually added to the workspace and loaded in separately.
 
 ## The Main Pipeline

--- a/scripts/variantstore/scripts/Dockerfile
+++ b/scripts/variantstore/scripts/Dockerfile
@@ -31,7 +31,7 @@ RUN mkdir /fiss-build && \
 
 
 # The main layer does not install development tools, instead copies artifacts from the build layer above.
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:522.0.0-alpine as main
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-alpine as main
 
 RUN apk update && apk upgrade
 

--- a/scripts/variantstore/scripts/Dockerfile
+++ b/scripts/variantstore/scripts/Dockerfile
@@ -6,7 +6,7 @@
 # expensive to create and isn't expected to change often, while the steps in this Dockerfile are much less expensive and
 # more likely to change. Using a build-base image essentially allows the expensive layers to be globally cached which
 # should make building the final image much faster in most cases.
-FROM us.gcr.io/broad-dsde-methods/variantstore:2025-05-24-alpine-build-base as build
+FROM us.gcr.io/broad-dsde-methods/variantstore:2025-05-31-alpine-build-base as build
 
 # Install all of our variantstore Python requirements.
 # We constrain the version of setuptools to sidestep an issue in `terra-notebook-util`'s FISS dependency.

--- a/scripts/variantstore/scripts/build_base.Dockerfile
+++ b/scripts/variantstore/scripts/build_base.Dockerfile
@@ -11,7 +11,7 @@
 # under ideal circumstances, potentially much longer on low memory and/or non-x86 build hosts). Since this image isn't
 # expected to change often it's broken out into a separate "build-base" image that can effectively be globally cached
 # and referenced from the main Dockerfile.
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:522.0.0-alpine
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-alpine
 
 RUN apk update && apk upgrade
 
@@ -88,13 +88,3 @@ RUN mkdir /vcftools /vcftools-build && \
     make install
 
 ENV PERL5LIB /vcftools/share/perl5/site_perl/:$PERL5LIB
-
-# Install pysam from source, HEAD of master branch. The fix for the issue below is not yet in a release.
-# https://github.com/pysam-developers/pysam/issues/1339
-# https://github.com/pysam-developers/pysam/commit/9fe6ca913ebc7b096c91a3d8467c97edf7989555
-RUN mkdir /gitrepos && \
-    cd /gitrepos && \
-    git clone https://github.com/pysam-developers/pysam.git && \
-    cd pysam && \
-    . /localvenv/bin/activate && \
-    python setup.py install

--- a/scripts/variantstore/scripts/data_table_upload.py
+++ b/scripts/variantstore/scripts/data_table_upload.py
@@ -2,7 +2,7 @@
 
 """
 Can be run in any analysis terminal provided the associated proxy group has auth to write to the target table.
-Note that this is currently hardcoded to write to the Foxtrot scale test workspace.
+Note that this is currently hardcoded to write to the Foxtrot Batch / scale test workspace.
 """
 
 import csv
@@ -16,7 +16,7 @@ INPUT_FILE = "output.csv"
 
 def put_items(batch):
     table.put_rows(
-        table = "samples", # should be 'sample' but that consistently gives cryptic 400 errors
+        table = "sample",
         items = batch,
         workspace = WORKSPACE_NAME,
         workspace_namespace = WORKSPACE_NAMESPACE)
@@ -25,9 +25,13 @@ def put_items(batch):
 i = 0
 batch = []
 with open(INPUT_FILE, 'r') as f:
-    reader = csv.DictReader(f)
-    for row in reader:
-        batch.append(dict(row))
+    reader = csv.DictReader(f, delimiter='\t')
+    for csv_row in reader:
+        name = csv_row['sample_id']
+        attr_names = ['research_id', 'reblocked_gvcf', 'reblocked_gvcf_index']
+        attrs = {k: csv_row[k] for k in attr_names}
+        row = table.Row(name=name, attributes=attrs)
+        batch.append(row)
         i = i + 1
         if i % UPLOAD_BATCH_SIZE == 0:
             put_items(batch)

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -13,7 +13,10 @@ workflow GvsBulkIngestGenomes {
         String? sample_id_column_name ## Note that a column WILL exist that is the <entity>_id from the table name. However, some users will want to specify an alternate column for the sample_name during ingest
         String? vcf_files_column_name
         String? vcf_index_files_column_name
-        String? sample_set_name ## NOTE: currently we only allow the loading of one sample set at a time
+        ## NOTE: currently we only allow the loading of one sample set at a time.
+        String? sample_set_name
+        # Optional FOFN of VCFs to ingest. If specified, the workflow will not generate a fofn from the data table.
+        File? bulk_ingest_fofn
         # End GenerateImportFofnFromDataTable
 
         # Begin GvsAssignIds
@@ -59,6 +62,7 @@ workflow GvsBulkIngestGenomes {
         vcf_files_column_name: "The column that supplies the path for the GVCFs to be ingested. If not specified, the workflow will attempt to derive the column name."
         vcf_index_files_column_name: "The column that supplies the path for the GVCF index files to be ingested. If not specified, the workflow will attempt to derive the column name."
         sample_set_name: "The recommended way to load samples; Sample sets must be created by the user. If no sample_set_name is specified, all samples will be loaded into GVS"
+        bulk_ingest_fofn: "An explicitly specified FOFN of VCFs to be ingested; If specified, the workflow will not generate a fofn from the data table. This can be useful for avoiding the scale limitations of Terra data tables. The format is tab delimited with no header: sample_name<tab>gvcf_file_path<tab>gvcf_index_file_path. If this value is specified, none of the data table parameters should be specified."
     }
 
     if (!defined(git_hash) ||
@@ -78,6 +82,14 @@ workflow GvsBulkIngestGenomes {
     String effective_workspace_id = select_first([workspace_id, GetToolVersions.workspace_id])
     String effective_workspace_bucket = select_first([workspace_bucket, GetToolVersions.workspace_bucket])
 
+    if (defined(bulk_ingest_fofn) && (defined(sample_id_column_name) || defined(vcf_files_column_name) || defined(vcf_index_files_column_name) || defined(sample_set_name))) {
+        call Utils.TerminateWorkflow as MustNotSpecifyDataTableParams {
+            input:
+                message = "GvsBulkIngestGenomes called with bulk_ingest_fofn specified, but also with at least one data table parameter specified (sample_id_column_name, vcf_files_column_name, vcf_index_files_column_name, sample_set_name).",
+                basic_docker = effective_basic_docker,
+        }
+    }
+
     if (!load_vcf_headers && !load_vet_and_ref_ranges) {
         call Utils.TerminateWorkflow as MustLoadAtLeastOneThing {
             input:
@@ -86,21 +98,24 @@ workflow GvsBulkIngestGenomes {
         }
     }
 
-    call GenerateImportFofnFromDataTable {
-        input:
-            variants_docker = effective_variants_docker,
-            sample_set_name = sample_set_name,
-            data_table_name = data_table_name,
-            user_defined_sample_id_column_name = sample_id_column_name, ## NOTE: the user needs to define this, or it will default to the <entity>_id column
-            vcf_files_column_name = vcf_files_column_name,
-            vcf_index_files_column_name = vcf_index_files_column_name,
-            workspace_id = effective_workspace_id,
-            workspace_bucket = effective_workspace_bucket,
+    if (!defined(bulk_ingest_fofn)) {
+        # If the user has not specified a fofn, we will generate one from the data table.
+        call GenerateImportFofnFromDataTable {
+            input:
+                variants_docker = effective_variants_docker,
+                sample_set_name = sample_set_name,
+                data_table_name = data_table_name,
+                user_defined_sample_id_column_name = sample_id_column_name, ## NOTE: the user needs to define this, or it will default to the <entity>_id column
+                vcf_files_column_name = vcf_files_column_name,
+                vcf_index_files_column_name = vcf_index_files_column_name,
+                workspace_id = effective_workspace_id,
+                workspace_bucket = effective_workspace_bucket,
+        }
     }
 
     call SplitBulkImportFofn {
         input:
-            import_fofn = GenerateImportFofnFromDataTable.output_fofn,
+            import_fofn = select_first([GenerateImportFofnFromDataTable.output_fofn, bulk_ingest_fofn]),
             basic_docker = effective_basic_docker,
     }
 

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -83,7 +83,7 @@ workflow GvsBulkIngestGenomes {
     String effective_workspace_bucket = select_first([workspace_bucket, GetToolVersions.workspace_bucket])
 
     if (defined(bulk_ingest_fofn) && (defined(sample_id_column_name) || defined(vcf_files_column_name) || defined(vcf_index_files_column_name) || defined(sample_set_name))) {
-        call Utils.TerminateWorkflow as MustNotSpecifyDataTableParams {
+        call Utils.TerminateWorkflow as MustNotSpecifyDataTableParamsWhenBulkIngestFofnSpecified {
             input:
                 message = "GvsBulkIngestGenomes called with bulk_ingest_fofn specified, but also with at least one data table parameter specified (sample_id_column_name, vcf_files_column_name, vcf_index_files_column_name, sample_set_name).",
                 basic_docker = effective_basic_docker,

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -9,13 +9,14 @@ workflow GvsBulkIngestGenomes {
     input {
         # Begin GenerateImportFofnFromDataTable
         # for now set the entity type names with a default
-        String data_table_name = "sample" ## Note that it is possible an advanced user has a different name for the table. We could glean some information from the sample_set name if that has been defined, but this has not, and try to use that information instead of simply using the default "sample"
-        String? sample_id_column_name ## Note that a column WILL exist that is the <entity>_id from the table name. However, some users will want to specify an alternate column for the sample_name during ingest
+        String data_table_name = "sample"
+        # Note that a column WILL exist that is the <entity>_id from the table name. However, some users will want to
+        # specify an alternate column for the sample_name during ingest
+        String? sample_id_column_name
         String? vcf_files_column_name
         String? vcf_index_files_column_name
-        ## NOTE: currently we only allow the loading of one sample set at a time.
         String? sample_set_name
-        # Optional FOFN of VCFs to ingest. If specified, the workflow will not generate a fofn from the data table.
+        # Optional FOFN of VCFs to ingest. If specified, the workflow will use this and not generate a FOFN from the data table.
         File? bulk_ingest_fofn
         # End GenerateImportFofnFromDataTable
 
@@ -62,7 +63,7 @@ workflow GvsBulkIngestGenomes {
         vcf_files_column_name: "The column that supplies the path for the GVCFs to be ingested. If not specified, the workflow will attempt to derive the column name."
         vcf_index_files_column_name: "The column that supplies the path for the GVCF index files to be ingested. If not specified, the workflow will attempt to derive the column name."
         sample_set_name: "The recommended way to load samples; Sample sets must be created by the user. If no sample_set_name is specified, all samples will be loaded into GVS"
-        bulk_ingest_fofn: "An explicitly specified FOFN of VCFs to be ingested; If specified, the workflow will not generate a fofn from the data table. This can be useful for avoiding the scale limitations of Terra data tables. The format is tab delimited with no header: sample_name<tab>gvcf_file_path<tab>gvcf_index_file_path. If this value is specified, none of the data table parameters should be specified."
+        bulk_ingest_fofn: "An explicitly specified FOFN of VCFs to be ingested. If specified, the workflow will not generate a FOFN from the data table. This can be useful for avoiding the scale limitations of Terra data tables. The format is tab delimited with no header: sample_name<tab>gvcf_file_path<tab>gvcf_index_file_path. If this value is specified, none of the data table parameters should be specified."
     }
 
     if (!defined(git_hash) ||
@@ -99,7 +100,7 @@ workflow GvsBulkIngestGenomes {
     }
 
     if (!defined(bulk_ingest_fofn)) {
-        # If the user has not specified a fofn, we will generate one from the data table.
+        # If the user has not specified a FOFN, we will generate one from the data table.
         call GenerateImportFofnFromDataTable {
             input:
                 variants_docker = effective_variants_docker,

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -56,7 +56,7 @@ task GetToolVersions {
   }
 
   File monitoring_script = "gs://gvs_quickstart_storage/cromwell_monitoring_script.sh"
-  String cloud_sdk_docker_decl = "gcr.io/google.com/cloudsdktool/cloud-sdk:522.0.0-alpine"
+  String cloud_sdk_docker_decl = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-alpine"
 
   # For GVS releases, set `version` to match the release branch name, e.g. gvs_<major>.<minor>.<patch>.
   # For non-release, leave the value at "unspecified".
@@ -128,7 +128,7 @@ task GetToolVersions {
     String cloud_sdk_docker = cloud_sdk_docker_decl #   Defined above as a declaration.
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
-    String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:522.0.0-slim"
+    String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
     String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-05-27-alpine-17c40e4ba193"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2025-04-29-gatkbase-99aac5f90069"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -129,7 +129,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handlful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-05-27-alpine-17c40e4ba193"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-05-31-alpine-e23d1b954c3f"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2025-04-29-gatkbase-99aac5f90069"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"


### PR DESCRIPTION
Bypass Terra Data Tables completely for Foxtrot. This makes an all-of-Foxtrot FOFN, uploads it to BQ to work out which samples are new to Foxtrot, and then downloads a new-to-Foxtrot FOFN which is used directly as input to `GvsBulkIngestGenomes`. 

There are some fixes to an upload script from an earlier vision for this PR, but this is no longer intended to be used in the Foxtrot process.

Integration run [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration%20mcovarr/submission_history/ccccbbd4-a4d3-4e7b-95a8-ea598f799460), sample run from FOFN [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration%20mcovarr/submission_history/fba14da7-3109-4df7-8bf1-354fd70b8644).