### PR TITLE
CMRG-inspired cleanup [VS-1739]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -343,8 +343,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1634_pgen_exome
-             - gg_VS-1754_FixAnotherBugInClinvarSignificance
+             - vs_1739_cmrg_learnings
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -61,7 +61,7 @@ workflow GvsExtractCallset {
     Boolean is_wgs = true
     Boolean convert_filtered_genotypes_to_nocalls = false
     Boolean write_cost_to_db = true
-    Int maximum_alternate_alleles = 1000
+    Int maximum_alternate_alleles = 100
   }
 
   String fq_gvs_dataset = "~{project_id}.~{dataset_name}"

--- a/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
+++ b/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
@@ -74,7 +74,7 @@ workflow GvsJointVariantCalling {
         File? training_python_script
         File? scoring_python_script
 
-        Int? maximum_alternate_alleles
+        Int maximum_alternate_alleles = 1000
 
         Int? extract_maxretries_override
         Int? extract_preemptible_override

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -131,7 +131,7 @@ task GetToolVersions {
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
     String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-10-07-alpine-2cb0189e94fd"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
-    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2025-09-25-gatkbase-01fb5660d2fd"
+    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2025-10-17-gatkbase-0a4709121758"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"
     String gotc_imputation_docker = "us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.5-1.10.2-0.1.16-1649948623"
     String plink_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/plink2:2024-04-23-slim-a0a65f52cc0e"

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/extract/ExtractCohortEngine.java
@@ -401,7 +401,7 @@ public class ExtractCohortEngine {
                 return Long.compare(firstSample, secondSample);
             }
         };
-        return SortingCollection.newInstance(GenericRecord.class, sortingCollectionCodec, sortingCollectionComparator, localSortMaxRecordsInRam, true);
+        return SortingCollection.newInstance(GenericRecord.class, sortingCollectionCodec, sortingCollectionComparator, localSortMaxRecordsInRam);
     }
 
     private void addToVetSortingCollection(final SortingCollection<GenericRecord> sortingCollection,

--- a/src/main/java/org/broadinstitute/hellbender/utils/gvs/localsort/SortingCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gvs/localsort/SortingCollection.java
@@ -112,8 +112,6 @@ public class SortingCollection<T> implements Iterable<T> {
 
     private final TempStreamFactory tempStreamFactory = new TempStreamFactory();
 
-    private final boolean printRecordSizeSampling;
-
     /**
      * Prepare to accumulate records to be sorted
      *
@@ -121,12 +119,11 @@ public class SortingCollection<T> implements Iterable<T> {
      * @param codec           For writing records to file and reading them back into RAM
      * @param comparator      Defines output sort order
      * @param maxRecordsInRam how many records to accumulate before spilling to disk
-     * @param printRecordSizeSampling If true record size will be sampled and output at DEBUG log level
      * @param tmpDir          Where to write files of records that will not fit in RAM
      */
-    private SortingCollection(final Class<T> componentType, final SortingCollection.Codec<T> codec,
+    private SortingCollection(final Class<T> componentType, final Codec<T> codec,
                               final Comparator<T> comparator, final int maxRecordsInRam,
-                              final boolean printRecordSizeSampling, final Path... tmpDir) {
+                              final Path... tmpDir) {
         if (maxRecordsInRam <= 0) {
             throw new IllegalArgumentException("maxRecordsInRam must be > 0");
         }
@@ -142,7 +139,6 @@ public class SortingCollection<T> implements Iterable<T> {
         @SuppressWarnings("unchecked")
         T[] ramRecords = (T[]) Array.newInstance(componentType, maxRecordsInRam);
         this.ramRecords = ramRecords;
-        this.printRecordSizeSampling = printRecordSizeSampling;
     }
 
     public void add(final T rec) {
@@ -320,7 +316,7 @@ public class SortingCollection<T> implements Iterable<T> {
                                                        final Comparator<T> comparator,
                                                        final int maxRecordsInRAM,
                                                        final File... tmpDir) {
-        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, false, Arrays.stream(tmpDir).map(File::toPath).toArray(Path[]::new));
+        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, Arrays.stream(tmpDir).map(File::toPath).toArray(Path[]::new));
 
     }
 
@@ -344,7 +340,6 @@ public class SortingCollection<T> implements Iterable<T> {
                 codec,
                 comparator,
                 maxRecordsInRAM,
-                false,
                 tmpDirs.stream().map(File::toPath).toArray(Path[]::new));
 
     }
@@ -364,7 +359,7 @@ public class SortingCollection<T> implements Iterable<T> {
                                                        final int maxRecordsInRAM,
                                                        final boolean printRecordSizeSampling) {
         final Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir"));
-        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, printRecordSizeSampling, tmpDir);
+        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, tmpDir);
     }
 
     /**
@@ -383,7 +378,7 @@ public class SortingCollection<T> implements Iterable<T> {
                                                        final int maxRecordsInRAM,
                                                        final boolean printRecordSizeSampling,
                                                        final Path... tmpDir) {
-        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, printRecordSizeSampling, tmpDir);
+        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, tmpDir);
     }
 
     /**
@@ -399,7 +394,7 @@ public class SortingCollection<T> implements Iterable<T> {
                                                        final Comparator<T> comparator,
                                                        final int maxRecordsInRAM) {
         final Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir"));
-        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, false, tmpDir);
+        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, tmpDir);
     }
 
     /**
@@ -416,7 +411,7 @@ public class SortingCollection<T> implements Iterable<T> {
                                                        final Comparator<T> comparator,
                                                        final int maxRecordsInRAM,
                                                        final Path... tmpDir) {
-        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, false, tmpDir);
+        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, tmpDir);
     }
 
     /**
@@ -437,7 +432,6 @@ public class SortingCollection<T> implements Iterable<T> {
                 codec,
                 comparator,
                 maxRecordsInRAM,
-                false,
                 tmpDirs.toArray(new Path[tmpDirs.size()]));
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/gvs/localsort/SortingCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gvs/localsort/SortingCollection.java
@@ -347,43 +347,6 @@ public class SortingCollection<T> implements Iterable<T> {
     /**
      * Syntactic sugar around the ctor, to save some typing of type parameters.  Writes files to java.io.tmpdir
      *
-     * @param componentType    Class of the record to be sorted.  Necessary because of Java generic lameness.
-     * @param codec            For writing records to file and reading them back into RAM
-     * @param comparator       Defines output sort order
-     * @param maxRecordsInRAM  how many records to accumulate in memory before spilling to disk
-     * @param printRecordSizeSampling If true record size will be sampled and output at DEBUG log level
-     */
-    public static <T> SortingCollection<T> newInstance(final Class<T> componentType,
-                                                       final SortingCollection.Codec<T> codec,
-                                                       final Comparator<T> comparator,
-                                                       final int maxRecordsInRAM,
-                                                       final boolean printRecordSizeSampling) {
-        final Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir"));
-        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, tmpDir);
-    }
-
-    /**
-     * Syntactic sugar around the ctor, to save some typing of type parameters
-     *
-     * @param componentType    Class of the record to be sorted.  Necessary because of Java generic lameness.
-     * @param codec            For writing records to file and reading them back into RAM
-     * @param comparator       Defines output sort order
-     * @param maxRecordsInRAM  how many records to accumulate in memory before spilling to disk
-     * @param printRecordSizeSampling If true record size will be sampled and output at DEBUG log level
-     * @param tmpDir           Where to write files of records that will not fit in RAM
-     */
-    public static <T> SortingCollection<T> newInstance(final Class<T> componentType,
-                                                       final SortingCollection.Codec<T> codec,
-                                                       final Comparator<T> comparator,
-                                                       final int maxRecordsInRAM,
-                                                       final boolean printRecordSizeSampling,
-                                                       final Path... tmpDir) {
-        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, tmpDir);
-    }
-
-    /**
-     * Syntactic sugar around the ctor, to save some typing of type parameters.  Writes files to java.io.tmpdir
-     *
      * @param componentType   Class of the record to be sorted.  Necessary because of Java generic lameness.
      * @param codec           For writing records to file and reading them back into RAM
      * @param comparator      Defines output sort order

--- a/src/main/java/org/broadinstitute/hellbender/utils/gvs/localsort/SortingCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gvs/localsort/SortingCollection.java
@@ -121,7 +121,7 @@ public class SortingCollection<T> implements Iterable<T> {
      * @param maxRecordsInRam how many records to accumulate before spilling to disk
      * @param tmpDir          Where to write files of records that will not fit in RAM
      */
