### PR TITLE
VS-1679 - Don't allow filter_set_name to be reused.

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -289,7 +289,6 @@ workflows:
              - master
              - ah_var_store
              - vs_1670_release_0_6_3
-             - gg_VS-1679_DontLetCreateFilterSetReuseFilterSetName
          tags:
              - /.*/
    - name: GvsBeta
@@ -345,7 +344,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_VS-1679_DontLetCreateFilterSetReuseFilterSetName
              - sanity_check_ref_ranges_schema
          tags:
              - /.*/

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -126,6 +126,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_VS-1679_DontLetCreateFilterSetReuseFilterSetName
          tags:
              - /.*/
    - name: GvsPopulateAltAllele
@@ -288,6 +289,7 @@ workflows:
              - master
              - ah_var_store
              - vs_1670_release_0_6_3
+             - gg_VS-1679_DontLetCreateFilterSetReuseFilterSetName
          tags:
              - /.*/
    - name: GvsBeta
@@ -344,6 +346,7 @@ workflows:
              - master
              - ah_var_store
              - vs_1676_AnVIL_3K
+             - gg_VS-1679_DontLetCreateFilterSetReuseFilterSetName
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -314,9 +314,6 @@ task CheckIfFilterSetNameIsInUse {
     # Check if table exists and contains rows with the same filter_set_name
     echo "Checking if filter set '~{filter_set_name}' already exists in ~{fq_filter_sites_destination_table}"
 
-    # Convert table name for bq command (replace . with :)
-    bq_table_check=$(echo ~{fq_filter_sites_destination_table} | sed s/\\./:/)
-
     # Check if table exists and query for existing filter_set_name
     set +o errexit
     existing_count=$(bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false --max_rows=1 \
@@ -339,9 +336,6 @@ task CheckIfFilterSetNameIsInUse {
     ## Filter_set_info table check
     # Check if table exists and contains rows with the same filter_set_name
     echo "Checking if filter set '~{filter_set_name}' already exists in ~{fq_filter_set_info_destination_table}"
-
-    # Convert table name for bq command (replace . with :)
-    bq_table_check=$(echo ~{fq_filter_set_info_destination_table} | sed s/\\./:/)
 
     # Check if table exists and query for existing filter_set_name
     set +o errexit

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsVQSR.wdl" as VQSR
 import "../../vcf_site_level_filtering_wdl/JointVcfFiltering.wdl" as VETS
-#A
+
 workflow GvsCreateFilterSet {
   input {
     Boolean go = true
@@ -492,31 +492,6 @@ task PopulateFilterSetSites {
     bash ~{monitoring_script} > monitoring.log &
 
     export GATK_LOCAL_JAR=~{default="/root/gatk.jar" gatk_override}
-
-    # Check if table exists and contains rows with the same filter_set_name
-    echo "Checking if filter set '~{filter_set_name}' already exists in ~{fq_filter_sites_destination_table}"
-
-    # Convert table name for bq command (replace . with :)
-    bq_table_check=$(echo ~{fq_filter_sites_destination_table} | sed s/\\./:/)
-
-    # Check if table exists and query for existing filter_set_name
-    set +o errexit
-    existing_count=$(bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false --max_rows=1 \
-    "SELECT COUNT(*) as count FROM \`~{fq_filter_sites_destination_table}\` WHERE filter_set_name = '~{filter_set_name}'" 2>/dev/null | tail -1)
-    query_exit_code=$?
-    set -o errexit
-
-    if [[ $query_exit_code -eq 0 ]]; then
-      # Table exists, check if filter_set_name already exists
-      if [[ "$existing_count" != "0" ]]; then
-        echo "ERROR: Filter set '~{filter_set_name}' already exists in table ~{fq_filter_sites_destination_table}"
-        echo "Found $existing_count existing rows with this filter_set_name"
-        exit 1
-      fi
-      echo "Table ~{fq_filter_sites_destination_table} exists but filter_set_name '~{filter_set_name}' not found. Proceeding..."
-    else
-      echo "Table ~{fq_filter_sites_destination_table} does not exist yet. Proceeding..."
-    fi
 
     echo "Generating filter set sites TSV"
     gatk --java-options "-Xmx1g" \

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -184,7 +184,6 @@ workflow GvsExtractCallset {
         project_id = query_project,
         fq_filter_set_info_table = "~{fq_filter_set_info_table}",
         filter_set_name = filter_set_name,
-        filter_set_info_timestamp = FilterSetInfoTimestamp.last_modified_timestamp,
         cloud_sdk_docker = effective_cloud_sdk_docker,
       }
 

--- a/scripts/variantstore/wdl/GvsExtractCallsetPgen.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallsetPgen.wdl
@@ -186,7 +186,6 @@ workflow GvsExtractCallsetPgen {
                 project_id = query_project,
                 fq_filter_set_info_table = "~{fq_filter_set_info_table}",
                 filter_set_name = filter_set_name,
-                filter_set_info_timestamp = FilterSetInfoTimestamp.last_modified_timestamp,
                 cloud_sdk_docker = effective_cloud_sdk_docker,
         }
 

--- a/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
+++ b/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
@@ -6,7 +6,7 @@ import "GvsCreateFilterSet.wdl" as CreateFilterSet
 import "GvsPrepareRangesCallset.wdl" as PrepareRangesCallset
 import "GvsExtractCallset.wdl" as ExtractCallset
 import "GvsUtils.wdl" as Utils
-#A
+
 workflow GvsJointVariantCalling {
     input {
         Boolean go = true

--- a/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
+++ b/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
@@ -6,7 +6,7 @@ import "GvsCreateFilterSet.wdl" as CreateFilterSet
 import "GvsPrepareRangesCallset.wdl" as PrepareRangesCallset
 import "GvsExtractCallset.wdl" as ExtractCallset
 import "GvsUtils.wdl" as Utils
-
+#A
 workflow GvsJointVariantCalling {
     input {
         Boolean go = true

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -852,7 +852,6 @@ task ValidateFilterSetName {
         String project_id
         String fq_filter_set_info_table
         String filter_set_name
-        String filter_set_info_timestamp = ""
         String cloud_sdk_docker
     }
     meta {
@@ -1354,6 +1353,31 @@ task PopulateFilterSetInfo {
     bash ~{monitoring_script} > monitoring.log &
 
     export GATK_LOCAL_JAR=~{default="/root/gatk.jar" gatk_override}
+
+    # Check if table exists and contains rows with the same filter_set_name
+    echo "Checking if filter set '~{filter_set_name}' already exists in ~{fq_filter_set_info_destination_table}"
+
+    # Convert table name for bq command (replace . with :)
+    bq_table_check=$(echo ~{fq_filter_set_info_destination_table} | sed s/\\./:/)
+
+    # Check if table exists and query for existing filter_set_name
+    set +o errexit
+    existing_count=$(bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false --max_rows=1 \
+    "SELECT COUNT(*) as count FROM \`~{fq_filter_set_info_destination_table}\` WHERE filter_set_name = '~{filter_set_name}'" 2>/dev/null | tail -1)
+    query_exit_code=$?
+    set -o errexit
+
+    if [[ $query_exit_code -eq 0 ]]; then
+      # Table exists, check if filter_set_name already exists
+      if [[ "$existing_count" != "0" ]]; then
+        echo "ERROR: Filter set '~{filter_set_name}' already exists in table ~{fq_filter_set_info_destination_table}"
+        echo "Found $existing_count existing rows with this filter_set_name"
+        exit 1
+      fi
+      echo "Table ~{fq_filter_set_info_destination_table} exists but filter_set_name '~{filter_set_name}' not found. Proceeding..."
+    else
+      echo "Table ~{fq_filter_set_info_destination_table} does not exist yet. Proceeding..."
+    fi
 
     echo "Creating SNPs recalibration file"
     gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" \

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -1354,31 +1354,6 @@ task PopulateFilterSetInfo {
 
     export GATK_LOCAL_JAR=~{default="/root/gatk.jar" gatk_override}
 
-    # Check if table exists and contains rows with the same filter_set_name
-    echo "Checking if filter set '~{filter_set_name}' already exists in ~{fq_filter_set_info_destination_table}"
-
-    # Convert table name for bq command (replace . with :)
-    bq_table_check=$(echo ~{fq_filter_set_info_destination_table} | sed s/\\./:/)
-
-    # Check if table exists and query for existing filter_set_name
-    set +o errexit
-    existing_count=$(bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false --max_rows=1 \
-    "SELECT COUNT(*) as count FROM \`~{fq_filter_set_info_destination_table}\` WHERE filter_set_name = '~{filter_set_name}'" 2>/dev/null | tail -1)
-    query_exit_code=$?
-    set -o errexit
-
-    if [[ $query_exit_code -eq 0 ]]; then
-      # Table exists, check if filter_set_name already exists
-      if [[ "$existing_count" != "0" ]]; then
-        echo "ERROR: Filter set '~{filter_set_name}' already exists in table ~{fq_filter_set_info_destination_table}"
-        echo "Found $existing_count existing rows with this filter_set_name"
-        exit 1
-      fi
-      echo "Table ~{fq_filter_set_info_destination_table} exists but filter_set_name '~{filter_set_name}' not found. Proceeding..."
-    else
-      echo "Table ~{fq_filter_set_info_destination_table} does not exist yet. Proceeding..."
-    fi
-
     echo "Creating SNPs recalibration file"
     gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" \
       CreateFilteringFiles \


### PR DESCRIPTION
VS-1679. This PR puts a check in place that prevents the filter_set_name from being used twice.

Passing Integration test [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/submission_history/d712d93c-ec26-48bf-b362-942702414726)

Test that GvsCreateFilterSet fails when reusing filter_set_name [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/submission_history/ec56aa77-324e-459e-8fa7-c3345743033e)
Test that GvsCreateFilterSet works when you give it a new filter_set_name [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/submission_history/aba37cde-8f2f-4561-a217-54191132fdd8)