### PR TITLE
Update MendelianViolation . Fix  java.lang.IndexOutOfBoundsException: when a genotype is haploid.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/samples/MendelianViolation.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/samples/MendelianViolation.java
@@ -177,8 +177,15 @@ public class MendelianViolation {
         }
         //Both parents have genotype information
         final Allele childRef = gChild.getAlleles().get(0);
-        return !(gMom.getAlleles().contains(childRef) && gDad.getAlleles().contains(gChild.getAlleles().get(1)) ||
-            gMom.getAlleles().contains(gChild.getAlleles().get(1)) && gDad.getAlleles().contains(childRef));
+        switch (gChild.getPloidy()) {
+            case 1:
+                return !(gMom.getAlleles().contains(childRef) || gDad.getAlleles().contains(childRef));
+            case 2:
+                final Allele childAlt = gChild.getAlleles().get(1);
+                return !(gMom.getAlleles().contains(childRef) && gDad.getAlleles().contains(childAlt) ||
+                    gMom.getAlleles().contains(childAlt) && gDad.getAlleles().contains(childRef));
+            default: return false;
+        }
     }
 
     private void createInheritanceMap(){


### PR DESCRIPTION
Hi the GATK team,

this PR fiesx a bug in  MendelianViolation  when a sample is haploid.

sorry, not tested: I'm currently editing the code using the github interface.

```
  java.lang.IndexOutOfBoundsException: Index 1 out of bounds for length 1
        at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
        at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
        at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
        at java.base/java.util.Objects.checkIndex(Objects.java:359)
        at java.base/java.util.ArrayList.get(ArrayList.java:427)
        at org.broadinstitute.hellbender.utils.samples.MendelianViolation.isViolation(MendelianViolation.java:180)
        at org.broadinstitute.hellbender.utils.samples.MendelianViolation.updateViolations(MendelianViolation.java:122)
        at org.broadinstitute.hellbender.utils.samples.MendelianViolation.isViolation(MendelianViolation.java:81)
        at org.broadinstitute.hellbender.tools.walkers.annotator.PossibleDeNovo.annotate(PossibleDeNovo.java:119)
        at org.broadinstitute.hellbender.tools.walkers.annotator.VariantAnnotatorEngine.addInfoAnnotations(VariantAnnotatorEngine.java:394)
        at org.broadinstitute.hellbender.tools.walkers.annotator.VariantAnnotatorEngine.annotateContext(VariantAnnotatorEngine.java:367)
        at org.broadinstitute.hellbender.tools.walkers.annotator.VariantAnnotatorEngine.annotateContext(VariantAnnotatorEngine.java:338)
        at org.broadinstitute.hellbender.tools.walkers.annotator.VariantAnnotator.apply(VariantAnnotator.java:243)
        at org.broadinstitute.hellbender.engine.VariantWalker.lambda$traverse$0(VariantWalker.java:104)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
        at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
        at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
        at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1845)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
```