### PR TITLE
Adjust PGEN extract memory based on Foxtrot experience [VS-1634]

### DIFF
--- a/scripts/variantstore/wdl/GvsExtractCallsetPgen.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallsetPgen.wdl
@@ -153,7 +153,7 @@ workflow GvsExtractCallsetPgen {
     Int effective_extract_memory_gib = if defined(extract_memory_override_gib) then select_first([extract_memory_override_gib])
                                        else if effective_scatter_count <= 100 then 35 + extract_overhead_memory_override_gib
                                            else if effective_scatter_count <= 500 then 15 + extract_overhead_memory_override_gib
-                                               else 5 + extract_overhead_memory_override_gib
+                                               else 12 + extract_overhead_memory_override_gib
     # WDL 1.0 trick to set a variable ('none') to be undefined.
     if (false) {
         File? none = ""


### PR DESCRIPTION
More memory actually ended up being significantly cheaper. PGEN extract slows waaaaay down before it actually OOMs, which leads to preemptions and more retries and even running on non-preemptibles.