### PR TITLE
Fix Funcotator transcript override functionality

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtils.java
@@ -2111,7 +2111,13 @@ public final class FuncotatorUtils {
      * @return The {@link String} corresponding to the given {@code transcriptId} without a version number.
      */
     public static String getTranscriptIdWithoutVersionNumber( final String transcriptId ) {
-        return transcriptId.replaceAll("\\.\\d+$", "");
+        final int end = transcriptId.indexOf('.');
+        if(end != -1) {
+            return transcriptId.substring(0, end);
+        }
+        else {
+            return transcriptId;
+        }
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactory.java
@@ -886,8 +886,7 @@ public class GencodeFuncotationFactory extends DataSourceFuncotationFactory {
         List<GencodeGtfTranscriptFeature> transcriptList;
 
         // Only get basic transcripts if we're using data from Gencode:
-        if ( gtfFeature.getGtfSourceFileType().equals(GencodeGtfCodec.GTF_FILE_TYPE_STRING) ||
-             gtfFeature.getGtfSourceFileType().equals(EnsemblGtfCodec.GTF_FILE_TYPE_STRING)) {
+        if ( gtfFeature.getGtfSourceFileType().equals(GencodeGtfCodec.GTF_FILE_TYPE_STRING) ) {
             if (preferMANETranscripts) {
                 // Filter out the non-MANE_Select/Mane_Plus_Clinical transcripts if we're only using MANE transcripts:
                 transcriptList = retreiveMANESelectModeTranscriptsCriteria(gtfFeature.getTranscripts());
@@ -895,9 +894,16 @@ public class GencodeFuncotationFactory extends DataSourceFuncotationFactory {
                 transcriptList = retrieveBasicTranscripts(gtfFeature);
             }
         } else {
-            transcriptList = gtfFeature.getTranscripts();
+            // GENCODE GRCh37 liftover GTF files (>=v43) are in ENSEMBL format
+            // We still want to be able to prefer MANE transcripts with the hg19 data source, hence the condition below
+            if (preferMANETranscripts && gtfFeature.getGtfSourceFileType().equals(EnsemblGtfCodec.GTF_FILE_TYPE_STRING))
+            {
+                transcriptList = retreiveMANESelectModeTranscriptsCriteria(gtfFeature.getTranscripts());
+            }
+            else {
+                transcriptList = gtfFeature.getTranscripts();
+            }
         }
-
 
         return createFuncotationsHelper(variant, altAllele, reference, transcriptList);
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactory.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/funcotator/dataSources/gencode/GencodeFuncotationFactory.java
@@ -886,7 +886,8 @@ public class GencodeFuncotationFactory extends DataSourceFuncotationFactory {
         List<GencodeGtfTranscriptFeature> transcriptList;
 
         // Only get basic transcripts if we're using data from Gencode:
-        if ( gtfFeature.getGtfSourceFileType().equals(GencodeGtfCodec.GTF_FILE_TYPE_STRING) ) {
+        if ( gtfFeature.getGtfSourceFileType().equals(GencodeGtfCodec.GTF_FILE_TYPE_STRING) ||
+             gtfFeature.getGtfSourceFileType().equals(EnsemblGtfCodec.GTF_FILE_TYPE_STRING)) {
             if (preferMANETranscripts) {
                 // Filter out the non-MANE_Select/Mane_Plus_Clinical transcripts if we're only using MANE transcripts:
                 transcriptList = retreiveMANESelectModeTranscriptsCriteria(gtfFeature.getTranscripts());

--- a/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/funcotator/FuncotatorUtilsUnitTest.java
@@ -2662,4 +2662,12 @@ public class FuncotatorUtilsUnitTest extends GATKBaseTest {
         final GATKPath customVcFile = new GATKPath(p.toUri().toString());
         FuncotatorUtils.setVariantClassificationCustomSeverity(customVcFile);
     }
+
+    @Test
+    public void testGetTranscriptIdWithoutVersionNumber() {
+        Assert.assertEquals(FuncotatorUtils.getTranscriptIdWithoutVersionNumber(""), "");
+        Assert.assertEquals(FuncotatorUtils.getTranscriptIdWithoutVersionNumber("ENST00000641515"), "ENST00000641515");
+        Assert.assertEquals(FuncotatorUtils.getTranscriptIdWithoutVersionNumber("ENST00000641515.2"), "ENST00000641515");
+        Assert.assertEquals(FuncotatorUtils.getTranscriptIdWithoutVersionNumber("ENST00000641515.2_4"), "ENST00000641515");
+    }
 }


### PR DESCRIPTION
Some of the newer GENCODE GTFs (at the very least GRCh37 liftovers of versions >v19) contain transcript IDs whose version numbers include a secondary number separated with an underscore, e.g. "ENST00000xxxxxx.yy_zz". The currently used regex only considers a single dot character followed by one or more digits and therefore fails to properly remove the version number. This PR should fix that.
Personal note: I don't like regexes in production code anyway, so instead of replacing it with one that works for now, I opted for a cleaner and more maintainable (in my opinion) alternative.

In addition, the recently introduced `--prefer-mane-transcripts` requires the file to be strictly of the GENCODE GTF format, but the hg19 data source with GENCODE v43 (backmapped to GRCh37) contains a GTF in the ENSEMBL GTF format (actually GFF3), making this option unusable. This PR should also fix that.