### PR TITLE
VS-1732. Modify Callset Statistics calculation to break up the chromosomes

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -377,6 +377,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_VS-1732_CallsetStatisticsAnotherImprovement
          tags:
              - /.*/
    - name: GvsFindHailCruft

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -379,7 +379,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_VS-1732_CallsetStatisticsAnotherImprovement
          tags:
              - /.*/
    - name: GvsFindHailCruft

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# 4
+# 5
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -380,6 +380,7 @@ task CollectMetricsForChromosome {
         echo "Number of chunk endpoints: ${#chunk_endpoints[@]}"
 
         # Iterate over all chunks
+        start_location=~{chromosome}000000000000
         for ((i=0; i<${#chunk_endpoints[@]}; i++)); do
             end_location=${chunk_endpoints[i]}
             echo "Running query for >= $start_location to < $end_location"

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# 7
+# 8
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -369,16 +369,17 @@ task CollectMetricsForChromosome {
                 chunk_endpoints+=($((nlocation * i)))
                 echo "Added chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
             done
-#            # Set the final endpoint to be beyond the end of the chromosome
-#            chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]=~{chromosome + 1}000000000000
-#            echo "Final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
-#        else
-#            # Just one chunk, so just do the whole chromosome
-#            chunk_endpoints+=(~{chromosome + 1}000000000000)
-#            echo "Only one chunk, final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
+            # Set the final endpoint to be beyond the end of the chromosome
+            echo "Setting final chunk endpoint to end of chromosome ~{chromosome + 1}000000000000"
+            chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]=~{chromosome + 1}000000000000
+            echo "Final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
+        else
+            # Just one chunk, so just do the whole chromosome
+            chunk_endpoints+=(~{chromosome + 1}000000000000)
+            echo "Only one chunk, final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
         fi
-        echo "Adding final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]} (end of chromosome)"
-        chunk_endpoints+=(~{chromosome + 1}000000000000)
+#        chunk_endpoints+=(~{chromosome + 1}000000000000)
+#        echo "Added final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]} (end of chromosome)"
 
         echo "Number of chunk endpoints: ${#chunk_endpoints[@]}"
 

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# H
+# I
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -342,6 +342,9 @@ task CollectMetricsForChromosome {
         start_location=~{chromosome}000000000000
         mid_location=$(cut -f 0 -d ',' locations.txt)
         max_location=$(cut -f 1 -d ',' locations.txt)
+        echo "start_location = $start_location"
+        echo "mid_location = $mid_location"
+        echo "max_location = $max_location"
 
         # Run the query twice
         for end_location in $mid_location $max_location; do

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -377,7 +377,7 @@ task CollectMetricsForChromosome {
 #            chunk_endpoints+=(~{chromosome + 1}000000000000)
 #            echo "Only one chunk, final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
         fi
-        echo "Adding final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
+        echo "Adding final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]} (end of chromosome)"
         chunk_endpoints+=(~{chromosome + 1}000000000000)
 
         echo "Number of chunk endpoints: ${#chunk_endpoints[@]}"

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# C
+# D
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -335,13 +335,13 @@ task CollectMetricsForChromosome {
 
         # bq query Get the mid-point and max of the locations for this chromosome
         bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false '
-        SELECT (max(location) - min(location)) / 2 + min(location), max(location)
+        SELECT CAST((max(location) - min(location)) / 2 + min(location) AS INT64), max(location)
             FROM `gvs-internal.gg_ah_var_store_20250529.callset__VET_DATA`
             WHERE location >= ~{chromosome}000000000000 and location < ~{chromosome + 1}000000000000' | sed 1d > locations.txt
 
         start_location=~{chromosome}000000000000
-        mid_location=$(head -1 locations.txt)
-        max_location=$(tail -1 locations.txt)
+        mid_location=$(cut -f 0 -d ',' locations.txt)
+        max_location=$(cut -f 1 -d ',' locations.txt)
 
         # Run the query twice
         for end_location in $mid_location $max_location; do

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# A
+# B
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -358,10 +358,11 @@ task CollectMetricsForChromosome {
         if [ ~{num_chunks} -gt 1 ]; then
             # bq query Get the mid-point and min of the (found) locations for this chromosome
             bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false '
-                SELECT CAST((max(location) + min(location)) / ~{num_chunks} AS INT64, min(location))
+                SELECT CAST((max(location) + min(location)) / ~{num_chunks} AS INT64, min(location)
                     FROM `~{project_id}.~{dataset_name}.~{extract_prefix}__VET_DATA`
                     WHERE location >= ~{chromosome}000000000000 and location < ~{chromosome + 1}000000000000' | sed 1d > locations.txt
 
+            cat locations.txt
             chunk_width=$(cut -f 1 -d ',' locations.txt)
             echo "chunk_width = $chunk_width"
             min_location=$(cut -f 2 -d ',' locations.txt)

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# K
+# L
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -433,10 +433,11 @@ task CollectMetricsForChromosome {
                 FROM `~{project_id}.~{dataset_name}.~{extract_prefix}__VET_DATA` v
                 LEFT JOIN `gvs-internal.gvs_public_reference_data.gnomad_v3_sites` gnomad ON (v.location = gnomad.location)
                 WHERE call_GT != "./."
-                AND v.location > '$start_location'
-                AND v.location <= '$end_location') GROUP BY 1,2
+                AND v.location >= '$start_location'
+                AND v.location < '$end_location') GROUP BY 1,2
             '
             start_location=$end_location
+            ((++start_location))        # move past the last location we just processed
         done
 
     >>>

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# L
+# M
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -434,7 +434,7 @@ task CollectMetricsForChromosome {
                 LEFT JOIN `gvs-internal.gvs_public_reference_data.gnomad_v3_sites` gnomad ON (v.location = gnomad.location)
                 WHERE call_GT != "./."
                 AND v.location >= '$start_location'
-                AND v.location < '$end_location') GROUP BY 1,2
+                AND v.location <= '$end_location') GROUP BY 1,2
             '
             start_location=$end_location
             ((++start_location))        # move past the last location we just processed

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# N
+
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -431,7 +431,7 @@ task CollectMetricsForChromosome {
                        titv(ref, alt) as titv,
                        CASE WHEN gnomad.location IS NULL THEN false ELSE true END in_gnomad
                 FROM `~{project_id}.~{dataset_name}.~{extract_prefix}__VET_DATA` v
-                LEFT JOIN `gvs-internal.gvs_public_reference_data.gnomad_v3_sites` gnomad ON (v.location = gnomad.location)
+                LEFT JOIN `aou-genomics-curation-prod.gvs_public_reference_data.gnomad_v3_sites` gnomad ON (v.location = gnomad.location)
                 WHERE call_GT != "./."
                 AND v.location >= '$start_location'
                 AND v.location < '$end_location') GROUP BY 1,2

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# D
+# E
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -434,7 +434,7 @@ task CollectMetricsForChromosome {
                 LEFT JOIN `aou-genomics-curation-prod.gvs_public_reference_data.gnomad_v3_sites` gnomad ON (v.location = gnomad.location)
                 WHERE call_GT != "./."
                 AND v.location >= '$start_location'
-                AND v.location < '$end_location' GROUP BY 1,2
+                AND v.location < '$end_location') GROUP BY 1,2
             '
             start_location=$end_location
         done

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-
+# 1
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -9,24 +9,43 @@ workflow GvsCallsetStatistics {
         String project_id
         String dataset_name
         String filter_set_name
+        Int num_chunks = 2
         String extract_prefix
         String metrics_table = "~{extract_prefix}_sample_metrics"
         String aggregate_metrics_table = "~{extract_prefix}_sample_metrics_aggregate"
         String statistics_table = "~{extract_prefix}_statistics"
+        String? basic_docker
         String? cloud_sdk_docker
     }
 
     # Always call `GetToolVersions` to get the git hash for this run as this is a top-level-only WDL (i.e. there are
     # no calling WDLs that might supply `git_hash`).
-    if (!defined(git_hash) || !defined(cloud_sdk_docker)) {
+    if (!defined(git_hash) || !defined(basic_docker) || !defined(cloud_sdk_docker)) {
       call Utils.GetToolVersions {
           input:
               git_branch_or_tag = git_branch_or_tag,
       }
     }
 
+    String effective_basic_docker = select_first([basic_docker, GetToolVersions.basic_docker])
     String effective_cloud_sdk_docker = select_first([cloud_sdk_docker, GetToolVersions.cloud_sdk_docker])
     String effective_git_hash = select_first([git_hash, GetToolVersions.git_hash])
+
+    if (num_chunks <= 0 || num_chunks > 50) {
+        call Utils.TerminateWorkflow as NumChunksError {
+            input:
+                message = "The input parameter 'num_chunks' must be >= 1 and < 50!",
+                basic_docker = effective_basic_docker,
+        }
+    }
+
+    if (num_chunks <= 0) {
+        call Utils.TerminateWorkflow as NumChunksTooLow {
+            input:
+                message = "The input parameter 'num_chunks' must be >= 1!",
+                basic_docker = effective_basic_docker,
+        }
+    }
 
     call Utils.ValidateFilterSetName {
         input:
@@ -55,6 +74,7 @@ workflow GvsCallsetStatistics {
                 project_id = project_id,
                 dataset_name = dataset_name,
                 filter_set_name = filter_set_name,
+                num_chunks = num_chunks,
                 extract_prefix = extract_prefix,
                 metrics_table = metrics_table,
                 cloud_sdk_docker = effective_cloud_sdk_docker,
@@ -305,6 +325,7 @@ task CollectMetricsForChromosome {
         String project_id
         String dataset_name
         String filter_set_name
+        Int num_chunks = 2
         String extract_prefix
         String metrics_table
         Int chromosome
@@ -335,16 +356,23 @@ task CollectMetricsForChromosome {
 
         # bq query Get the mid-point and max of the locations for this chromosome
         bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false '
-        SELECT CAST((max(location) + min(location)) / 2 AS INT64)
-            FROM `gvs-internal.gg_ah_var_store_20250529.callset__VET_DATA`
+        SELECT CAST((max(location) + min(location)) / ~{num_chunks} AS INT64)
+            FROM `~{project_id}.~{dataset_name}.~{extract_prefix}__VET_DATA`
             WHERE location >= ~{chromosome}000000000000 and location < ~{chromosome + 1}000000000000' | sed 1d > locations.txt
 
-        start_location=~{chromosome}000000000000
-        mid_location=$(cat locations.txt)
-        max_location=~{chromosome + 1}000000000000
+        nlocation=$(cat locations.txt)
+        chunk_endpoints=()
+        for i in $(seq 1 $((num_chunks - 1))); do
+            chunk_endpoints+=($((nlocation * i)))
+        done
+        echo "Chunk endpoints: ${chunk_endpoints[@]}"
 
-        # Run the query twice
-        for end_location in $mid_location $max_location; do
+        # Set the final endpoint to be beyond the end of the chromosome
+        chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]=~{chromosome + 1}000000000000
+
+        # Iterate over all chunks
+        for ((i=0; i<${#chunk_endpoints[@]}; i++)); do
+            end_location=${chunk_endpoints[i]}
             echo "Running query for >= $start_location to < $end_location"
 
             # bq query --max_rows check: ok insert (elaborate one)

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-
+# A
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -333,9 +333,19 @@ task CollectMetricsForChromosome {
             exit 1
         fi
 
-        # Run the query twice: once for mod value 0, once for mod value 1
-        for mod_value in 0 1; do
-            echo "Running query for mod value: ${mod_value}"
+        # bq query Get the mid-point and max of the locations for this chromosome
+        bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false '
+        SELECT (max(location) - min(location)) / 2 + min(location), max(location)
+            FROM `gvs-internal.gg_ah_var_store_20250529.callset__VET_DATA`
+            WHERE location >= ~{chromosome}000000000000 and location < ~{chromosome + 1}000000000000) | sed 1d > locations.txt
+
+        start_location=~{chromosome}000000000000
+        mid_location=$(head -1 locations.txt)
+        max_location=$(tail -1 locations.txt)
+
+        # Run the query twice
+        for end_location in $mid_location $max_location; do
+            echo "Running query for $start_location to $end_location"
 
             # bq query --max_rows check: ok insert (elaborate one)
             bq --apilog=false query --project_id=~{project_id} --use_legacy_sql=false '
@@ -423,10 +433,10 @@ task CollectMetricsForChromosome {
                 FROM `~{project_id}.~{dataset_name}.~{extract_prefix}__VET_DATA` v
                 LEFT JOIN `aou-genomics-curation-prod.gvs_public_reference_data.gnomad_v3_sites` gnomad ON (v.location = gnomad.location)
                 WHERE call_GT != "./."
-                AND mod(v.sample_id, 2) = '$mod_value'
-                AND v.location >= ~{chromosome}000000000000
-                AND v.location < ~{chromosome + 1}000000000000) GROUP BY 1,2
+                AND v.location >= '$start_location'
+                AND v.location < '$end_location' GROUP BY 1,2
             '
+            start_location=$end_location
         done
 
     >>>

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# 8
+# 9
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -369,10 +369,9 @@ task CollectMetricsForChromosome {
                 chunk_endpoints+=($((nlocation * i)))
                 echo "Added chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
             done
+            chunk_endpoints+=(~{chromosome + 1}000000000000)
             # Set the final endpoint to be beyond the end of the chromosome
-            echo "Setting final chunk endpoint to end of chromosome ~{chromosome + 1}000000000000"
-            chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]=~{chromosome + 1}000000000000
-            echo "Final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
+            echo "Added final chunk endpoint => to end of chromosome ~{chromosome + 1}000000000000"
         else
             # Just one chunk, so just do the whole chromosome
             chunk_endpoints+=(~{chromosome + 1}000000000000)

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# 6
+# 7
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# F
+# G
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -335,7 +335,7 @@ task CollectMetricsForChromosome {
 
         # bq query Get the mid-point and max of the locations for this chromosome
         bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false '
-        SELECT CAST((max(location) - min(location)) / 2 + min(location) AS INT64), max(location)
+        SELECT CAST((max(location) + min(location)) / 2 + min(location) AS INT64), max(location)
             FROM `gvs-internal.gg_ah_var_store_20250529.callset__VET_DATA`
             WHERE location >= ~{chromosome}000000000000 and location < ~{chromosome + 1}000000000000' | sed 1d > locations.txt
 

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# M
+# N
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -335,17 +335,17 @@ task CollectMetricsForChromosome {
 
         # bq query Get the mid-point and max of the locations for this chromosome
         bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false '
-        SELECT CAST((max(location) + min(location)) / 2 AS INT64), max(location)
+        SELECT CAST((max(location) + min(location)) / 2 AS INT64)
             FROM `gvs-internal.gg_ah_var_store_20250529.callset__VET_DATA`
             WHERE location >= ~{chromosome}000000000000 and location < ~{chromosome + 1}000000000000' | sed 1d > locations.txt
 
         start_location=~{chromosome}000000000000
-        mid_location=$(cut -f 1 -d ',' locations.txt)
-        max_location=$(cut -f 2 -d ',' locations.txt)
+        mid_location=$(cat locations.txt)
+        max_location=~{chromosome + 1}000000000000
 
         # Run the query twice
         for end_location in $mid_location $max_location; do
-            echo "Running query for $start_location to $end_location"
+            echo "Running query for >= $start_location to < $end_location"
 
             # bq query --max_rows check: ok insert (elaborate one)
             bq --apilog=false query --project_id=~{project_id} --use_legacy_sql=false '
@@ -434,10 +434,9 @@ task CollectMetricsForChromosome {
                 LEFT JOIN `gvs-internal.gvs_public_reference_data.gnomad_v3_sites` gnomad ON (v.location = gnomad.location)
                 WHERE call_GT != "./."
                 AND v.location >= '$start_location'
-                AND v.location <= '$end_location') GROUP BY 1,2
+                AND v.location < '$end_location') GROUP BY 1,2
             '
             start_location=$end_location
-            ((++start_location))        # move past the last location we just processed
         done
 
     >>>

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# 1
+# 2
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -354,21 +354,29 @@ task CollectMetricsForChromosome {
             exit 1
         fi
 
-        # bq query Get the mid-point and max of the locations for this chromosome
-        bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false '
-        SELECT CAST((max(location) + min(location)) / ~{num_chunks} AS INT64)
-            FROM `~{project_id}.~{dataset_name}.~{extract_prefix}__VET_DATA`
-            WHERE location >= ~{chromosome}000000000000 and location < ~{chromosome + 1}000000000000' | sed 1d > locations.txt
-
-        nlocation=$(cat locations.txt)
         chunk_endpoints=()
-        for i in $(seq 1 $((num_chunks - 1))); do
-            chunk_endpoints+=($((nlocation * i)))
-        done
-        echo "Chunk endpoints: ${chunk_endpoints[@]}"
+        if [ ~{num_chunks} -gt 1 ]; then
+            # bq query Get the mid-point and max of the locations for this chromosome
+            bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false '
+                SELECT CAST((max(location) + min(location)) / ~{num_chunks} AS INT64)
+                    FROM `~{project_id}.~{dataset_name}.~{extract_prefix}__VET_DATA`
+                    WHERE location >= ~{chromosome}000000000000 and location < ~{chromosome + 1}000000000000' | sed 1d > locations.txt
 
-        # Set the final endpoint to be beyond the end of the chromosome
-        chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]=~{chromosome + 1}000000000000
+            nlocation=$(cat locations.txt)
+            echo "nlocation = $nlocation"
+
+            for i in $(seq 1 $((~{num_chunks} - 1))); do
+                chunk_endpoints+=($((nlocation * i)))
+                echo "Added chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
+            done
+            # Set the final endpoint to be beyond the end of the chromosome
+            chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]=~{chromosome + 1}000000000000
+            echo "Final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
+        else
+            # Just one chunk, so just do the whole chromosome
+            chunk_endpoints+=($((~{chromosome} + 1)000000000000))
+            echo "Only one chunk, final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
+        fi
 
         # Iterate over all chunks
         for ((i=0; i<${#chunk_endpoints[@]}; i++)); do

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# J
+# K
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -339,15 +339,9 @@ task CollectMetricsForChromosome {
             FROM `gvs-internal.gg_ah_var_store_20250529.callset__VET_DATA`
             WHERE location >= ~{chromosome}000000000000 and location < ~{chromosome + 1}000000000000' | sed 1d > locations.txt
 
-        echo "Hello"
-        cat locations.txt
-        echo "There"
         start_location=~{chromosome}000000000000
         mid_location=$(cut -f 1 -d ',' locations.txt)
         max_location=$(cut -f 2 -d ',' locations.txt)
-        echo "start_location = $start_location"
-        echo "mid_location = $mid_location"
-        echo "max_location = $max_location"
 
         # Run the query twice
         for end_location in $mid_location $max_location; do
@@ -439,8 +433,8 @@ task CollectMetricsForChromosome {
                 FROM `~{project_id}.~{dataset_name}.~{extract_prefix}__VET_DATA` v
                 LEFT JOIN `gvs-internal.gvs_public_reference_data.gnomad_v3_sites` gnomad ON (v.location = gnomad.location)
                 WHERE call_GT != "./."
-                AND v.location >= '$start_location'
-                AND v.location < '$end_location') GROUP BY 1,2
+                AND v.location > '$start_location'
+                AND v.location <= '$end_location') GROUP BY 1,2
             '
             start_location=$end_location
         done

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# B
+# C
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -337,7 +337,7 @@ task CollectMetricsForChromosome {
         bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false '
         SELECT (max(location) - min(location)) / 2 + min(location), max(location)
             FROM `gvs-internal.gg_ah_var_store_20250529.callset__VET_DATA`
-            WHERE location >= ~{chromosome}000000000000 and location < ~{chromosome + 1}000000000000)' | sed 1d > locations.txt
+            WHERE location >= ~{chromosome}000000000000 and location < ~{chromosome + 1}000000000000' | sed 1d > locations.txt
 
         start_location=~{chromosome}000000000000
         mid_location=$(head -1 locations.txt)

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# I
+# J
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -339,9 +339,12 @@ task CollectMetricsForChromosome {
             FROM `gvs-internal.gg_ah_var_store_20250529.callset__VET_DATA`
             WHERE location >= ~{chromosome}000000000000 and location < ~{chromosome + 1}000000000000' | sed 1d > locations.txt
 
+        echo "Hello"
+        cat locations.txt
+        echo "There"
         start_location=~{chromosome}000000000000
-        mid_location=$(cut -f 0 -d ',' locations.txt)
-        max_location=$(cut -f 1 -d ',' locations.txt)
+        mid_location=$(cut -f 1 -d ',' locations.txt)
+        max_location=$(cut -f 2 -d ',' locations.txt)
         echo "start_location = $start_location"
         echo "mid_location = $mid_location"
         echo "max_location = $max_location"

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# X
+# i
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -354,6 +354,7 @@ task CollectMetricsForChromosome {
             exit 1
         fi
 
+        start_location=~{chromosome}000000000000
         chunk_endpoints=()
         if [ ~{num_chunks} -gt 1 ]; then
             # bq query Get the mid-point and max of the locations for this chromosome
@@ -366,25 +367,17 @@ task CollectMetricsForChromosome {
             echo "nlocation = $nlocation"
 
             for i in $(seq 1 $((~{num_chunks} - 1))); do
-                chunk_endpoints+=($((nlocation * i)))
+                chunk_endpoints+=($((nlocation * i + start_location)))
                 echo "Added chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
             done
-#            chunk_endpoints+=(~{chromosome + 1}000000000000)
-#            # Set the final endpoint to be beyond the end of the chromosome
-#            echo "Added final chunk endpoint > to beginning of next chromosome = ~{chromosome + 1}000000000000"
-#        else
-#            # Just one chunk, so just do the whole chromosome
-#            chunk_endpoints+=(~{chromosome + 1}000000000000)
-#            echo "Only one chunk, final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
         fi
-        # Set the final endpoint to be beyond the end of the chromosome
+        # Set the final endpoint to be beyond the start of the next chromosome
         chunk_endpoints+=(~{chromosome + 1}000000000000)
-        echo "Added final chunk endpoint > to beginning of next chromosome = ~{chromosome + 1}000000000000"
+        echo "Added final chunk endpoint (the beginning of the next chromosome) = ~{chromosome + 1}000000000000"
 
         echo "Number of chunk endpoints: ${#chunk_endpoints[@]}"
 
         # Iterate over all chunks
-        start_location=~{chromosome}000000000000
         for ((i=0; i<${#chunk_endpoints[@]}; i++)); do
             end_location=${chunk_endpoints[i]}
             echo "Running query for >= $start_location to < $end_location"

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# 3
+# 4
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -374,7 +374,7 @@ task CollectMetricsForChromosome {
             echo "Final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
         else
             # Just one chunk, so just do the whole chromosome
-            chunk_endpoints+=(~{chromosome} + 1)000000000000)
+            chunk_endpoints+=(~{chromosome + 1}000000000000)
             echo "Only one chunk, final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
         fi
         echo "Number of chunk endpoints: ${#chunk_endpoints[@]}"

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# G
+# H
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -335,7 +335,7 @@ task CollectMetricsForChromosome {
 
         # bq query Get the mid-point and max of the locations for this chromosome
         bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false '
-        SELECT CAST((max(location) + min(location)) / 2 + min(location) AS INT64), max(location)
+        SELECT CAST((max(location) + min(location)) / 2 AS INT64), max(location)
             FROM `gvs-internal.gg_ah_var_store_20250529.callset__VET_DATA`
             WHERE location >= ~{chromosome}000000000000 and location < ~{chromosome + 1}000000000000' | sed 1d > locations.txt
 

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# 2
+# 3
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -374,9 +374,10 @@ task CollectMetricsForChromosome {
             echo "Final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
         else
             # Just one chunk, so just do the whole chromosome
-            chunk_endpoints+=($((~{chromosome} + 1)000000000000))
+            chunk_endpoints+=(~{chromosome} + 1)000000000000)
             echo "Only one chunk, final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
         fi
+        echo "Number of chunk endpoints: ${#chunk_endpoints[@]}"
 
         # Iterate over all chunks
         for ((i=0; i<${#chunk_endpoints[@]}; i++)); do
@@ -467,7 +468,7 @@ task CollectMetricsForChromosome {
                        titv(ref, alt) as titv,
                        CASE WHEN gnomad.location IS NULL THEN false ELSE true END in_gnomad
                 FROM `~{project_id}.~{dataset_name}.~{extract_prefix}__VET_DATA` v
-                LEFT JOIN `aou-genomics-curation-prod.gvs_public_reference_data.gnomad_v3_sites` gnomad ON (v.location = gnomad.location)
+                LEFT JOIN `gvs-internal.gvs_public_reference_data.gnomad_v3_sites` gnomad ON (v.location = gnomad.location)
                 WHERE call_GT != "./."
                 AND v.location >= '$start_location'
                 AND v.location < '$end_location') GROUP BY 1,2

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# B
+# C
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -358,7 +358,7 @@ task CollectMetricsForChromosome {
         if [ ~{num_chunks} -gt 1 ]; then
             # bq query Get the mid-point and min of the (found) locations for this chromosome
             bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false '
-                SELECT CAST((max(location) + min(location)) / ~{num_chunks} AS INT64, min(location)
+                SELECT CAST((max(location) - min(location)) / ~{num_chunks} AS INT64), min(location)
                     FROM `~{project_id}.~{dataset_name}.~{extract_prefix}__VET_DATA`
                     WHERE location >= ~{chromosome}000000000000 and location < ~{chromosome + 1}000000000000' | sed 1d > locations.txt
 

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# 9
+# X
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -369,16 +369,17 @@ task CollectMetricsForChromosome {
                 chunk_endpoints+=($((nlocation * i)))
                 echo "Added chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
             done
-            chunk_endpoints+=(~{chromosome + 1}000000000000)
-            # Set the final endpoint to be beyond the end of the chromosome
-            echo "Added final chunk endpoint => to end of chromosome ~{chromosome + 1}000000000000"
-        else
-            # Just one chunk, so just do the whole chromosome
-            chunk_endpoints+=(~{chromosome + 1}000000000000)
-            echo "Only one chunk, final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
+#            chunk_endpoints+=(~{chromosome + 1}000000000000)
+#            # Set the final endpoint to be beyond the end of the chromosome
+#            echo "Added final chunk endpoint > to beginning of next chromosome = ~{chromosome + 1}000000000000"
+#        else
+#            # Just one chunk, so just do the whole chromosome
+#            chunk_endpoints+=(~{chromosome + 1}000000000000)
+#            echo "Only one chunk, final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
         fi
-#        chunk_endpoints+=(~{chromosome + 1}000000000000)
-#        echo "Added final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]} (end of chromosome)"
+        # Set the final endpoint to be beyond the end of the chromosome
+        chunk_endpoints+=(~{chromosome + 1}000000000000)
+        echo "Added final chunk endpoint > to beginning of next chromosome = ~{chromosome + 1}000000000000"
 
         echo "Number of chunk endpoints: ${#chunk_endpoints[@]}"
 

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# i
+# A
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -354,20 +354,21 @@ task CollectMetricsForChromosome {
             exit 1
         fi
 
-        start_location=~{chromosome}000000000000
         chunk_endpoints=()
         if [ ~{num_chunks} -gt 1 ]; then
-            # bq query Get the mid-point and max of the locations for this chromosome
+            # bq query Get the mid-point and min of the (found) locations for this chromosome
             bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false '
-                SELECT CAST((max(location) + min(location)) / ~{num_chunks} AS INT64)
+                SELECT CAST((max(location) + min(location)) / ~{num_chunks} AS INT64, min(location))
                     FROM `~{project_id}.~{dataset_name}.~{extract_prefix}__VET_DATA`
                     WHERE location >= ~{chromosome}000000000000 and location < ~{chromosome + 1}000000000000' | sed 1d > locations.txt
 
-            nlocation=$(cat locations.txt)
-            echo "nlocation = $nlocation"
+            chunk_width=$(cut -f 1 -d ',' locations.txt)
+            echo "chunk_width = $chunk_width"
+            min_location=$(cut -f 2 -d ',' locations.txt)
+            echo "min_location = $min_location"
 
             for i in $(seq 1 $((~{num_chunks} - 1))); do
-                chunk_endpoints+=($((nlocation * i + start_location)))
+                chunk_endpoints+=($((chunk_width * i + min_location)))
                 echo "Added chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
             done
         fi
@@ -378,6 +379,7 @@ task CollectMetricsForChromosome {
         echo "Number of chunk endpoints: ${#chunk_endpoints[@]}"
 
         # Iterate over all chunks
+        start_location=~{chromosome}000000000000
         for ((i=0; i<${#chunk_endpoints[@]}; i++)); do
             end_location=${chunk_endpoints[i]}
             echo "Running query for >= $start_location to < $end_location"

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# C
+
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -35,14 +35,6 @@ workflow GvsCallsetStatistics {
         call Utils.TerminateWorkflow as NumChunksError {
             input:
                 message = "The input parameter 'num_chunks' must be >= 1 and < 50!",
-                basic_docker = effective_basic_docker,
-        }
-    }
-
-    if (num_chunks <= 0) {
-        call Utils.TerminateWorkflow as NumChunksTooLow {
-            input:
-                message = "The input parameter 'num_chunks' must be >= 1!",
                 basic_docker = effective_basic_docker,
         }
     }
@@ -362,7 +354,6 @@ task CollectMetricsForChromosome {
                     FROM `~{project_id}.~{dataset_name}.~{extract_prefix}__VET_DATA`
                     WHERE location >= ~{chromosome}000000000000 and location < ~{chromosome + 1}000000000000' | sed 1d > locations.txt
 
-            cat locations.txt
             chunk_width=$(cut -f 1 -d ',' locations.txt)
             echo "chunk_width = $chunk_width"
             min_location=$(cut -f 2 -d ',' locations.txt)
@@ -469,7 +460,7 @@ task CollectMetricsForChromosome {
                        titv(ref, alt) as titv,
                        CASE WHEN gnomad.location IS NULL THEN false ELSE true END in_gnomad
                 FROM `~{project_id}.~{dataset_name}.~{extract_prefix}__VET_DATA` v
-                LEFT JOIN `gvs-internal.gvs_public_reference_data.gnomad_v3_sites` gnomad ON (v.location = gnomad.location)
+                LEFT JOIN `aou-genomics-curation-prod.gvs_public_reference_data.gnomad_v3_sites` gnomad ON (v.location = gnomad.location)
                 WHERE call_GT != "./."
                 AND v.location >= '$start_location'
                 AND v.location < '$end_location') GROUP BY 1,2

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# A
+# B
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -337,7 +337,7 @@ task CollectMetricsForChromosome {
         bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false '
         SELECT (max(location) - min(location)) / 2 + min(location), max(location)
             FROM `gvs-internal.gg_ah_var_store_20250529.callset__VET_DATA`
-            WHERE location >= ~{chromosome}000000000000 and location < ~{chromosome + 1}000000000000) | sed 1d > locations.txt
+            WHERE location >= ~{chromosome}000000000000 and location < ~{chromosome + 1}000000000000)' | sed 1d > locations.txt
 
         start_location=~{chromosome}000000000000
         mid_location=$(head -1 locations.txt)

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# 5
+# 6
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -369,14 +369,17 @@ task CollectMetricsForChromosome {
                 chunk_endpoints+=($((nlocation * i)))
                 echo "Added chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
             done
-            # Set the final endpoint to be beyond the end of the chromosome
-            chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]=~{chromosome + 1}000000000000
-            echo "Final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
-        else
-            # Just one chunk, so just do the whole chromosome
-            chunk_endpoints+=(~{chromosome + 1}000000000000)
-            echo "Only one chunk, final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
+#            # Set the final endpoint to be beyond the end of the chromosome
+#            chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]=~{chromosome + 1}000000000000
+#            echo "Final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
+#        else
+#            # Just one chunk, so just do the whole chromosome
+#            chunk_endpoints+=(~{chromosome + 1}000000000000)
+#            echo "Only one chunk, final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
         fi
+        echo "Adding final chunk endpoint ${chunk_endpoints[$((${#chunk_endpoints[@]} - 1))]}"
+        chunk_endpoints+=(~{chromosome + 1}000000000000)
+
         echo "Number of chunk endpoints: ${#chunk_endpoints[@]}"
 
         # Iterate over all chunks

--- a/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
+++ b/scripts/variantstore/wdl/GvsCallsetStatistics.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# E
+# F
 workflow GvsCallsetStatistics {
     input {
         String? git_branch_or_tag
@@ -431,7 +431,7 @@ task CollectMetricsForChromosome {
                        titv(ref, alt) as titv,
                        CASE WHEN gnomad.location IS NULL THEN false ELSE true END in_gnomad
                 FROM `~{project_id}.~{dataset_name}.~{extract_prefix}__VET_DATA` v
-                LEFT JOIN `aou-genomics-curation-prod.gvs_public_reference_data.gnomad_v3_sites` gnomad ON (v.location = gnomad.location)
+                LEFT JOIN `gvs-internal.gvs_public_reference_data.gnomad_v3_sites` gnomad ON (v.location = gnomad.location)
                 WHERE call_GT != "./."
                 AND v.location >= '$start_location'
                 AND v.location < '$end_location') GROUP BY 1,2


### PR DESCRIPTION
VS-1732. Modify Callset Statistics calculation to break up the chromosomes
This PR modifies the GvsCallsetStatistics wdl to add an optional parameter num_chunks.
num_chunks (default value 2) specifies the number of chunks the chromosome should be broken into in order to avoid having the query run too long.

Passing run (3K callset) for 3 chunks [here](https://app.terra.bio/#workspaces/gvs-dev/NHGRI_AnVIL_3K%20ggrant/submission_history/285acd14-d74b-417f-a20a-6f7ca22c9dc7)
Passing run (3K callset) for 1 chunk [here](https://app.terra.bio/#workspaces/gvs-dev/NHGRI_AnVIL_3K%20ggrant/submission_history/e8bad57d-f833-4455-8579-8af21879b0b7) 