### PR TITLE
Accurately index outputs from PrintSVEvidence and CollectSVEvidence

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/BafEvidenceCodec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/BafEvidenceCodec.java
@@ -30,7 +30,7 @@ public class BafEvidenceCodec extends AsciiFeatureCodec<BafEvidence>
 
     @Override
     public TabixFormat getTabixFormat() {
-        return new TabixFormat(TabixFormat.ZERO_BASED, 1, 2, 0, '#', 0);
+        return new TabixFormat(TabixFormat.ZERO_BASED, 1, 2, 2, '#', 0);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/DiscordantPairEvidenceCodec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/DiscordantPairEvidenceCodec.java
@@ -29,7 +29,7 @@ public class DiscordantPairEvidenceCodec extends AsciiFeatureCodec<DiscordantPai
 
     @Override
     public TabixFormat getTabixFormat() {
-        return new TabixFormat(TabixFormat.ZERO_BASED, 1, 2, 0, '#', 0);
+        return new TabixFormat(TabixFormat.ZERO_BASED, 1, 2, 2, '#', 0);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/SiteDepthCodec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/SiteDepthCodec.java
@@ -25,7 +25,7 @@ public class SiteDepthCodec extends AsciiFeatureCodec<SiteDepth>
     }
 
     @Override public TabixFormat getTabixFormat() {
-        return new TabixFormat(TabixFormat.ZERO_BASED, 1, 2, 0, '#', 0);
+        return new TabixFormat(TabixFormat.ZERO_BASED, 1, 2, 2, '#', 0);
     }
 
     @Override public SiteDepth decode( final String line ) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/codecs/SplitReadEvidenceCodec.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/codecs/SplitReadEvidenceCodec.java
@@ -30,7 +30,7 @@ public class SplitReadEvidenceCodec extends AsciiFeatureCodec<SplitReadEvidence>
 
     @Override
     public TabixFormat getTabixFormat() {
-        return new TabixFormat(TabixFormat.ZERO_BASED, 1, 2, 0, '#', 0);
+        return new TabixFormat(TabixFormat.ZERO_BASED, 1, 2, 2, '#', 0);
     }
 
     @Override


### PR DESCRIPTION
This PR is intended to accurately index the files output through `PrintSVEvidence` and `CollectSVEvidence`.

Currently, the various codecs accessible through these tools use the column `0` as the end column when indexing. However, this is not compatible with later version of htsjdk, so we instead use the column `2` (which is also the start column) in each of these cases.

The `DepthEvidenceCodec` is already configured properly, so we do not need to change anything for it.