### PR TITLE
VS-1684 Don't fail on monitoring log format

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -344,7 +344,6 @@ workflows:
              - master
              - ah_var_store
              - vs_1676_AnVIL_3K
-             - gg_VS-1684_DontFailOnMonitoringLogFormat
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
+++ b/scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
@@ -5,7 +5,7 @@ import "GvsQuickstartHailIntegration.wdl" as QuickstartHailIntegration
 import "GvsQuickstartVATIntegration.wdl" as QuickstartVATIntegration
 import "../GvsJointVariantCalling.wdl" as JointVariantCalling
 import "../GvsUtils.wdl" as Utils
-# A
+
 workflow GvsQuickstartIntegration {
     input {
         String git_branch_or_tag


### PR DESCRIPTION
This PR modifies the summarize_task_monitor_logs python script to exit gracefully (error 0) if it doesn't recognize a monitoring log line. That way we won't fail the workflow that calls it.  We leave it as an exercise to the user to figure out why this has happened.

Passing integration test [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/submission_history/6589e53b-5c35-4383-bee1-6bfe0398ff50)