### PR TITLE
Fix ploidy compatibility with VDS `intermediate_resume_point` [VS-1633]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -340,7 +340,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1633_fix_avro_extract
+             - vs_1633_ploidy_with_vds_resume
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/scripts/import_gvs.py
+++ b/scripts/variantstore/scripts/import_gvs.py
@@ -197,7 +197,7 @@ def import_gvs(refs: 'List[List[str]]',
         vets_filter = vets_filter.key_by('locus')
         vets_filter.write(vets_filter_path, overwrite=True)
 
-        ploidy = import_gvs_ploidy.import_ploidy(*ploidy_data)
+    ploidy = import_gvs_ploidy.import_ploidy(*ploidy_data)
 
     n_samples = 0
 

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -129,7 +129,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-08-13-alpine-b25aaed8271d"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-08-14-alpine-ed9cbc2508e8"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2025-07-29-gatkbase-650b8e1a32f0"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"


### PR DESCRIPTION
Ploidy data is currently not being initialized in the "resume" scenario, but deleting four spaces can fix that! Integration run going [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration%20mcovarr/submission_history/4e99a1f0-5e98-42bd-a2ba-19d5c5bd899c)