-    private SortingCollection(final Class<T> componentType, final Codec<T> codec,
+    private SortingCollection(final Class<T> componentType, final SortingCollection.Codec<T> codec,
                               final Comparator<T> comparator, final int maxRecordsInRam,
                               final Path... tmpDir) {
         if (maxRecordsInRam <= 0) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/gvs/localsort/SortingCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gvs/localsort/SortingCollection.java
@@ -153,27 +153,7 @@ public class SortingCollection<T> implements Iterable<T> {
             throw new IllegalStateException("Cannot add after calling iterator()");
         }
         if (numRecordsInRam == maxRecordsInRam) {
-
-            long startMem = 0;
-            if (printRecordSizeSampling) {
-                // Garbage collect and get free memory
-                Runtime.getRuntime().gc();
-                startMem = Runtime.getRuntime().freeMemory();
-            }
-
             spillToDisk();
-
-            if (printRecordSizeSampling) {
-                //Garbage collect again and get free memory
-                Runtime.getRuntime().gc();
-                long endMem = Runtime.getRuntime().freeMemory();
-
-                long usedBytes = endMem - startMem;
-                log.info(String.format("%d records in ram required approximately %s memory or %s per record. ", maxRecordsInRam,
-                        StringUtil.humanReadableByteCount(usedBytes),
-                        StringUtil.humanReadableByteCount(usedBytes / maxRecordsInRam)));
-
-            }
         }
         ramRecords[numRecordsInRam++] = rec;
     }


### PR DESCRIPTION
`GvsExtractCallset` still uses a default of 1000 maximum alt alleles when called from `GvsJointVariantCalling`, but will now use a default of 100 maximum alt alleles when called directly. Also remove memory debug logging code that was invariably reporting negative memory usage.