### PR TITLE
Fix Hail cluster leakage [VS-1730]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -173,6 +173,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - vs_1730_clusters_leaking
        tags:
          - /.*/
    - name: GvsTieOutVDS
@@ -340,7 +341,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1633_ploidy_with_vds_resume
+             - vs_1730_clusters_leaking
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -155,6 +155,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - vs_1730_clusters_leaking
        tags:
          - /.*/
    - name: GvsValidateVDS

--- a/scripts/variantstore/scripts/hail_gvs_import.py
+++ b/scripts/variantstore/scripts/hail_gvs_import.py
@@ -8,6 +8,7 @@ import argparse
 import os
 
 from hail_gvs_util import *
+from vds_validation import validate
 
 
 def create_vds(argsfn, vds_path, references_path, temp_path, intermediate_resume_point):
@@ -67,6 +68,8 @@ if __name__ == '__main__':
                         required=False)
     parser.add_argument('--intermediate-resume-point', type=int, required=False, default=0,
                         help='Intermediate VDS index at which to resume')
+    parser.add_argument('--run-validation', type=bool, help='Whether to run VDS validation after creating the VDS',
+                        required=False, default=False)
 
     args = parser.parse_args()
     avro_path, temp_path, vds_path = remove_trailing_slashes(args.avro_path, args.temp_path, args.vds_path)
@@ -76,3 +79,7 @@ if __name__ == '__main__':
     references_path = 'gs://hail-common/references' if is_gcs else args.references_path
     create_vds(arguments_fn, vds_path, references_path, temp_path, args.intermediate_resume_point)
 
+    if args.run_validation:
+        print("Beginning VDS validation")
+        validate(vds)
+        print("Finished VDS validation")

--- a/scripts/variantstore/scripts/hail_gvs_import.py
+++ b/scripts/variantstore/scripts/hail_gvs_import.py
@@ -77,7 +77,7 @@ if __name__ == '__main__':
     arguments_fn, is_gcs = determine_arguments_function(args)
 
     references_path = 'gs://hail-common/references' if is_gcs else args.references_path
-    create_vds(arguments_fn, vds_path, references_path, temp_path, args.intermediate_resume_point)
+    vds = create_vds(arguments_fn, vds_path, references_path, temp_path, args.intermediate_resume_point)
 
     if args.run_validation:
         print("Beginning VDS validation")

--- a/scripts/variantstore/scripts/hail_gvs_import.py
+++ b/scripts/variantstore/scripts/hail_gvs_import.py
@@ -29,23 +29,24 @@ def create_vds(argsfn, vds_path, references_path, temp_path, intermediate_resume
     # Commented out parameters are ones where we are comfortable with the default, but want to make them easily
     # accessible to users.
     try:
-        import_gvs.import_gvs(
-            vets=argsfn('vets'),
-            refs=argsfn('refs'),
-            sample_mapping=argsfn('sample_mapping'),
-            site_filtering_data=argsfn('site_filtering_data'),
-            vets_filtering_data=argsfn('vets_filtering_data'),
-            ploidy_data=argsfn('ploidy_data'),
-            reference_genome=rg38,
-            final_path=vds_path,
-            tmp_dir=f'{temp_path}/hail_tmp_create_vds',
-            # truth_sensitivity_snp_threshold: 'float' = 0.997,
-            # truth_sensitivity_indel_threshold: 'float' = 0.990,
-            # partitions_per_sample=0.35, # check with Hail about how to tune this for your large callset
-            # intermediate_resume_point=0, # if your first run fails, and you want to use the intermediate files that already exist, check in with Hail to find out what stage to resume on
-            # skip_final_merge=false, # if you want to create your VDS in two steps (because of mem issues) this can be skipped until the final run
-            intermediate_resume_point=intermediate_resume_point
-        )
+        vds = import_gvs.import_gvs(
+                vets=argsfn('vets'),
+                refs=argsfn('refs'),
+                sample_mapping=argsfn('sample_mapping'),
+                site_filtering_data=argsfn('site_filtering_data'),
+                vets_filtering_data=argsfn('vets_filtering_data'),
+                ploidy_data=argsfn('ploidy_data'),
+                reference_genome=rg38,
+                final_path=vds_path,
+                tmp_dir=f'{temp_path}/hail_tmp_create_vds',
+                # truth_sensitivity_snp_threshold: 'float' = 0.997,
+                # truth_sensitivity_indel_threshold: 'float' = 0.990,
+                # partitions_per_sample=0.35, # check with Hail about how to tune this for your large callset
+                # intermediate_resume_point=0, # if your first run fails, and you want to use the intermediate files that already exist, check in with Hail to find out what stage to resume on
+                # skip_final_merge=false, # if you want to create your VDS in two steps (because of mem issues) this can be skipped until the final run
+                intermediate_resume_point=intermediate_resume_point
+            )
+        return vds
     finally:
         local_hail_log_path = os.path.realpath(Env.hc()._log)
         fs = RouterFS()

--- a/scripts/variantstore/scripts/hail_gvs_import.py
+++ b/scripts/variantstore/scripts/hail_gvs_import.py
@@ -68,8 +68,8 @@ if __name__ == '__main__':
                         required=False)
     parser.add_argument('--intermediate-resume-point', type=int, required=False, default=0,
                         help='Intermediate VDS index at which to resume')
