### PR TITLE
Enable Windows Compatibility

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,7 @@ src/main/resources/large/** filter=lfs diff=lfs merge=lfs -text
 *.fa text eol=lf
 *.fai text eol=lf
 *.dict text eol=lf
+*.vcf text eol=lf
+*.g.vcf text eol=lf
+*.vcf.gz binary
+*.vcf.idx binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,7 @@ src/main/resources/large/** filter=lfs diff=lfs merge=lfs -text
 *.fa text eol=lf
 *.fai text eol=lf
 *.dict text eol=lf
+*.tsv text eol=lf
 *.vcf text eol=lf
 *.g.vcf text eol=lf
 *.vcf.gz binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,9 @@ src/test/resources/large/funcotator/funcotator_dataSources/simple_uniprot/hg38 -
 src/test/resources/large/** filter=lfs diff=lfs merge=lfs -text
 src/main/resources/large/** filter=lfs diff=lfs merge=lfs -text
 *.psd filter=lfs diff=lfs merge=lfs -text
+
+# Ensure reference files use LF line endings to maintain consistent MD5 checksums across platforms
+*.fasta text eol=lf
+*.fa text eol=lf
+*.fai text eol=lf
+*.dict text eol=lf

--- a/.github/workflows/gatk-tests.yml
+++ b/.github/workflows/gatk-tests.yml
@@ -141,6 +141,66 @@ jobs:
           identifier: Java ${{ matrix.Java }} build and test ${{ matrix.testType }}
           only-artifact: ${{ needs.check-secrets.outputs.google-credentials != 'true' }}
 
+  #Run tests on Windows
+  test-windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        java: [ 17.0.6+10 ]
+        scalaVersion: [ 2.13 ]
+      fail-fast: false
+    env:
+      TEST_TYPE: noncloud
+      SCALA_VERSION: ${{ matrix.scalaVersion }}
+    name: Java ${{ matrix.java }} Windows build and test
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: 'Set up java ${{ matrix.java }}'
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: 'Setup Hadoop environment for Windows'
+        shell: pwsh
+        run: |
+          $hadoopHome = "C:\hadoop"
+          $hadoopTemp = "$hadoopHome\temp"
+          New-Item -Path $hadoopTemp -ItemType Directory -Force
+          echo "HADOOP_HOME=$hadoopHome" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "hadoop.home.dir=$hadoopHome" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: 'Compile with Gradle'
+        run: |
+          ./gradlew compileJava
+          ./gradlew installDist
+
+      - name: pull lfs files
+        run: git lfs pull
+
+      - name: compile test code
+        run: ./gradlew compileTestJava
+
+      - name: run-tests
+        id: jacoco-tests
+        run: |
+          ./gradlew --daemon -Dscala.version=${{ env.SCALA_VERSION }} jacocoTestReport
+
+      - uses: ./.github/actions/upload-gatk-test-results
+        if: always()
+        with:
+          warnPR: ${{ github.event_name == 'pull_request' && steps.jacoco-tests.outcome != 'success' }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          job-matrix-id: ${{ github.run_id }}.2${{ strategy.job-index }}
+          repo-path: ${{ github.ref_name }}_${{ github.run_id }}.2${{ strategy.job-index }}
+          bot-comment-key: ${{ secrets.GATK_BOT_COMMENT_KEY }}
+          identifier: Java ${{ matrix.java }} Windows build and test
+          only-artifact: true
+
 
   #Run our docker tests
   testOnDocker:

--- a/build.gradle
+++ b/build.gradle
@@ -179,7 +179,7 @@ configurations.configureEach {
 }
 
 tasks.withType(JavaCompile).configureEach {
-    options.compilerArgs = ['-proc:none', '-Xlint:all', '-Xdiags:verbose']
+    options.compilerArgs = ['-proc:none', '-Xlint:all', '-Werror', '-Xdiags:verbose']
     options.encoding = 'UTF-8'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -179,7 +179,7 @@ configurations.configureEach {
 }
 
 tasks.withType(JavaCompile).configureEach {
-    options.compilerArgs = ['-proc:none', '-Xlint:all', '-Werror', '-Xdiags:verbose']
+    options.compilerArgs = ['-proc:none', '-Xlint:all', '-Xdiags:verbose']
     options.encoding = 'UTF-8'
 }
 

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -25,6 +25,7 @@ import org.broadinstitute.hellbender.utils.help.HelpConstants;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.runtime.RuntimeUtils;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.file.*;
@@ -154,7 +155,8 @@ public abstract class CommandLineProgram implements CommandLinePluginProvider {
     public Object instanceMainPostParseArgs() {
         // Provide one temp directory if the caller didn't
         if (tmpDir == null) {
-            tmpDir = new GATKPath(System.getProperty("java.io.tmpdir"));
+            // Use File.getAbsolutePath() which handles Windows paths correctly
+            tmpDir = new GATKPath(new File(System.getProperty("java.io.tmpdir")).getAbsolutePath());
         }
 
         // Build the default headers
@@ -536,10 +538,12 @@ public abstract class CommandLineProgram implements CommandLinePluginProvider {
             logger.debug(e);
         } finally {
             // Make sure we clean up the test file
-            try {
-                Files.deleteIfExists(tempFilePath);
-            } catch(Exception e) {
-                logger.warn("Failed to delete temp file for testing temp dir", e);
+            if (tempFilePath != null) {
+                try {
+                    Files.deleteIfExists(tempFilePath);
+                } catch(Exception e) {
+                    logger.warn("Failed to delete temp file for testing temp dir", e);
+                }
             }
         }
         

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureInput.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureInput.java
@@ -153,7 +153,9 @@ public final class FeatureInput<T extends Feature> extends GATKPath implements S
         } else if (getScheme() != null && !getScheme().equals("file")) { // local files always have a "file" scheme
             return toPath().toAbsolutePath().toUri().toString();
         } else {
-            return getURI().getPath();
+            // For local files, convert to absolute path using the platform-specific path separator
+            // This ensures consistency with File.getAbsolutePath() behavior
+            return toPath().toAbsolutePath().toString();
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKPath.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKPath.java
@@ -4,6 +4,7 @@ import com.google.cloud.storage.contrib.nio.CloudStorageFileSystem;
 
 import htsjdk.io.HtsPath;
 
+import org.apache.commons.io.FilenameUtils;
 import org.broadinstitute.barclay.argparser.TaggedArgument;
 import org.broadinstitute.barclay.argparser.TaggedArgumentParser;
 import org.broadinstitute.hellbender.exceptions.GATKException;
@@ -20,6 +21,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * GATK tool command line arguments that are input or output resources. These can
@@ -201,5 +203,47 @@ public class GATKPath extends HtsPath implements TaggedArgument, Serializable {
                 result :
                 31 * result + getTagAttributes().hashCode();
         return result;
+    }
+
+    /**
+     * Override getExtension() to work around issues in htsjdk 4.2.0 on Windows.
+     * Uses Apache Commons FilenameUtils which handles URIs and paths correctly across platforms.
+     *
+     * @return the extension of the file name (including the leading '.'), or empty if no extension
+     */
+    @Override
+    public Optional<String> getExtension() {
+        final String uriPath = getURI().getPath();
+        if (uriPath == null || uriPath.isEmpty()) {
+            return Optional.empty();
+        }
+
+        final String extension = FilenameUtils.getExtension(uriPath);
+        if (extension == null || extension.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of("." + extension);
+    }
+
+    /**
+     * Override getBaseName() to work around issues in htsjdk 4.2.0 on Windows.
+     * Uses Apache Commons FilenameUtils which handles URIs and paths correctly across platforms.
+     *
+     * @return the base name of the file (without extension), or empty if no file name component
+     */
+    @Override
+    public Optional<String> getBaseName() {
+        final String uriPath = getURI().getPath();
+        if (uriPath == null || uriPath.isEmpty()) {
+            return Optional.empty();
+        }
+
+        final String baseName = FilenameUtils.getBaseName(uriPath);
+        if (baseName == null || baseName.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(baseName);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/genomicsdb/GenomicsDBImport.java
@@ -573,11 +573,8 @@ public final class GenomicsDBImport extends GATKTool {
                     headers.add(header);
 
                     final String sampleName = header.getGenotypeSamples().get(0);
-                    try {
-                        sampleNameMap.addSample(sampleName, new URI(variantPathString));
-                    } catch (final URISyntaxException e) {
-                        throw new UserException("Malformed URI " + e.getMessage(), e);
-                    }
+                    // Use variantPath.toUri() instead of new URI(variantPathString) to handle Windows paths correctly
+                    sampleNameMap.addSample(sampleName, variantPath.toUri());
                 }
                 mergedHeaderLines = VCFUtils.smartMergeHeaders(headers, true);
                 mergedHeaderSequenceDictionary = new VCFHeader(mergedHeaderLines).getSequenceDictionary();

--- a/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
@@ -766,7 +766,14 @@ public final class IOUtils {
             uri = URI.create(uriString);
         } catch (IllegalArgumentException x) {
             // not a valid URI. Caller probably just gave us a file name.
-            return Paths.get(uriString);
+            try {
+                return Paths.get(uriString);
+            } catch (InvalidPathException e) {
+                // On Windows, strings like "1:1-100" (interval notation) will throw InvalidPathException
+                // because ':' is not allowed except after drive letters. Return a placeholder path
+                // that will fail existence checks, allowing the caller to treat it as an interval string.
+                return Paths.get(uriString.replaceAll(":", "_"));
+            }
         }
         try {
             // special case GCS, in case the filesystem provider wasn't installed properly but is available.
@@ -789,7 +796,15 @@ public final class IOUtils {
                 // TODO: we depend on this code path to allow IntervalUtils to all getPath on a string that may be either
                 // a literal interval or a feature file containing intervals
                 // not a valid URI. Caller probably just gave us a file name or "chr1:1-2".
-                return Paths.get(uriString);
+                try {
+                    return Paths.get(uriString);
+                } catch (InvalidPathException ipe) {
+                    // On Windows, interval strings like "1:1-100" will throw InvalidPathException
+                    // because ':' is not allowed in Windows paths (except after drive letter).
+                    // In this case, we create a bogus Path that wraps the string for compatibility.
+                    // The caller (e.g., IntervalUtils) will handle this appropriately.
+                    return Paths.get(uriString.replaceAll(":", "_"));
+                }
             }
             catch ( IOException io ) {
                 throw new UserException(uriString + " is not a supported path", io);
@@ -823,7 +838,15 @@ public final class IOUtils {
      * @return a String with the absolute name, and the file:// protocol removed, if it was present.
      */
     public static String getAbsolutePathWithoutFileProtocol(final Path path) {
-        return path.toAbsolutePath().toUri().toString().replaceFirst("^file://", "");
+        String result = path.toAbsolutePath().toUri().toString();
+        // Remove file:// or file:/// protocol
+        result = result.replaceFirst("^file:///", "").replaceFirst("^file://", "");
+        // On Windows, after removing file:///, we get /C:/Users/... which needs the leading slash removed
+        // Check for Windows absolute path pattern: /[A-Z]:/
+        if (result.matches("^/[A-Za-z]:.*")) {
+            result = result.substring(1);
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/io/IOUtils.java
@@ -840,12 +840,9 @@ public final class IOUtils {
     public static String getAbsolutePathWithoutFileProtocol(final Path path) {
         String result = path.toAbsolutePath().toUri().toString();
         // Remove file:// or file:/// protocol
-        result = result.replaceFirst("^file:///", "").replaceFirst("^file://", "");
         // On Windows, after removing file:///, we get /C:/Users/... which needs the leading slash removed
         // Check for Windows absolute path pattern: /[A-Z]:/
-        if (result.matches("^/[A-Za-z]:.*")) {
-            result = result.substring(1);
-        }
+        result = result.replaceFirst("^file:(?:/{1,3})?", "");
         return result;
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/BwaMemIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/BwaMemIntegrationTest.java
@@ -15,6 +15,7 @@ import org.broadinstitute.hellbender.utils.bwa.BwaMemAlignment;
 import org.broadinstitute.hellbender.utils.bwa.BwaMemIndex;
 import org.broadinstitute.hellbender.testutils.ReadTestUtils;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -40,6 +41,10 @@ public final class BwaMemIntegrationTest extends GATKBaseTest {
 
     @BeforeClass
     public void loadIndex() throws IOException {
+        // BWA native library is not available for Windows - only Linux and macOS are supported
+        if (System.getProperty("os.name").toLowerCase().contains("win")) {
+            throw new SkipException("BWA native library is not available for Windows. Skipping test.");
+        }
         final RandomDNA rdnDNA = new RandomDNA(103);
         try {
             fastaFile = rdnDNA.nextFasta(TEST_DICTIONARY, 60);

--- a/src/test/java/org/broadinstitute/hellbender/BwaMemIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/BwaMemIntegrationTest.java
@@ -7,6 +7,7 @@ import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.reference.FastaSequenceIndex;
 import htsjdk.samtools.reference.FastaSequenceIndexCreator;
 import htsjdk.samtools.reference.IndexedFastaSequenceFile;
+import org.apache.commons.lang3.SystemUtils;
 import org.broadinstitute.hellbender.utils.RandomDNA;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -42,7 +43,7 @@ public final class BwaMemIntegrationTest extends GATKBaseTest {
     @BeforeClass
     public void loadIndex() throws IOException {
         // BWA native library is not available for Windows - only Linux and macOS are supported
-        if (System.getProperty("os.name").toLowerCase().contains("win")) {
+        if (SystemUtils.IS_OS_WINDOWS) {
             throw new SkipException("BWA native library is not available for Windows. Skipping test.");
         }
         final RandomDNA rdnDNA = new RandomDNA(103);

--- a/src/test/java/org/broadinstitute/hellbender/GATKBaseTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/GATKBaseTest.java
@@ -22,18 +22,18 @@ import java.util.List;
 public abstract class GATKBaseTest extends BaseTest {
 
     private static final String CURRENT_DIRECTORY = System.getProperty("user.dir");
-    public static final String gatkDirectory = System.getProperty("gatkdir", CURRENT_DIRECTORY) + "/";
+    public static final String gatkDirectory = System.getProperty("gatkdir", CURRENT_DIRECTORY) + File.separator;
 
-    public static final String publicMainResourcesDir = new File(gatkDirectory, "src/main/resources").getAbsolutePath() + "/";
-    public static final String packageMainResourcesDir = publicMainResourcesDir + "org/broadinstitute/hellbender/";
+    public static final String publicMainResourcesDir = new File(gatkDirectory, "src/main/resources").getAbsolutePath() + File.separator;
+    public static final String packageMainResourcesDir = publicMainResourcesDir + "org" + File.separator + "broadinstitute" + File.separator + "hellbender" + File.separator;
 
     private static final String publicTestDirRelative = "src/test/resources/";
-    public static final String publicTestDir = new File(gatkDirectory, publicTestDirRelative).getAbsolutePath() + "/";
+    public static final String publicTestDir = new File(gatkDirectory, publicTestDirRelative).getAbsolutePath() + File.separator;
     public static final String publicTestDirRoot = publicTestDir.replace(publicTestDirRelative, "");
 
-    public static final String packageRootTestDir = publicTestDir + "org/broadinstitute/hellbender/";
-    public static final String toolsTestDir = packageRootTestDir + "tools/";
-    public static final String exampleTestDir = toolsTestDir + "examples/";
+    public static final String packageRootTestDir = publicTestDir + "org" + File.separator + "broadinstitute" + File.separator + "hellbender" + File.separator;
+    public static final String toolsTestDir = packageRootTestDir + "tools" + File.separator;
+    public static final String exampleTestDir = toolsTestDir + "examples" + File.separator;
 
     public static final String GCS_GATK_TEST_RESOURCES = "gs://hellbender/test/resources/";
 
@@ -47,7 +47,7 @@ public abstract class GATKBaseTest extends BaseTest {
     /**
      * LARGE FILES FOR TESTING (MANAGED BY GIT LFS)
      */
-    public static final String largeFileTestDir = new File(publicTestDir, "large").getAbsolutePath() + "/";
+    public static final String largeFileTestDir = new File(publicTestDir, "large").getAbsolutePath() + File.separator;
 
     // The complete B37 human reference, including the Epstein-Barr contig, in fasta.gz format.
     // Source: /seq/references/Homo_sapiens_assembly19/v1/ in the Broad Institute filesystem.
@@ -119,15 +119,15 @@ public abstract class GATKBaseTest extends BaseTest {
     public static final String hg19MicroReference = publicTestDir + "hg19micro.fasta";
 
     public static final String FULL_HG19_DICT = publicTestDir + "Homo_sapiens_assembly19.dict";
-    public static final String FULL_HG38_DICT = publicTestDir + "large/Homo_sapiens_assembly38.dict";
+    public static final String FULL_HG38_DICT = publicTestDir + "large" + File.separator + "Homo_sapiens_assembly38.dict";
 
     public static final String exampleFASTA = publicTestDir + "exampleFASTA.fasta";
     public static final String exampleReference = hg19MiniReference;
     public static final String hg19MiniIntervalFile = publicTestDir + "hg19mini.interval_list";
     public static final String wgsIntervalFile = publicTestDir + "wgs_calling_regions.v1.interval_list";
 
-    public static final String DREAM_BAMS_DIR = publicTestDir + "large/mutect/dream_synthetic_bams";
-    public static final String DREAM_VCFS_DIR = publicTestDir + "org/broadinstitute/hellbender/tools/mutect/dream/vcfs";
+    public static final String DREAM_BAMS_DIR = publicTestDir + "large" + File.separator + "mutect" + File.separator + "dream_synthetic_bams";
+    public static final String DREAM_VCFS_DIR = publicTestDir + "org" + File.separator + "broadinstitute" + File.separator + "hellbender" + File.separator + "tools" + File.separator + "mutect" + File.separator + "dream" + File.separator + "vcfs";
 
     public static final String thousandGenomes = largeFileTestDir + "1000G.phase3.broad.withGenotypes.chr20.10100000.vcf";
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/GATKPathUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/GATKPathUnitTest.java
@@ -264,10 +264,11 @@ public class GATKPathUnitTest extends GATKBaseTest {
 
     @Test
     public void testStdIn() throws IOException {
-        final IOPath ioPath = new GATKPath(
-                SystemUtils.IS_OS_WINDOWS ?
-                        "-" :
-                        "/dev/stdin");
+        if (SystemUtils.IS_OS_WINDOWS) {
+            // stdin is not addressable as a device in the file system namespace on Windows, so skip
+            throw new SkipException("No stdin test on Windows");
+        }
+        final IOPath ioPath = new GATKPath("/dev/stdin");
         try (final InputStream is = ioPath.getInputStream();
              final DataInputStream dis = new DataInputStream(is)) {
             final byte[] actualFileContents = new byte[0];

--- a/src/test/java/org/broadinstitute/hellbender/engine/GATKPathUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/GATKPathUnitTest.java
@@ -473,9 +473,9 @@ public class GATKPathUnitTest extends GATKBaseTest {
         final String twoBitRefURL = publicTestDir + "large/human_g1k_v37.20.21.2bit";
         return new Object[][] {
                 { twoBitRefURL, false },
-                { "file://" + twoBitRefURL, false },
+                { Paths.get(twoBitRefURL).toUri().toString(), false },
                 { hg38Reference, true }, // gzipped
-                { "file://" + hg38Reference, true }, // gzipped
+                { Paths.get(hg38Reference).toUri().toString(), true }, // gzipped
                 { GCS_b37_CHR20_21_REFERENCE_2BIT, false },
                 { GCS_b37_CHR20_21_REFERENCE, true },
                 // dummy query params at the end to make sure URI.getPath does the right thing

--- a/src/test/java/org/broadinstitute/hellbender/engine/GenomicsDBIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/GenomicsDBIntegrationTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.engine;
 
 import htsjdk.variant.variantcontext.VariantContext;
+import org.apache.commons.lang3.SystemUtils;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.tools.walkers.variantutils.SelectVariants;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
@@ -27,7 +28,7 @@ public class GenomicsDBIntegrationTest extends CommandLineProgramTest {
     @BeforeClass
     public void checkPlatform() {
         // GenomicsDB native library is not available for Windows - only Linux and macOS are supported
-        if (System.getProperty("os.name").toLowerCase().contains("win")) {
+        if (SystemUtils.IS_OS_WINDOWS) {
             throw new SkipException("GenomicsDB native library is not available for Windows. Skipping test.");
         }
     }

--- a/src/test/java/org/broadinstitute/hellbender/engine/GenomicsDBIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/GenomicsDBIntegrationTest.java
@@ -10,6 +10,8 @@ import org.broadinstitute.hellbender.testutils.GenomicsDBTestUtils;
 import org.broadinstitute.hellbender.testutils.VariantContextTestUtils;
 import org.genomicsdb.GenomicsDBLibLoader;
 import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -21,6 +23,14 @@ public class GenomicsDBIntegrationTest extends CommandLineProgramTest {
     public static final String TEST_DATA_PATH =  publicTestDir + "/org/broadinstitute/hellbender/engine/GenomicsDBIntegration/";
     private static final File TINY_GVCF = new File(TEST_DATA_PATH, "tiny.g.vcf");
     private static final SimpleInterval INTERVAL = new SimpleInterval("20", 1, 63025520);
+
+    @BeforeClass
+    public void checkPlatform() {
+        // GenomicsDB native library is not available for Windows - only Linux and macOS are supported
+        if (System.getProperty("os.name").toLowerCase().contains("win")) {
+            throw new SkipException("GenomicsDB native library is not available for Windows. Skipping test.");
+        }
+    }
 
     @Override
     public String getTestedClassName() {

--- a/src/test/java/org/broadinstitute/hellbender/engine/PipelineSupportIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/PipelineSupportIntegrationTest.java
@@ -1,9 +1,11 @@
 package org.broadinstitute.hellbender.engine;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.utils.runtime.ProcessController;
 import org.broadinstitute.hellbender.testutils.BaseTest;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -15,6 +17,10 @@ public class PipelineSupportIntegrationTest extends GATKBaseTest {
     @Test
     // Asserting that Picard programs are able to pipe their output without errors
     public void testPipeForPicardTools() {
+        // Skip on Windows: uses Unix-specific 'sh' command
+        if (SystemUtils.IS_OS_WINDOWS) {
+            throw new SkipException("Test uses Unix command 'sh' which is not available on Windows");
+        }
         File output = createTempFile("testOutput",".bam");
         String gatkLaunchScript = System.getenv("GATK_LAUNCH_SCRIPT");
         String gatkLaunchScriptSubsitution = gatkLaunchScript == null ? "./gatk" : gatkLaunchScript;

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceTwoBitSparkSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReferenceTwoBitSparkSourceUnitTest.java
@@ -9,6 +9,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ReferenceTwoBitSparkSourceUnitTest extends GATKBaseTest {
     private static String fastaRefURL = publicTestDir + "large/human_g1k_v37.20.21.fasta";
@@ -60,17 +62,29 @@ public class ReferenceTwoBitSparkSourceUnitTest extends GATKBaseTest {
 
     @DataProvider(name="referenceTestCases")
     public Object[][] getReferenceTestCases() {
-        return new Object[][] {
-                { twoBitRefURL, true },
-                { "file://" + twoBitRefURL, true },
-                { hg38Reference, false }, // gzipped
-                { "file://" + hg38Reference, false }, // gzipped
-                { GCS_b37_CHR20_21_REFERENCE_2BIT, true },
-                { GCS_b37_CHR20_21_REFERENCE, false },
-                // dummy query params at the end to make sure URI.getPath does the right thing
-                { GCS_b37_CHR20_21_REFERENCE_2BIT + "?query=param", true },
-                { GCS_b37_CHR20_21_REFERENCE + "?query=param", false},
-        };
+        final boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
+        final List<Object[]> testCases = new ArrayList<>();
+
+        // Always test plain paths
+        testCases.add(new Object[] { twoBitRefURL, true });
+        testCases.add(new Object[] { hg38Reference, false }); // gzipped
+
+        // Skip file:// URI tests on Windows because "file://" + Windows path creates invalid URIs
+        // (e.g., "file://C:\Users" has illegal character ':' in authority section)
+        if (!isWindows) {
+            testCases.add(new Object[] { "file://" + twoBitRefURL, true });
+            testCases.add(new Object[] { "file://" + hg38Reference, false }); // gzipped
+        }
+
+        // GCS URIs work on all platforms
+        testCases.add(new Object[] { GCS_b37_CHR20_21_REFERENCE_2BIT, true });
+        testCases.add(new Object[] { GCS_b37_CHR20_21_REFERENCE, false });
+
+        // dummy query params at the end to make sure URI.getPath does the right thing
+        testCases.add(new Object[] { GCS_b37_CHR20_21_REFERENCE_2BIT + "?query=param", true });
+        testCases.add(new Object[] { GCS_b37_CHR20_21_REFERENCE + "?query=param", false });
+
+        return testCases.toArray(new Object[0][]);
     }
 
     @Test(dataProvider = "referenceTestCases")

--- a/src/test/java/org/broadinstitute/hellbender/testutils/ArgumentsBuilderTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/testutils/ArgumentsBuilderTest.java
@@ -12,13 +12,14 @@ public final class ArgumentsBuilderTest{
         ArgumentsBuilder args = new ArgumentsBuilder();
         args.addRaw("--value1");
         args.addRaw(1);
+        final File testFile = new File("path/to/somewhere");
         args.addRaw("--Input")
-            .addRaw(new File("path/to/somewhere"))
+            .addRaw(testFile)
             .addRaw("--Value2 2")
             .addRaw(" --Value3 3 --Value4 4");
 
         Assert.assertEquals(args.getArgsArray(), new String[]{"--value1", "1",
-                "--Input", "path/to/somewhere","--Value2","2","--Value3","3","--Value4","4"});
+                "--Input", testFile.getPath(),"--Value2","2","--Value3","3","--Value4","4"});
     }
     @Test
     public void testOneBigString(){
@@ -31,8 +32,10 @@ public final class ArgumentsBuilderTest{
 
     @Test
     public void testFromArray(){
-        ArgumentsBuilder args = new ArgumentsBuilder(new Object[]{"--Option " + new File("path/to"), "--OtherOption " + -1, new File("somewhere")});
-        Assert.assertEquals(args.getArgsArray(), new String[]{"--Option","path/to", "--OtherOption", "-1", "somewhere"});
+        final File testFile1 = new File("path/to");
+        final File testFile2 = new File("somewhere");
+        ArgumentsBuilder args = new ArgumentsBuilder(new Object[]{"--Option " + testFile1, "--OtherOption " + -1, testFile2});
+        Assert.assertEquals(args.getArgsArray(), new String[]{"--Option", testFile1.getPath(), "--OtherOption", "-1", testFile2.getPath()});
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/hellbender/tools/BwaMemIndexImageCreatorIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/BwaMemIndexImageCreatorIntegrationTest.java
@@ -1,10 +1,12 @@
 package org.broadinstitute.hellbender.tools;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.broadinstitute.hellbender.BwaMemTestUtils;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.utils.bwa.BwaMemIndex;
 import org.broadinstitute.hellbender.GATKBaseTest;
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -22,6 +24,11 @@ public class BwaMemIndexImageCreatorIntegrationTest extends CommandLineProgramTe
 
     @Test
     public void testImageFileGeneration() throws Exception {
+
+        // pre-build fermi-lite binaries are only available for Linux and Mac
+        if (SystemUtils.IS_OS_WINDOWS) {
+            throw new SkipException("pre-build fermi-lite binaries are only available for Linux and Mac");
+        }
 
         final File tempImage = GATKBaseTest.createTempFile("tempBwaMemIndexImage", ".img");
         final List<String> args = new ArrayList<>(Arrays.asList(

--- a/src/test/java/org/broadinstitute/hellbender/tools/SplitReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/SplitReadsIntegrationTest.java
@@ -95,14 +95,14 @@ public final class SplitReadsIntegrationTest extends CommandLineProgramTest {
         outputDir.toFile().deleteOnExit();
 
         args.add("-"+ StandardArgumentDefinitions.INPUT_SHORT_NAME);
-        args.add(getTestDataDir() + "/" + baseName + fileExtension);
+        args.add(getTestDataDir() + File.separator + baseName + fileExtension);
 
         args.add("-"+ StandardArgumentDefinitions.OUTPUT_SHORT_NAME );
         args.add(outputDir.toString());
 
         if (isReferenceRequired(type)) {
             args.add("-" + StandardArgumentDefinitions.REFERENCE_SHORT_NAME );
-            args.add(getTestDataDir()+ "/" + getReferenceSequenceName(baseName));
+            args.add(getTestDataDir() + File.separator + getReferenceSequenceName(baseName));
         }
 
         splitArgs.forEach(arg -> {

--- a/src/test/java/org/broadinstitute/hellbender/tools/copynumber/CollectReadCountsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/copynumber/CollectReadCountsIntegrationTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.copynumber;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.IntervalArgumentCollection;
@@ -8,6 +9,7 @@ import org.broadinstitute.hellbender.tools.copynumber.formats.collections.Simple
 import org.broadinstitute.hellbender.utils.IntervalMergingRule;
 import org.broadinstitute.hellbender.utils.IntervalSetRule;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -97,6 +99,11 @@ public final class CollectReadCountsIntegrationTest extends CommandLineProgramTe
 
     @Test(dataProvider = "testData")
     public void testHDF5Output(final File inputBAMFile, final File expectedOutputFile) {
+        // HDF5 is currently supported on x86-64 architecture and Linux or OSX systems.
+        if (SystemUtils.IS_OS_WINDOWS) {
+            throw new SkipException("HDF5 is currently supported on x86-64 architecture and Linux or OSX systems.");
+        }
+
         final File resultOutputFile = createTempFile("collect-read-counts-test", ".hdf5");
         final ArgumentsBuilder argsBuilder = new ArgumentsBuilder()
                 .addInput(inputBAMFile)

--- a/src/test/java/org/broadinstitute/hellbender/tools/copynumber/DenoiseReadCountsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/copynumber/DenoiseReadCountsIntegrationTest.java
@@ -1,11 +1,13 @@
 package org.broadinstitute.hellbender.tools.copynumber;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.testutils.ArgumentsBuilder;
 import org.broadinstitute.hellbender.tools.copynumber.arguments.CopyNumberStandardArgument;
 import org.broadinstitute.hellbender.tools.copynumber.formats.collections.CopyRatioCollection;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -62,6 +64,10 @@ public final class DenoiseReadCountsIntegrationTest extends CommandLineProgramTe
     @Test(dataProvider = "dataDenoiseReadCounts")
     public void testDenoiseReadCounts(final ArgumentsBuilder argumentsBuilder,
                                       final boolean isStandardizedEqualsDenoised) {
+        // HDF5 is currently supported on x86-64 architecture and Linux or OSX systems
+        if (SystemUtils.IS_OS_WINDOWS) {
+            throw new SkipException("HDF5 is currently supported on x86-64 architecture and Linux or OSX systems");
+        }
         final File standardizedCRFile = createTempFile("test", ".standardizedCR.tsv");
         final File denoisedCRFile = createTempFile("test", ".denoisedCR.tsv");
         final String[] arguments = argumentsBuilder

--- a/src/test/java/org/broadinstitute/hellbender/tools/copynumber/formats/collections/HDF5SimpleCountCollectionUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/copynumber/formats/collections/HDF5SimpleCountCollectionUnitTest.java
@@ -2,12 +2,14 @@ package org.broadinstitute.hellbender.tools.copynumber.formats.collections;
 
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
+import org.apache.commons.lang3.SystemUtils;
 import org.broadinstitute.hdf5.HDF5File;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.tools.copynumber.formats.metadata.SampleLocatableMetadata;
 import org.broadinstitute.hellbender.tools.copynumber.formats.metadata.SimpleSampleLocatableMetadata;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -18,6 +20,10 @@ import java.util.List;
 public final class HDF5SimpleCountCollectionUnitTest extends GATKBaseTest {
     @Test
     public void basicTest() {
+        // HDF5 is currently supported on x86-64 architecture and Linux or OSX systems
+        if (SystemUtils.IS_OS_WINDOWS) {
+            throw new SkipException("HDF5 is currently supported on x86-64 architecture and Linux or OSX systems");
+        }
         final File outputFile = createTempFile("HDF5ReadCountCollection", ".hdf5");
         final SampleLocatableMetadata metadata = new SimpleSampleLocatableMetadata(
                 "test-sample",

--- a/src/test/java/org/broadinstitute/hellbender/tools/copynumber/formats/collections/SimpleCountCollectionUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/copynumber/formats/collections/SimpleCountCollectionUnitTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
+import org.apache.commons.lang3.SystemUtils;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.copynumber.formats.metadata.SampleLocatableMetadata;
@@ -11,6 +12,7 @@ import org.broadinstitute.hellbender.tools.copynumber.formats.metadata.SimpleSam
 import org.broadinstitute.hellbender.tools.copynumber.formats.records.SimpleCount;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -91,6 +93,10 @@ public final class SimpleCountCollectionUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "simpleCountCollectionReadTestData")
     public void testRead(final File file) {
+        // HDF5 is currently supported on x86-64 architecture and Linux or OSX systems
+        if (SystemUtils.IS_OS_WINDOWS) {
+            throw new SkipException("HDF5 is currently supported on x86-64 architecture and Linux or OSX systems");
+        }
         final SimpleCountCollection counts = SimpleCountCollection.read(file);
         assertCountsExpected(counts);
     }
@@ -121,6 +127,10 @@ public final class SimpleCountCollectionUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "simpleCountCollectionReadTestData")
     public void testReadAndSubset(final File file) {
+        // HDF5 is currently supported on x86-64 architecture and Linux or OSX systems
+        if (SystemUtils.IS_OS_WINDOWS) {
+            throw new SkipException("HDF5 is currently supported on x86-64 architecture and Linux or OSX systems");
+        }
         final SimpleCountCollection countsSubsetNull = SimpleCountCollection.readAndSubset(file,
                 null);
         assertCountsExpected(countsSubsetNull);

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/ApplyBQSRSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/ApplyBQSRSparkIntegrationTest.java
@@ -41,7 +41,7 @@ public final class ApplyBQSRSparkIntegrationTest extends CommandLineProgramTest 
         }
     }
 
-    final String resourceDir = getTestDataDir() + "/" + "BQSR" + "/";
+    final String resourceDir = getTestDataDir() + File.separator + "BQSR" + File.separator;
     final String hiSeqBam = resourceDir + "HiSeq.1mb.1RG.2k_lines.alternate_allaligned.bam";
     final String hg18Reference = publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
     final String hiSeqCram = resourceDir + "HiSeq.1mb.1RG.2k_lines.alternate.cram";

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/BaseRecalibratorSparkIntegrationTest.java
@@ -51,7 +51,7 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
     }
 
     private String getResourceDir(){
-        return getTestDataDir() + "/" + "BQSR" + "/";
+        return getTestDataDir() + File.separator + "BQSR" + File.separator;
     }
 
     private String getCloudInputs() {
@@ -179,7 +179,7 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
     // TODO: This test is disabled because a new expected result needs to be created.
     @Test(description = "This is to test https://github.com/broadinstitute/hellbender/issues/322", groups = {"cloud", "spark"}, enabled = false)
     public void testPlottingWorkflow() throws IOException {
-        final String resourceDir = getTestDataDir() + "/" + "BQSR" + "/";
+        final String resourceDir = getTestDataDir() + File.separator + "BQSR" + File.separator;
         final String chr2021Reference2bit = GCS_b37_CHR20_21_REFERENCE_2BIT;
         final String dbSNPb37_chr2021 = resourceDir + DBSNP_138_B37_CH20_1M_1M1K_VCF;
         final String HiSeqBam_chr20 = getResourceDir() + WGS_B37_CH20_1M_1M1K_BAM;
@@ -209,7 +209,7 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
 
     @Test(groups = {"spark", "bucket"})
     public void testBQSRFailWithoutDBSNP() throws IOException {
-        final String resourceDir =  getTestDataDir() + "/" + "BQSR" + "/";
+        final String resourceDir =  getTestDataDir() + File.separator + "BQSR" + File.separator;
         final String localResources =  getResourceDir();
 
         final String chr2021Reference2bit = GCS_b37_CHR20_21_REFERENCE_2BIT;
@@ -226,7 +226,7 @@ public final class BaseRecalibratorSparkIntegrationTest extends CommandLineProgr
 
     @Test(groups = {"spark", "bucket"})
     public void testBQSRFailWithIncompatibleReference() throws IOException {
-        final String resourceDir =  getTestDataDir() + "/" + "BQSR" + "/";
+        final String resourceDir =  getTestDataDir() + File.separator + "BQSR" + File.separator;
         final String localResources =  getResourceDir();
 
         final String HiSeqBam_chr17 = resourceDir + "NA12878.chr17_69k_70k.dictFix.bam";

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/BQSRPipelineSparkIntegrationTest.java
@@ -46,7 +46,7 @@ public class BQSRPipelineSparkIntegrationTest extends CommandLineProgramTest {
     }
 
     private String getResourceDir(){
-        return getTestDataDir() + "/" + "BQSR" + "/";
+        return getTestDataDir() + File.separator + "BQSR" + File.separator;
     }
 
     @DataProvider(name = "BQSRLocalRefTest")

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/FlagStatSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/FlagStatSparkIntegrationTest.java
@@ -29,7 +29,7 @@ public final class FlagStatSparkIntegrationTest extends CommandLineProgramTest {
 
         Assert.assertTrue(outputFile.exists());
         //the expected output was created using stand-alone hellbender
-        IntegrationTestSpec.assertMatchingFiles(Lists.newArrayList(outputFile), Lists.newArrayList(getToolTestDataDir() +"/"+ "expectedStats.txt"), false, null);
+        IntegrationTestSpec.assertMatchingFiles(Lists.newArrayList(outputFile), Lists.newArrayList(getToolTestDataDir() + File.separator + "expectedStats.txt"), false, null);
     }
     @Test(groups = "spark")
     public void flagStatSparkLocalWithBigInterval() throws IOException {
@@ -51,7 +51,7 @@ public final class FlagStatSparkIntegrationTest extends CommandLineProgramTest {
 
         Assert.assertTrue(outputFile.exists());
         //the expected output was created using stand-alone hellbender
-        IntegrationTestSpec.assertMatchingFiles(Lists.newArrayList(outputFile), Lists.newArrayList(getToolTestDataDir() +"/"+ "expectedStats.chr1-chr8.txt"), false, null);
+        IntegrationTestSpec.assertMatchingFiles(Lists.newArrayList(outputFile), Lists.newArrayList(getToolTestDataDir() + File.separator + "expectedStats.chr1-chr8.txt"), false, null);
     }
 
     @Test(groups = "spark")
@@ -67,7 +67,7 @@ public final class FlagStatSparkIntegrationTest extends CommandLineProgramTest {
 
         Assert.assertTrue(outputFile.exists());
         //the expected output was created using stand-alone hellbender
-        IntegrationTestSpec.assertMatchingFiles(Lists.newArrayList(outputFile), Lists.newArrayList(getToolTestDataDir() +"/"+ "expectedStats.chr1_1.txt"), false, null);
+        IntegrationTestSpec.assertMatchingFiles(Lists.newArrayList(outputFile), Lists.newArrayList(getToolTestDataDir() + File.separator + "expectedStats.chr1_1.txt"), false, null);
     }
 
     @Test(groups = "spark")

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSparkIntegrationTest.java
@@ -44,7 +44,7 @@ public class ReadsPipelineSparkIntegrationTest extends CommandLineProgramTest {
     }
 
     private String getResourceDir(){
-        return getTestDataDir() + "/" + "BQSR" + "/";
+        return getTestDataDir() + File.separator + "BQSR" + File.separator;
     }
 
     @DataProvider(name = "ReadsPipeline")

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/ApplyBQSRIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/ApplyBQSRIntegrationTest.java
@@ -61,7 +61,7 @@ public final class ApplyBQSRIntegrationTest extends CommandLineProgramTest {
         return ApplyBQSR.class.getSimpleName();
     }
 
-    private final String resourceDir = getTestDataDir() + "/" + "BQSR" + "/";
+    private final String resourceDir = getTestDataDir() + File.separator + "BQSR" + File.separator;
     private final String hg18Reference = publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
     private final String hiSeqBam = resourceDir + "HiSeq.1mb.1RG.2k_lines.alternate.bam";
     private final String hiSeqCram = resourceDir + "HiSeq.1mb.1RG.2k_lines.alternate.cram";

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibratorIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibratorIntegrationTest.java
@@ -48,7 +48,7 @@ public final class BaseRecalibratorIntegrationTest extends CommandLineProgramTes
     }
 
     private String getResourceDir(){
-        return getTestDataDir() + "/" + "BQSR" + "/";
+        return getTestDataDir() + File.separator + "BQSR" + File.separator;
     }
 
     @DataProvider(name = "BQSRTest")
@@ -108,7 +108,7 @@ public final class BaseRecalibratorIntegrationTest extends CommandLineProgramTes
 
     @Test(description = "This is to test https://github.com/broadinstitute/hellbender/issues/322")
     public void testPlottingWorkflow() throws IOException {
-        final String resourceDir = getTestDataDir() + "/" + "BQSR" + "/";
+        final String resourceDir = getTestDataDir() + File.separator + "BQSR" + File.separator;
         final String hg18Reference = publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
         final String dbSNPb37_chr17 =  getResourceDir() + "dbsnp_132.b37.excluding_sites_after_129.chr17_69k_70k.vcf";
         final String HiSeqBam_chr17 = getResourceDir() + "NA12878.chr17_69k_70k.dictFix.bam";
@@ -136,7 +136,7 @@ public final class BaseRecalibratorIntegrationTest extends CommandLineProgramTes
 
     @Test
     public void testBQSRFailWithoutDBSNP() throws IOException {
-        final String resourceDir =  getTestDataDir() + "/" + "BQSR" + "/";
+        final String resourceDir =  getTestDataDir() + File.separator + "BQSR" + File.separator;
 
         final String hg18Reference = publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
         final String HiSeqBam_chr17 = resourceDir + "NA12878.chr17_69k_70k.dictFix.bam";
@@ -153,7 +153,7 @@ public final class BaseRecalibratorIntegrationTest extends CommandLineProgramTes
 
     @Test
     public void testBQSRFailWithIncompatibleReference() throws IOException {
-        final String resourceDir =  getTestDataDir() + "/" + "BQSR" + "/";
+        final String resourceDir =  getTestDataDir() + File.separator + "BQSR" + File.separator;
 
         final String HiSeqBam_Hg18 = resourceDir + "HiSeq.1mb.1RG.2k_lines.bam";
 
@@ -168,7 +168,7 @@ public final class BaseRecalibratorIntegrationTest extends CommandLineProgramTes
 
     @Test
     public void testBQSRFailWithIncompatibleSequenceDictionaries() throws IOException {
-        final String resourceDir =  getTestDataDir() + "/" + "BQSR" + "/";
+        final String resourceDir =  getTestDataDir() + File.separator + "BQSR" + File.separator;
 
         final String bam_chr20 = resourceDir + WGS_B37_CH20_1M_1M1K_BAM;
         final String dbSNPb37_chr17 =  getResourceDir() + "dbsnp_132.b37.excluding_sites_after_129.chr17_69k_70k.vcf";

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/qc/PileupIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/qc/PileupIntegrationTest.java
@@ -5,6 +5,7 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.testutils.IntegrationTestSpec;
 import org.testng.annotations.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 
@@ -13,7 +14,7 @@ import java.util.Arrays;
  */
 public class PileupIntegrationTest extends CommandLineProgramTest {
 
-    private final String TEST_OUTPUT_DIRECTORY = getToolTestDataDir().toLowerCase() + "/";
+    private final String TEST_OUTPUT_DIRECTORY = getToolTestDataDir().toLowerCase() + File.separator;
 
     @Test
     public void testSimplePileup() throws IOException {

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReadsIntegrationTest.java
@@ -51,8 +51,8 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
     @Test
     public void testSplitsFixNDN() throws Exception {
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                "-R " + b37_reference_20_21 + " -I " + getTestDataDir() +"/" + "splitNCigarReadsSnippet.bam -O %s -fixNDN --process-secondary-alignments",
-                Arrays.asList(getTestDataDir() +"/" + "expected.splitNCigarReadsSnippet.splitNcigarReads.fixNDN.bam"));
+                "-R " + b37_reference_20_21 + " -I " + getTestDataDir() + File.separator + "splitNCigarReadsSnippet.bam -O %s -fixNDN --process-secondary-alignments",
+                Arrays.asList(getTestDataDir() + File.separator + "expected.splitNCigarReadsSnippet.splitNcigarReads.fixNDN.bam"));
         spec.executeTest("test fix NDN", this);
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateEngineUnitTest.java
@@ -23,8 +23,8 @@ import java.io.File;
 import java.util.*;
 
 public class SVAnnotateEngineUnitTest extends GATKBaseTest {
-    private final File TOY_GTF_FILE = new File(getToolTestDataDir().replaceFirst("Engine", "") + "unittest.gtf");
-    private final File TINY_NONCODING_BED_FILE = new File(getToolTestDataDir().replaceFirst("Engine", "") + "noncoding.unittest.bed");
+    private final File TOY_GTF_FILE = new File(getToolTestDataDir().replaceFirst("Engine", "") + File.separator + "unittest.gtf");
+    private final File TINY_NONCODING_BED_FILE = new File(getToolTestDataDir().replaceFirst("Engine", "") + File.separator + "noncoding.unittest.bed");
 
 
     // Pairs of intervals with different relationships to check if first (variant) interval spans second (feature)

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateIntegrationTest.java
@@ -17,7 +17,7 @@ import java.util.*;
 
 
 public class SVAnnotateIntegrationTest extends CommandLineProgramTest {
-    final String INPUT_VCF_PATH = getToolTestDataDir() + "integration.vcf.gz";
+    final String INPUT_VCF_PATH = getToolTestDataDir() + File.separator + "integration.vcf.gz";
     final File inputVCF = new File(INPUT_VCF_PATH);
     private final String LARGE_FILE_DIR = GATKBaseTest.largeFileTestDir + "SVAnnotate/";
     final File GTF_FILE = new File(LARGE_FILE_DIR + "MANE.selected.GRCh38.v0.95.select_ensembl_genomic.gtf");

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/sv/SVAnnotateUnitTest.java
@@ -17,8 +17,8 @@ import java.io.File;
 import java.util.*;
 
 public class SVAnnotateUnitTest extends GATKBaseTest {
-    protected final File TOY_GTF_FILE = new File(getToolTestDataDir() + "unittest.gtf");
-    protected final File TINY_NONCODING_BED_FILE = new File(getToolTestDataDir() + "noncoding.unittest.bed");
+    protected final File TOY_GTF_FILE = new File(getToolTestDataDir() + File.separator + "unittest.gtf");
+    protected final File TINY_NONCODING_BED_FILE = new File(getToolTestDataDir() + File.separator + "noncoding.unittest.bed");
 
     /**
      * Load toy GTF containing toy genes into FeatureDataSource

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/varianteval/AlleleFrequencyQCIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/varianteval/AlleleFrequencyQCIntegrationTest.java
@@ -7,17 +7,18 @@ import org.broadinstitute.hellbender.testutils.IntegrationTestSpec;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 
 public class AlleleFrequencyQCIntegrationTest extends CommandLineProgramTest {
 
-    private String evalVcf = getToolTestDataDir() + "af.na12878_array.vcf";
-    private String comparisonVcf = getToolTestDataDir() + "af.thousand_genomes.10sites.vcf";
+    private String evalVcf = getToolTestDataDir() + File.separator + "af.na12878_array.vcf";
+    private String comparisonVcf = getToolTestDataDir() + File.separator + "af.thousand_genomes.10sites.vcf";
 
 
     private String getExpectedFile(String testName) {
-        return getToolTestDataDir() + "expected/" + testName + ".expected.txt";
+        return getToolTestDataDir() + File.separator + "expected" + File.separator + testName + ".expected.txt";
     }
 
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/haplotype/HaplotypeBAMWriterUnitTest.java
@@ -25,7 +25,7 @@ import java.util.*;
 
 public class HaplotypeBAMWriterUnitTest extends GATKBaseTest {
     private final SAMFileHeader samHeader = ArtificialReadUtils.createArtificialSamHeaderWithPrograms(20, 1, 1000, 3);
-    private final String expectedFilePath = getToolTestDataDir() + "/expected/";
+    private final String expectedFilePath = getToolTestDataDir() + File.separator + "expected" + File.separator;
 
     @DataProvider(name="ReadsLikelikhoodData")
     public Object[][] makeReadsLikelikhoodData() {

--- a/src/test/java/org/broadinstitute/hellbender/utils/runtime/ProcessControllerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/runtime/ProcessControllerUnitTest.java
@@ -2,11 +2,13 @@ package org.broadinstitute.hellbender.utils.runtime;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.GATKBaseTest;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -22,6 +24,11 @@ public final class ProcessControllerUnitTest extends GATKBaseTest {
 
     @Test
     public void testReuseAfterError() {
+        // Skip on Windows: uses Unix-specific 'cat' command
+        if (SystemUtils.IS_OS_WINDOWS) {
+            throw new SkipException("Test uses Unix command 'cat' which is not available on Windows");
+        }
+
         ProcessController controller = new ProcessController();
 
         ProcessSettings job;
@@ -49,6 +56,11 @@ public final class ProcessControllerUnitTest extends GATKBaseTest {
 
     @Test
     public void testEnvironment() {
+        // Skip on Windows: uses Unix-specific 'sh' shell command
+        if (SystemUtils.IS_OS_WINDOWS) {
+            throw new SkipException("Test uses Unix command 'sh' which is not available on Windows");
+        }
+
         String key = "MY_NEW_VAR";
         String value = "value is here";
 
@@ -70,6 +82,11 @@ public final class ProcessControllerUnitTest extends GATKBaseTest {
 
     @Test
     public void testDirectory() throws IOException {
+        // Skip on Windows: uses Unix-specific 'pwd' command
+        if (SystemUtils.IS_OS_WINDOWS) {
+            throw new SkipException("Test uses Unix command 'pwd' which is not available on Windows");
+        }
+
         File dir = createTempDir("temp.").getCanonicalFile();
 
         ProcessSettings job = new ProcessSettings(new String[] {"pwd"});
@@ -89,6 +106,11 @@ public final class ProcessControllerUnitTest extends GATKBaseTest {
 
     @Test
     public void testReadStdInBuffer() {
+        // Skip on Windows: uses Unix-specific 'cat' command
+        if (SystemUtils.IS_OS_WINDOWS) {
+            throw new SkipException("Test uses Unix command 'cat' which is not available on Windows");
+        }
+
         String bufferText = "Hello from buffer";
         ProcessSettings job = new ProcessSettings(new String[] {"cat"});
         job.getStdoutSettings().setBufferSize(-1);
@@ -104,6 +126,11 @@ public final class ProcessControllerUnitTest extends GATKBaseTest {
 
     @Test
     public void testReadStdInFile() {
+        // Skip on Windows: uses Unix-specific 'cat' command
+        if (SystemUtils.IS_OS_WINDOWS) {
+            throw new SkipException("Test uses Unix command 'cat' which is not available on Windows");
+        }
+
         File input = null;
         try {
             String fileText = "Hello from file";
@@ -140,6 +167,11 @@ public final class ProcessControllerUnitTest extends GATKBaseTest {
 
     @Test
     public void testErrorToOut() throws IOException {
+        // Skip on Windows: uses Unix-specific 'cat' command
+        if (SystemUtils.IS_OS_WINDOWS) {
+            throw new SkipException("Test uses Unix command 'cat' which is not available on Windows");
+        }
+
         File outFile = null;
         File errFile = null;
         try {
@@ -182,6 +214,11 @@ public final class ProcessControllerUnitTest extends GATKBaseTest {
 
     @Test
     public void testErrorToErr() throws IOException {
+        // Skip on Windows: uses Unix-specific 'cat' command
+        if (SystemUtils.IS_OS_WINDOWS) {
+            throw new SkipException("Test uses Unix command 'cat' which is not available on Windows");
+        }
+
         File outFile = null;
         File errFile = null;
         try {
@@ -359,6 +396,11 @@ public final class ProcessControllerUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "scriptCommands")
     public void testScript(ScriptCommand script) throws IOException {
+        // Skip on Windows: uses Unix-specific 'sh' shell command
+        if (SystemUtils.IS_OS_WINDOWS) {
+            throw new SkipException("Test uses Unix command 'sh' which is not available on Windows");
+        }
+
         File scriptFile = null;
         File outputFile = null;
         try {

--- a/src/test/java/org/broadinstitute/hellbender/utils/runtime/ProcessControllerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/runtime/ProcessControllerUnitTest.java
@@ -153,6 +153,11 @@ public final class ProcessControllerUnitTest extends GATKBaseTest {
 
     @Test
     public void testWriteStdOut() {
+        // Skip on Windows: echo output format differs (CRLF vs LF line endings)
+        if (SystemUtils.IS_OS_WINDOWS) {
+            throw new SkipException("Test expects Unix line ending behavior which differs on Windows");
+        }
+
         final String testInput = "Testing to stdout";
         final ProcessSettings job = new ProcessSettings(new String[] {"echo", testInput});
         job.getStdoutSettings().printStandard(true);
@@ -278,6 +283,11 @@ public final class ProcessControllerUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "truncateSizes")
     public void testTruncateBuffer(int truncateLen, int expectedLen) {
+        // Skip on Windows: echo output format differs (CRLF vs LF line endings)
+        if (SystemUtils.IS_OS_WINDOWS) {
+            throw new SkipException("Test expects Unix line ending behavior which differs on Windows");
+        }
+
         byte[] expected = Arrays.copyOf(TRUNCATE_OUTPUT_BYTES, expectedLen);
 
         String[] command = {"echo", TRUNCATE_TEXT};
@@ -330,6 +340,11 @@ public final class ProcessControllerUnitTest extends GATKBaseTest {
 
     @Test(dataProvider = "echoCommands")
     public void testEcho(EchoCommand script) throws IOException {
+        // Skip on Windows: echo output format differs (CRLF vs LF line endings)
+        if (SystemUtils.IS_OS_WINDOWS) {
+            throw new SkipException("Test expects Unix line ending behavior which differs on Windows");
+        }
+
         File outputFile = null;
         try {
             outputFile = GATKBaseTest.createTempFile("temp", "");

--- a/src/test/java/org/broadinstitute/hellbender/utils/samples/SampleDBUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/samples/SampleDBUnitTest.java
@@ -7,13 +7,14 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.io.File;
 import java.util.*;
 
 
 public class SampleDBUnitTest extends GATKBaseTest {
     private static SampleDBBuilder builder;
     // all the test sample files are located here
-    private GATKPath testPED = new GATKPath(getToolTestDataDir() +  "testtrio.ped");
+    private GATKPath testPED = new GATKPath(getToolTestDataDir() + File.separator + "testtrio.ped");
 
     private static final Set<Sample> testPEDSamples = new LinkedHashSet<>(Arrays.asList(
             new Sample("kid", "fam1", "dad", "mom", Sex.MALE, Affection.AFFECTED),

--- a/src/testUtils/java/org/broadinstitute/hellbender/testutils/BaseTest.java
+++ b/src/testUtils/java/org/broadinstitute/hellbender/testutils/BaseTest.java
@@ -139,10 +139,52 @@ public abstract class BaseTest {
     public static void runToolInNewJVM(String toolName, ArgumentsBuilder arguments, Map<String, String> environment){
         final String javaHome = System.getProperty("java.home");
         final String javaBin = javaHome + File.separator + "bin" + File.separator + "java";
-        final String classpath = System.getProperty("java.class.path");;
+        final String classpath = System.getProperty("java.class.path");
+
+        // On Windows, use a classpath JAR to avoid command line length limitations (max 8191 characters)
+        final boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
+        String classpathArg = classpath;
+        File manifestJar = null;
+
+        if (isWindows) {
+            try {
+                // Create a temporary JAR with a manifest containing the classpath
+                manifestJar = File.createTempFile("gatk-test-classpath-", ".jar");
+                manifestJar.deleteOnExit();
+
+                // Build the manifest with Class-Path entry
+                final java.util.jar.Manifest manifest = new java.util.jar.Manifest();
+                manifest.getMainAttributes().put(java.util.jar.Attributes.Name.MANIFEST_VERSION, "1.0");
+
+                // Convert classpath to URLs (required format for manifest Class-Path)
+                final String[] classpathEntries = classpath.split(File.pathSeparator);
+                final StringBuilder classPathBuilder = new StringBuilder();
+                for (String entry : classpathEntries) {
+                    final File file = new File(entry);
+                    // Convert to URI to handle spaces and special characters
+                    classPathBuilder.append(file.toURI().toURL()).append(" ");
+                }
+                manifest.getMainAttributes().put(java.util.jar.Attributes.Name.CLASS_PATH, classPathBuilder.toString().trim());
+
+                // Write the JAR with only the manifest
+                try (final java.util.jar.JarOutputStream jos = new java.util.jar.JarOutputStream(
+                        new java.io.FileOutputStream(manifestJar), manifest)) {
+                    // No entries needed, just the manifest
+                }
+
+                classpathArg = manifestJar.getAbsolutePath();
+            } catch (IOException e) {
+                // Fall back to direct classpath if manifest JAR creation fails
+                classpathArg = classpath;
+                if (manifestJar != null && manifestJar.exists()) {
+                    manifestJar.delete();
+                }
+            }
+        }
+
         final List<String> baseCommand = new ArrayList<>(Arrays.asList(
                 javaBin,
-                "-cp", classpath,
+                "-cp", classpathArg,
                 Main.class.getName(),
                 toolName));
         baseCommand.addAll(arguments.getArgsList());

--- a/src/testUtils/java/org/broadinstitute/hellbender/testutils/GenomicsDBTestUtils.java
+++ b/src/testUtils/java/org/broadinstitute/hellbender/testutils/GenomicsDBTestUtils.java
@@ -22,7 +22,10 @@ public final class GenomicsDBTestUtils {
      * @return a string formatted as a genomicsDB uri pointing to the given workspace i.e "gendb:///pathTo/workspace
      */
     public static String makeGenomicsDBUri(final File workspace){
-        return IOUtils.GENOMIC_DB_URI_SCHEME + "://" + workspace.getAbsolutePath();
+        // Convert the file path to a URI path string to ensure proper formatting on all platforms (e.g., Windows)
+        // This uses the Path.toUri() method which properly converts backslashes to forward slashes
+        final String uriPath = workspace.toPath().toUri().normalize().getPath();
+        return IOUtils.GENOMIC_DB_URI_SCHEME + "://" + uriPath;
     }
 
     /**


### PR DESCRIPTION
The reasoning, motivation, and status quo are provided in #9293.

As mentioned in the issue, Windows is currently not supported for GATK.

This PR creates a CI/CD flow for Windows to enable development support and flag regressions.
Addresses all Windows failing tests.

This PR focuses on making small changes to the Code Under Test to be platform-independent, as well as small changes on tests that are not possible to be implemented under windows platform. In general, the changes are:

- Using File.separator instead of "/".
- Adding LF handling in .gitattributes to prevent differing MD5 checksums due to Windows (CRLF) vs. Unix (LF) line endings.
- Using Java-provided absolute paths (via the File API) instead of proxies.
- Adding null checks in scenarios where they were missing (e.g., Files.deleteIfExists does not perform a null check for its argument under the hood).
- Extending GATKPath to explicitly use Apache Commons FilenameUtils.
- Improving fallback from IOUtils, which was causing intervals to be detected as paths on Windows due to the ":" in paths like C:\this\is\a\path. This was the original problem I was facing.
- Skipping tests that cannot be implemented on Windows due to missing binaries (e.g., the BWA library is only available for Linux and macOS) or capabilities (e.g., stdin, cat, sh, etc., are not available on Windows).
- Fixing the command-line length limitation on Windows (limited to 8191 characters) by pushing it to a temporary JAR's manifest.

Notes:

- This PR was developed on top of 4.6.2.0 tag (as stable) and then rebased to master latest. 
- Due to the lack of Github actions for local development and the known complexity for setting up Hadoop, I have not tested the section that requires HADOOP_HOME being set. I have setup the github action change to include it nonetheless.

Closes #9293.