### PR TITLE
VS-1754. Remove a (now non-existent) clinvar significance from expected.

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -344,6 +344,7 @@ workflows:
              - master
              - ah_var_store
              - vs_1634_pgen_exome
+             - gg_VS-1754_RemoveOneClinvarSignificanceFromTest
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/variant-annotations-table/GvsValidateVAT.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsValidateVAT.wdl
@@ -1101,7 +1101,6 @@ task ClinvarSignificance {
         #                                 "risk factor",
         #                                 "protective",
         #                                 "affects",
-        #                                 "conflicting data from submitters",
         #                                 "other",
         #                                 "not provided"]
 
@@ -1114,7 +1113,6 @@ task ClinvarSignificance {
         echo 'affects
         association
         benign
-        conflicting data from submitters
         drug response
         likely benign
         likely pathogenic
@@ -1125,7 +1123,7 @@ task ClinvarSignificance {
         risk factor
         uncertain significance' > expected_clinvar_classes.txt
 
-        comm -23 <(sort bq_clinvar_classes.txt) expected_clinvar_classes.txt > missing_clinvar_classes.txt
+        comm -13 <(sort bq_clinvar_classes.txt) expected_clinvar_classes.txt > missing_clinvar_classes.txt
 
         NUMRESULTS=$( wc -l bq_clinvar_classes.txt | awk '{print $1;}' ) # we expect this to be 13+
         NUMMISS=$( wc -l missing_clinvar_classes.txt | awk '{print $1;}' ) # we expect this to be 0


### PR DESCRIPTION
Remove a (now non-existent) clinvar significance from expected.

Passing Integration Test [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/submission_history/b7b887d0-2069-4273-acee-97e9a8bf34ed).