### PR TITLE
Plumb through `train_extra_args` to allow bypass of INDEL training

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -290,8 +290,8 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1670_release_0_6_3
              - gvs_expanded_references
+             - mars_no_indels
          tags:
              - /.*/
    - name: GvsBeta

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -348,10 +348,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - VS-1619
-             - vs_1691_wdl_for_the_dogs
-             - vs_1676_AnVIL_3K
-             - master_merge_2025_07_16
+             - mars_no_indels
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
+++ b/scripts/variantstore/wdl/GvsCreateFilterSet.wdl
@@ -31,6 +31,7 @@ workflow GvsCreateFilterSet {
     String? git_branch_or_tag
     String? git_hash
     File? gatk_override
+    String? train_extra_args
 
     Boolean use_VETS = true
     # Defaulting to true here as this wdl is called by itself for the AoU use case where we would want a fully annotated VCF.
@@ -183,6 +184,7 @@ workflow GvsCreateFilterSet {
         resource_args = vets_resource_args,
         extract_extra_args = "-L ${effective_interval_list}",
         score_extra_args = "-L ${effective_interval_list}",
+        train_extra_args = train_extra_args,
         extract_runtime_attributes = vets_extract_runtime_attributes,
         train_runtime_attributes = vets_train_runtime_attributes,
         score_runtime_attributes = vets_score_runtime_attributes,


### PR DESCRIPTION
Failed attempt to test this [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration%20mcovarr/submission_history/b046b9f8-f3a6-4b34-87b5-44b2a07f7e28) (code might be okay but wasn't run with the required parameters).