-    parser.add_argument('--run-validation', type=bool, help='Whether to run VDS validation after creating the VDS',
-                        required=False, default=False)
+    parser.add_argument('--run-validation', help='Whether to run VDS validation after creating the VDS',
+                        action='store_true')
 
     args = parser.parse_args()
     avro_path, temp_path, vds_path = remove_trailing_slashes(args.avro_path, args.temp_path, args.vds_path)

--- a/scripts/variantstore/scripts/import_gvs.py
+++ b/scripts/variantstore/scripts/import_gvs.py
@@ -39,7 +39,7 @@ def import_gvs(refs: 'List[List[str]]',
                intermediate_resume_point=0,
                skip_final_merge=False,
                ref_block_max_length: 'int' = 1000
-               ):
+               ) -> hl.vds.VariantDataset:
     """Import a collection of Avro files exported from GVS.
 
     This function is used to import Avro files exported from BigQuery for
@@ -377,7 +377,9 @@ def import_gvs(refs: 'List[List[str]]',
         vd = vd.annotate_entries(FT=~ft.any_no & (ft.any_yes | ft.all_ok))
 
         vd = vd.drop('allele_NO', 'allele_YES', 'allele_OK')
-        hl.vds.VariantDataset(
+        final_vds = hl.vds.VariantDataset(
             reference_data=rd,
             variant_data=vd,
-        ).write(final_path, overwrite=True)
+        )
+        final_vds.write(final_path, overwrite=True)
+        return final_vds

--- a/scripts/variantstore/scripts/merge_and_rescore_vdses.py
+++ b/scripts/variantstore/scripts/merge_and_rescore_vdses.py
@@ -196,9 +196,9 @@ if __name__ == '__main__':
                         help="File with ids of samples to remove, one sample id per line, header should be 'research_id'.",
                         required=False)
 
-    parser.add_argument('--run-validation', type=bool,
+    parser.add_argument('--run-validation',
                         help='Whether to run VDS validation after creating the VDS',
-                        required=False, default=False)
+                        action='store_true')
 
     parser.add_argument('--temp-path', type=str, help='Path to temporary directory', required=True)
 

--- a/scripts/variantstore/scripts/merge_and_rescore_vdses.py
+++ b/scripts/variantstore/scripts/merge_and_rescore_vdses.py
@@ -248,7 +248,7 @@ if __name__ == '__main__':
     merged_and_rescored_vds = hl.vds.VariantDataset(tmp_merged_vds.reference_data, rescored_vd)
     merged_and_rescored_vds.write(args.output_vds_path)
 
-    if (args.validate_vds):
+    if (args.run_validation):
         print("Beginning validation of merged and rescored VDS")
         validate(merged_and_rescored_vds)
         print("Finished validation of merged and rescored VDS")

--- a/scripts/variantstore/scripts/merge_and_rescore_vdses.py
+++ b/scripts/variantstore/scripts/merge_and_rescore_vdses.py
@@ -5,6 +5,7 @@ from typing import Sequence
 
 import hail as hl
 from hail.utils.java import info
+from vds_validation import validate
 
 
 _GRCH38 = None
@@ -195,6 +196,10 @@ if __name__ == '__main__':
                         help="File with ids of samples to remove, one sample id per line, header should be 'research_id'.",
                         required=False)
 
+    parser.add_argument('--run-validation', type=bool,
+                        help='Whether to run VDS validation after creating the VDS',
+                        required=False, default=False)
+
     parser.add_argument('--temp-path', type=str, help='Path to temporary directory', required=True)
 
     args = parser.parse_args()
@@ -242,3 +247,8 @@ if __name__ == '__main__':
     rescored_vd = patch_variant_data(vd, site, vets)
     merged_and_rescored_vds = hl.vds.VariantDataset(tmp_merged_vds.reference_data, rescored_vd)
     merged_and_rescored_vds.write(args.output_vds_path)
+
+    if (args.validate_vds):
+        print("Beginning validation of merged and rescored VDS")
+        validate(merged_and_rescored_vds)
+        print("Finished validation of merged and rescored VDS")

--- a/scripts/variantstore/scripts/vds_validation.py
+++ b/scripts/variantstore/scripts/vds_validation.py
@@ -48,7 +48,7 @@ def check_densify_small_region(vds):
 
 
 
-def main(vds):
+def validate(vds):
     check_densify_small_region(vds)
     chrs = [f'chr{c}' for c in itertools.chain(range(1, 23), ['X', 'Y', 'M'])]
     for chromosome_to_validate in chrs:
@@ -76,4 +76,4 @@ if __name__ == '__main__':
 
     vds = hl.vds.read_vds(args.vds_path)
 
-    main(vds)
+    validate(vds)

--- a/scripts/variantstore/wdl/GvsCreateVDS.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVDS.wdl
@@ -235,6 +235,7 @@ task CreateVds {
             --secondary-script-path-list ~{gvs_import_script} \
             --secondary-script-path-list ~{hail_gvs_util_script} \
             --secondary-script-path-list ~{gvs_import_ploidy_script} \
+            --secondary-script-path-list ~{vds_validation_script} \
             --script-arguments-json-path script-arguments.json \
             --account ${account_name} \
             --autoscaling-policy gvs-autoscaling-policy \

--- a/scripts/variantstore/wdl/GvsCreateVDS.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVDS.wdl
@@ -227,7 +227,6 @@ task CreateVds {
             "avro-path": "~{avro_path}"
             ~{if (run_validation) then ', "run-validation": ""' else ''}
             ~{', "intermediate-resume-point": ' + intermediate_resume_point}
-
         }
         FIN
 

--- a/scripts/variantstore/wdl/GvsCreateVDS.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVDS.wdl
@@ -144,6 +144,7 @@ task CreateVds {
         String vds_path
         String avro_path
         Boolean leave_cluster_running_at_end
+        Boolean run_validation = true
         File run_in_hail_cluster_script
         File run_in_existing_hail_cluster_script
         File hail_gvs_import_script
@@ -243,25 +244,7 @@ task CreateVds {
             ~{'--cluster-max-idle-minutes ' + cluster_max_idle_minutes} \
             ~{'--cluster-max-age-minutes ' + cluster_max_age_minutes} \
             ~{'--master-memory-fraction ' + master_memory_fraction} \
-            --leave-cluster-running-at-end
-
-        # construct a JSON of arguments for python script to be run in the hail cluster
-        cat > validation-script-arguments.json <<FIN
-        {
-            "vds-path": "~{vds_path}",
-            "temp-path": "${hail_temp_path}"
-        }
-        FIN
-
-        # Run the hail python script to validate a VDS
-        python3 ~{run_in_existing_hail_cluster_script} \
-            --script-path ~{vds_validation_script} \
-            --script-arguments-json-path validation-script-arguments.json \
-            --account ${account_name} \
-            --region ~{region} \
-            --gcs-project ~{workspace_project} \
-            --cluster-name ${cluster_name} \
-            ~{true='--leave-cluster-running-at-end' false='' leave_cluster_running_at_end}
+            ~{if (run_validation) then '--run-validation' else ''}
     >>>
 
     runtime {

--- a/scripts/variantstore/wdl/GvsCreateVDS.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVDS.wdl
@@ -225,7 +225,9 @@ task CreateVds {
             "vds-path": "~{vds_path}",
             "temp-path": "${hail_temp_path}",
             "avro-path": "~{avro_path}"
+            ~{if (run_validation) then ', "run-validation": ""' else ''}
             ~{', "intermediate-resume-point": ' + intermediate_resume_point}
+
         }
         FIN
 
@@ -244,8 +246,7 @@ task CreateVds {
             --cluster-name ${cluster_name} \
             ~{'--cluster-max-idle-minutes ' + cluster_max_idle_minutes} \
             ~{'--cluster-max-age-minutes ' + cluster_max_age_minutes} \
-            ~{'--master-memory-fraction ' + master_memory_fraction} \
-            ~{if (run_validation) then '--run-validation' else ''}
+            ~{'--master-memory-fraction ' + master_memory_fraction}
     >>>
 
     runtime {

--- a/scripts/variantstore/wdl/GvsMergeAndRescoreVDSes.wdl
+++ b/scripts/variantstore/wdl/GvsMergeAndRescoreVDSes.wdl
@@ -252,6 +252,7 @@ task MergeAndRescoreVDS {
         python3 ~{run_in_hail_cluster_script} \
             --script-path ~{merge_and_rescore_script} \
             --secondary-script-path-list ~{hail_gvs_util_script} \
+            --secondary-script-path-list ~{vds_validation_script} \
             --script-arguments-json-path script-arguments.json \
             --account ${account_name} \
             --autoscaling-policy gvs-autoscaling-policy \

--- a/scripts/variantstore/wdl/GvsMergeAndRescoreVDSes.wdl
+++ b/scripts/variantstore/wdl/GvsMergeAndRescoreVDSes.wdl
@@ -243,6 +243,7 @@ task MergeAndRescoreVDS {
             "input-echo-vds": "~{input_echo_vds_path}",
             "input-unmerged-foxtrot-vds": "~{input_unmerged_foxtrot_vds_path}",
             "output-vds-path": "~{output_merged_and_rescored_foxtrot_vds_path}"
+            ~{if (skip_validate) then '' else ', "run-validation": ""'}
             ~{', "intermediate-resume-point": ' + intermediate_resume_point}
             ~{', "samples-to-remove-path": "' + samples_to_remove_path + '"'}
         }
@@ -262,7 +263,6 @@ task MergeAndRescoreVDS {
             ~{'--cluster-max-idle-minutes ' + cluster_max_idle_minutes} \
             ~{'--cluster-max-age-minutes ' + cluster_max_age_minutes} \
             ~{'--master-memory-fraction ' + master_memory_fraction} \
-            ~{if (skip_validate) then '' else '--run-validation' } \
             ~{true='--leave-cluster-running-at-end' false='' leave_cluster_running_at_end}
     >>>
 

--- a/scripts/variantstore/wdl/GvsMergeAndRescoreVDSes.wdl
+++ b/scripts/variantstore/wdl/GvsMergeAndRescoreVDSes.wdl
@@ -128,6 +128,7 @@ workflow GvsMergeAndRescoreVDSes {
             output_merged_and_rescored_foxtrot_vds_path = output_merged_and_rescored_foxtrot_vds_path,
             input_foxtrot_avro_path = input_foxtrot_avro_path,
             samples_to_remove_path = samples_to_remove_path,
+            skip_validate = skip_validate,
             hail_version = effective_hail_version,
             hail_wheel = hail_wheel,
             hail_temp_path = hail_temp_path,
@@ -146,27 +147,8 @@ workflow GvsMergeAndRescoreVDSes {
             master_memory_fraction = master_memory_fraction,
     }
 
-    if (!skip_validate) {
-        call ValidateVDS.GvsValidateVDS as ValidateVds {
-            input:
-                go = MergeAndRescoreVDS.done,
-                cluster_prefix = cluster_prefix,
-                vds_path = output_merged_and_rescored_foxtrot_vds_path,
-                hail_version = effective_hail_version,
-                hail_wheel = hail_wheel,
-                hail_temp_path = hail_temp_path,
-                workspace_project = effective_google_project,
-                region = region,
-                workspace_bucket = effective_workspace_bucket,
-                gcs_subnetwork_name = gcs_subnetwork_name,
-                cloud_sdk_slim_docker = effective_cloud_sdk_slim_docker,
-                leave_cluster_running_at_end = leave_cluster_running_at_end,
-        }
-    }
-
     output {
-        String create_cluster_name = MergeAndRescoreVDS.cluster_name
-        String? validate_cluster_name = ValidateVds.cluster_name
+        String cluster_name = MergeAndRescoreVDS.cluster_name
         Boolean done = true
     }
 }
@@ -179,6 +161,7 @@ task MergeAndRescoreVDS {
         String input_foxtrot_avro_path
         String output_merged_and_rescored_foxtrot_vds_path
         String? samples_to_remove_path
+        Boolean skip_validate
         Boolean leave_cluster_running_at_end
         File merge_and_rescore_script
         File hail_gvs_util_script
@@ -276,6 +259,7 @@ task MergeAndRescoreVDS {
             ~{'--cluster-max-idle-minutes ' + cluster_max_idle_minutes} \
             ~{'--cluster-max-age-minutes ' + cluster_max_age_minutes} \
             ~{'--master-memory-fraction ' + master_memory_fraction} \
+            ~{if (skip_validate) then '' else '--run-validation' } \
             ~{true='--leave-cluster-running-at-end' false='' leave_cluster_running_at_end}
     >>>
 

--- a/scripts/variantstore/wdl/GvsMergeAndRescoreVDSes.wdl
+++ b/scripts/variantstore/wdl/GvsMergeAndRescoreVDSes.wdl
@@ -135,6 +135,7 @@ workflow GvsMergeAndRescoreVDSes {
             run_in_hail_cluster_script = GetHailScripts.run_in_hail_cluster_script,
             merge_and_rescore_script = GetHailScripts.merge_and_rescore_script,
             hail_gvs_util_script = GetHailScripts.hail_gvs_util_script,
+            vds_validation_script = GetHailScripts.vds_validation_script,
             intermediate_resume_point = intermediate_resume_point,
             workspace_project = effective_google_project,
             region = region,
@@ -166,6 +167,7 @@ task MergeAndRescoreVDS {
         File merge_and_rescore_script
         File hail_gvs_util_script
         File run_in_hail_cluster_script
+        File vds_validation_script
         String? hail_version
         File? hail_wheel
         String? hail_temp_path

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -129,7 +129,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-08-27-alpine-02964546f8cd"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-08-27-alpine-aae4c53d262e"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2025-07-29-gatkbase-650b8e1a32f0"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -129,7 +129,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-08-14-alpine-ed9cbc2508e8"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-08-27-alpine-6e014c81cffa"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2025-07-29-gatkbase-650b8e1a32f0"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -129,7 +129,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-08-27-alpine-6e014c81cffa"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-08-27-alpine-02964546f8cd"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2025-07-29-gatkbase-650b8e1a32f0"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -129,7 +129,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-08-28-alpine-6ba0109b7b6c"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-08-28-alpine-60ba644b49ea"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2025-07-29-gatkbase-650b8e1a32f0"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -129,7 +129,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-08-27-alpine-aae4c53d262e"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-08-28-alpine-6ba0109b7b6c"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2025-07-29-gatkbase-650b8e1a32f0"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"


### PR DESCRIPTION
Refactor VDS validation to be imported as a module and invoked from the VDS creation and Merge & Rescore scripts. We keep the efficiency of running all the Hail bits in a single cluster without the danger of leaking the cluster if there's a crash while running the main code. Successful runs [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration%20mcovarr/submission_history/4016884e-70d1-4c9c-a38c-b6faa0472b7a) and [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration%20mcovarr/submission_history/e3eab229-e714-4910-a074-193576f553b8).