### PR TITLE
Updated GKL version to 0.9.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ final guavaVersion = System.getProperty('guava.version', '32.1.3-jre')
 final log4j2Version = System.getProperty('log4j2Version', '2.24.1')
 final testNGVersion = System.getProperty('testNGVersion', '7.7.0')
 final googleCloudNioVersion = System.getProperty('googleCloudNioVersion','0.127.8')
-final gklVersion = System.getProperty('gklVersion', '0.9.0')
+final gklVersion = System.getProperty('gklVersion', '0.9.1')
 
 final baseJarName = 'gatk'
 final secondaryBaseJarName = 'hellbender'


### PR DESCRIPTION
This PR updates the GKL dependency from v0.9.0 to v0.9.1, which includes a small but important bug fix for the Smith-Waterman implementation.

The change in GKL is minimal and localized, it simply moves a static global variable (D_MAX_SEQ_LEN) to an internal scope to avoid potential conflicts. There are no changes to the algorithm or outputs. You can view the change [here.]( https://github.com/IntelLabs/GKL/commit/e4b33e5be1d092c5f3151cab6144929cdbd70aaa)

I've verified the update locally, and everything works as expected. Given the limited scope of the change, this should be safe to include in the upcoming release.