### PR TITLE
VS-1747 Respect the withdrawn flag in GvsExtractCohortFromSampleNames

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -463,6 +463,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - FoxtrotRelease_20251104_1
    - name: GvsMapUnmappedVIDs
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/variant-annotations-table/GvsMapUnmappedVIDs.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -270,6 +270,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_VS-1747_MadRespectForTheWithdrawnFlag
          tags:
              - /.*/
    - name: GvsWithdrawSamples

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -193,6 +193,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - FoxtrotRelease_20251104_1
          tags:
              - /.*/
    - name: GvsExtractCallsetShard30603

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -193,7 +193,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - FoxtrotRelease_20251104_1
          tags:
              - /.*/
    - name: GvsExtractCallsetShard30603
@@ -270,7 +269,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_VS-1747_MadRespectForTheWithdrawnFlag
          tags:
              - /.*/
    - name: GvsWithdrawSamples
@@ -464,7 +462,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - FoxtrotRelease_20251104_1
    - name: GvsMapUnmappedVIDs
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/variant-annotations-table/GvsMapUnmappedVIDs.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -269,6 +269,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_VS-1747_MadRespectForTheWithdrawnFlag
          tags:
              - /.*/
    - name: GvsWithdrawSamples

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -269,7 +269,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_VS-1747_MadRespectForTheWithdrawnFlag
          tags:
              - /.*/
    - name: GvsWithdrawSamples

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -5,7 +5,7 @@ import "GvsExtractCallset.wdl" as GvsExtractCallset
 import "GvsUtils.wdl" as Utils
 
 # Workflow used by AoU to extract variants for a given cohort of sample_names
-# A
+# B
 
 workflow GvsExtractCohortFromSampleNames {
 
@@ -150,6 +150,7 @@ workflow GvsExtractCohortFromSampleNames {
           sample_names_file = cohort_sample_names_file,
           fq_sample_table = "~{gvs_project}.~{gvs_dataset}.sample_info",
           project_id = query_project,
+          dataset_name = gvs_dataset,
           cloud_sdk_docker = effective_cloud_sdk_docker,
       }
     }

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -4,7 +4,6 @@ import "GvsPrepareRangesCallset.wdl" as GvsPrepareCallset
 import "GvsExtractCallset.wdl" as GvsExtractCallset
 import "GvsUtils.wdl" as Utils
 
-# C
 # Workflow used by AoU to extract variants for a given cohort of sample_names
 
 workflow GvsExtractCohortFromSampleNames {

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -4,7 +4,7 @@ import "GvsPrepareRangesCallset.wdl" as GvsPrepareCallset
 import "GvsExtractCallset.wdl" as GvsExtractCallset
 import "GvsUtils.wdl" as Utils
 
-# B
+# C
 # Workflow used by AoU to extract variants for a given cohort of sample_names
 
 workflow GvsExtractCohortFromSampleNames {

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -5,7 +5,6 @@ import "GvsExtractCallset.wdl" as GvsExtractCallset
 import "GvsUtils.wdl" as Utils
 
 # Workflow used by AoU to extract variants for a given cohort of sample_names
-# H
 
 workflow GvsExtractCohortFromSampleNames {
 

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -5,7 +5,7 @@ import "GvsExtractCallset.wdl" as GvsExtractCallset
 import "GvsUtils.wdl" as Utils
 
 # Workflow used by AoU to extract variants for a given cohort of sample_names
-# D
+# E
 
 workflow GvsExtractCohortFromSampleNames {
 

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -13,6 +13,7 @@ workflow GvsExtractCohortFromSampleNames {
     Array[String]? cohort_sample_names_array
     File? cohort_sample_names
     Boolean is_wgs = true
+    Boolean validate_sample_names_in_sample_info = false
 
     String gvs_project
     String gvs_dataset
@@ -141,8 +142,22 @@ workflow GvsExtractCohortFromSampleNames {
                                                else 7500
 
   if (!DoesTableExist.table_exists) {
+    # Check if all the samples in the file are present in sample_info
+    if (validate_sample_names_in_sample_info) {
+      call Utils.ValidateSampleNamesInSampleInfoTable {
+        input:
+          sample_names_file = cohort_sample_names_file,
+          fq_sample_table = "~{gvs_project}.~{gvs_dataset}.sample_info",
+          project_id = query_project,
+          cloud_sdk_docker = effective_cloud_sdk_docker,
+      }
+    }
+
+    # TODO - Make the below conditional on the above.
+
     call GvsPrepareCallset.GvsPrepareCallset {
       input:
+        go = select_first([ValidateSampleNamesInSampleInfoTable.done, true]),
         call_set_identifier = call_set_identifier,
         extract_table_prefix = effective_cohort_table_prefix,
         sample_names_to_extract = cohort_sample_names_file,

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -154,8 +154,6 @@ workflow GvsExtractCohortFromSampleNames {
       }
     }
 
-    # TODO - Make the below conditional on the above.
-
     call GvsPrepareCallset.GvsPrepareCallset {
       input:
         go = select_first([ValidateSampleNamesInSampleInfoTable.done, true]),

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -5,7 +5,7 @@ import "GvsExtractCallset.wdl" as GvsExtractCallset
 import "GvsUtils.wdl" as Utils
 
 # Workflow used by AoU to extract variants for a given cohort of sample_names
-# G
+# H
 
 workflow GvsExtractCohortFromSampleNames {
 

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -5,7 +5,7 @@ import "GvsExtractCallset.wdl" as GvsExtractCallset
 import "GvsUtils.wdl" as Utils
 
 # Workflow used by AoU to extract variants for a given cohort of sample_names
-# C
+# D
 
 workflow GvsExtractCohortFromSampleNames {
 

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -4,7 +4,7 @@ import "GvsPrepareRangesCallset.wdl" as GvsPrepareCallset
 import "GvsExtractCallset.wdl" as GvsExtractCallset
 import "GvsUtils.wdl" as Utils
 
-# A
+# B
 # Workflow used by AoU to extract variants for a given cohort of sample_names
 
 workflow GvsExtractCohortFromSampleNames {

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -4,6 +4,7 @@ import "GvsPrepareRangesCallset.wdl" as GvsPrepareCallset
 import "GvsExtractCallset.wdl" as GvsExtractCallset
 import "GvsUtils.wdl" as Utils
 
+# A
 # Workflow used by AoU to extract variants for a given cohort of sample_names
 
 workflow GvsExtractCohortFromSampleNames {

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -5,7 +5,7 @@ import "GvsExtractCallset.wdl" as GvsExtractCallset
 import "GvsUtils.wdl" as Utils
 
 # Workflow used by AoU to extract variants for a given cohort of sample_names
-# E
+# F
 
 workflow GvsExtractCohortFromSampleNames {
 

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -142,7 +142,7 @@ workflow GvsExtractCohortFromSampleNames {
                                                else 7500
 
   if (!DoesTableExist.table_exists) {
-    # Check if all the samples in the file are present in sample_info
+    # Check if all the samples in the file are present in sample_info and are not marked as withdrawn.
     if (validate_sample_names_in_sample_info) {
       call Utils.ValidateSampleNamesInSampleInfoTable {
         input:

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -5,6 +5,7 @@ import "GvsExtractCallset.wdl" as GvsExtractCallset
 import "GvsUtils.wdl" as Utils
 
 # Workflow used by AoU to extract variants for a given cohort of sample_names
+# A
 
 workflow GvsExtractCohortFromSampleNames {
 

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -5,7 +5,7 @@ import "GvsExtractCallset.wdl" as GvsExtractCallset
 import "GvsUtils.wdl" as Utils
 
 # Workflow used by AoU to extract variants for a given cohort of sample_names
-# B
+# C
 
 workflow GvsExtractCohortFromSampleNames {
 

--- a/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCohortFromSampleNames.wdl
@@ -5,7 +5,7 @@ import "GvsExtractCallset.wdl" as GvsExtractCallset
 import "GvsUtils.wdl" as Utils
 
 # Workflow used by AoU to extract variants for a given cohort of sample_names
-# F
+# G
 
 workflow GvsExtractCohortFromSampleNames {
 

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -837,22 +837,21 @@ task ValidateSampleNamesInSampleInfoTable {
     echo "project_id = ~{project_id}" > ~/.bigqueryrc
 
     # Create a temporary table with the input sample names
-    TEMP_TABLE="temp_sample_validation_${RANDOM}"
+    CREATE TEMP TABLE sample_validation(sample_name STRING)
 
     # Upload sample names to a temporary BQ table
     bq --apilog=false load --project_id=~{project_id} \
       --autodetect \
       --source_format=CSV \
       --replace \
-      ~{dataset_name}.${TEMP_TABLE} \
-      ~{sample_names_file} \
-      sample_name:STRING
+      sample_validation \
+      ~{sample_names_file}
 
     # Find sample names that are NOT in the fq_sample_table
     # bq query --max_rows check: enlarged max rows in case we get a lot of missing samples
     bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false --max_rows=1000000 "
       SELECT DISTINCT input.sample_name
-      FROM ~{project_id}.~{dataset_name}.${TEMP_TABLE} AS input
+      FROM sample_validation AS input
       LEFT JOIN \`~{fq_sample_table}\` AS samples
       ON input.sample_name = samples.sample_name
       WHERE samples.sample_name IS NULL
@@ -863,7 +862,7 @@ task ValidateSampleNamesInSampleInfoTable {
     # bq query --max_rows check: enlarged max rows in case we get a lot of missing samples
     bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false --max_rows=1000000 "
       SELECT DISTINCT input.sample_name
-      FROM ~{project_id}.~{dataset_name}.${TEMP_TABLE} AS input
+      FROM sample_validation AS input
       JOIN \`~{fq_sample_table}\` AS samples
       ON input.sample_name = samples.sample_name
       WHERE samples.withdrawn IS NOT NULL
@@ -883,14 +882,14 @@ task ValidateSampleNamesInSampleInfoTable {
       echo "ERROR: Sample name validation failed."
 
       # Clean up temp table
-      bq --apilog=false rm -f -t ~{project_id}.~{dataset_name}.${TEMP_TABLE}
+      bq --apilog=false DROP TABLE sample_validation
       exit 1
     fi
 
     echo "All sample names validated successfully"
 
     # Clean up temp table
-    bq --apilog=false rm -f -t ~{project_id}.~{dataset_name}.${TEMP_TABLE}
+    bq --apilog=false DROP TABLE sample_validation
   >>>
 
   output {
@@ -901,7 +900,7 @@ task ValidateSampleNamesInSampleInfoTable {
   runtime {
     docker: cloud_sdk_docker
     memory: "3 GB"
-    disks: "local-disk 10 HDD"
+    disks: "local-disk 500 SSD"
     preemptible: 3
     cpu: 1
   }

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -871,9 +871,7 @@ task ValidateSampleNamesInSampleInfoTable {
       exit 1
     fi
 
-    echo "C"
-
-    # If here, there are no unrecognized sample names - now check if any of the input sample names are listed as withdrawn in the sample table
+    # Now check if any of the input sample names are listed as withdrawn in the sample table
 
     # Find sample names that are NOT in the fq_sample_table
     # bq query --max_rows check: enlarged max rows in case we get a lot of missing samples
@@ -887,10 +885,18 @@ task ValidateSampleNamesInSampleInfoTable {
 
     echo "D"
 
-    # Check if any samples are withdrawn
-    if [ -s withdrawn_samples.txt ]; then
-      echo "ERROR: The following sample names are listed as withdrawn  ~{fq_sample_table}:"
-      cat withdrawn_samples.txt
+    # Check if any samples are missing or are withdrawn
+    if [ -s missing_samples.txt ] || [ -s withdrawn_samples.txt ]; then
+      if [ -s missing_samples.txt ]; then
+        echo "ERROR: The following sample names were not found in ~{fq_sample_table}:"
+        cat missing_samples.txt
+      fi
+      if [ -s withdrawn_samples.txt ]; then
+        echo "ERROR: The following sample names are listed as withdrawn  ~{fq_sample_table}:"
+        cat withdrawn_samples.txt
+      fi
+
+      echo "ERROR: Sample name validation failed."
 
       # Clean up temp table
       bq --apilog=false rm -f -t ~{project_id}.~{dataset_name}.${TEMP_TABLE}

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -867,14 +867,40 @@ task ValidateSampleNamesInSampleInfoTable {
       cat missing_samples.txt
 
       # Clean up temp table
-      bq --apilog=false rm -f -t ${TEMP_TABLE}
+      bq --apilog=false rm -f -t ~{project_id}.~{dataset_name}.${TEMP_TABLE}
+      exit 1
+    fi
+
+    echo "C"
+
+    # If here, there are no unrecognized sample names - now check if any of the input sample names are listed as withdrawn in the sample table
+
+    # Find sample names that are NOT in the fq_sample_table
+    # bq query --max_rows check: enlarged max rows in case we get a lot of missing samples
+    bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false --max_rows=1000000 "
+      SELECT DISTINCT input.sample_name
+      FROM ~{project_id}.~{dataset_name}.${TEMP_TABLE} AS input
+      JOIN \`~{fq_sample_table}\` AS samples
+      ON input.sample_name = samples.sample_name
+      WHERE samples.withdrawn IS NOT NULL
+      " | sed 1d > withdrawn_samples.txt
+
+    echo "D"
+
+    # Check if any samples are withdrawn
+    if [ -s withdrawn_samples.txt ]; then
+      echo "ERROR: The following sample names are listed as withdrawn  ~{fq_sample_table}:"
+      cat withdrawn_samples.txt
+
+      # Clean up temp table
+      bq --apilog=false rm -f -t ~{project_id}.~{dataset_name}.${TEMP_TABLE}
       exit 1
     fi
 
     echo "All sample names validated successfully"
 
     # Clean up temp table
-    bq --apilog=false rm -f -t ${TEMP_TABLE}
+    bq --apilog=false rm -f -t ~{project_id}.~{dataset_name}.${TEMP_TABLE}
   >>>
 
   output {

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -836,8 +836,10 @@ task ValidateSampleNamesInSampleInfoTable {
 
     echo "project_id = ~{project_id}" > ~/.bigqueryrc
 
+    echo "A"
     # Create a temporary table with the input sample names
     CREATE TEMP TABLE sample_validation(sample_name STRING)
+    echo "B"
 
     # Upload sample names to a temporary BQ table
     bq --apilog=false load --project_id=~{project_id} \
@@ -846,6 +848,7 @@ task ValidateSampleNamesInSampleInfoTable {
       --replace \
       sample_validation \
       ~{sample_names_file}
+    echo "C"
 
     # Find sample names that are NOT in the fq_sample_table
     # bq query --max_rows check: enlarged max rows in case we get a lot of missing samples
@@ -857,6 +860,7 @@ task ValidateSampleNamesInSampleInfoTable {
       WHERE samples.sample_name IS NULL
       " | sed 1d > missing_samples.txt
 
+    echo "D"
     # Now check if any of the input sample names are listed as withdrawn in the sample table
 
     # bq query --max_rows check: enlarged max rows in case we get a lot of missing samples
@@ -868,6 +872,7 @@ task ValidateSampleNamesInSampleInfoTable {
       WHERE samples.withdrawn IS NOT NULL
       " | sed 1d > withdrawn_samples.txt
 
+    echo "E"
     # Check if any samples are missing or are withdrawn
     if [ -s missing_samples.txt ] || [ -s withdrawn_samples.txt ]; then
       if [ -s missing_samples.txt ]; then

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -816,6 +816,7 @@ task ValidateSampleNamesInSampleInfoTable {
     File sample_names_file
     String fq_sample_table
     String project_id
+    String dataset_name
     String cloud_sdk_docker
   }
   meta {
@@ -842,14 +843,14 @@ task ValidateSampleNamesInSampleInfoTable {
       --autodetect \
       --source_format=CSV \
       --replace \
-      ${TEMP_TABLE} \
+      \'~{project_id}.~{dataset_name}.${TEMP_TABLE}\' \
       ~{sample_names_file}
 
     # Find sample names that are NOT in the fq_sample_table
     # bq query --max_rows check: enlarged max rows in case we get a lot of missing samples
     bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false --max_rows=1000000 "
       SELECT DISTINCT input.sample_name
-      FROM \`~{project_id}.${TEMP_TABLE}\` AS input
+      FROM \'~{project_id}.~{dataset_name}.${TEMP_TABLE}\' AS input
       LEFT JOIN \`~{fq_sample_table}\` AS samples
       ON input.sample_name = samples.sample_name
       WHERE samples.sample_name IS NULL

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -860,7 +860,6 @@ task ValidateSampleNamesInSampleInfoTable {
 
     # Now check if any of the input sample names are listed as withdrawn in the sample table
 
-    # Find sample names that are NOT in the fq_sample_table
     # bq query --max_rows check: enlarged max rows in case we get a lot of missing samples
     bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false --max_rows=1000000 "
       SELECT DISTINCT input.sample_name

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -843,7 +843,7 @@ task ValidateSampleNamesInSampleInfoTable {
       --autodetect \
       --source_format=CSV \
       --replace \
-      \'~{project_id}.~{dataset_name}.${TEMP_TABLE}\' \
+      ~{dataset_name}.${TEMP_TABLE} \
       ~{sample_names_file}
 
     # Find sample names that are NOT in the fq_sample_table

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -844,17 +844,22 @@ task ValidateSampleNamesInSampleInfoTable {
       --source_format=CSV \
       --replace \
       ~{dataset_name}.${TEMP_TABLE} \
-      ~{sample_names_file}
+      ~{sample_names_file} \
+      sample_name:STRING
+
+    echo "A"
 
     # Find sample names that are NOT in the fq_sample_table
     # bq query --max_rows check: enlarged max rows in case we get a lot of missing samples
     bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false --max_rows=1000000 "
       SELECT DISTINCT input.sample_name
-      FROM \'~{project_id}.~{dataset_name}.${TEMP_TABLE}\' AS input
+      FROM ~{project_id}.~{dataset_name}.${TEMP_TABLE} AS input
       LEFT JOIN \`~{fq_sample_table}\` AS samples
       ON input.sample_name = samples.sample_name
       WHERE samples.sample_name IS NULL
       " | sed 1d > missing_samples.txt
+
+    echo "B"
 
     # Check if any samples are missing
     if [ -s missing_samples.txt ]; then

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -836,11 +836,8 @@ task ValidateSampleNamesInSampleInfoTable {
 
     echo "project_id = ~{project_id}" > ~/.bigqueryrc
 
-    echo "A"
     # Name a temporary table with the input sample names
     TEMP_TABLE="temp_sample_validation_${RANDOM}"
-
-    echo "B"
 
     # Upload sample names to a temporary BQ table
     bq --apilog=false load --project_id=~{project_id} \
@@ -850,12 +847,9 @@ task ValidateSampleNamesInSampleInfoTable {
       ~{dataset_name}.${TEMP_TABLE} \
       ~{sample_names_file} \
       sample_name:STRING
-    echo "C"
 
     # Set expiration on temp table to 1 hour
     bq --apilog=false update --expiration 3600 ~{project_id}:~{dataset_name}.${TEMP_TABLE}
-
-    echo "D"
 
     # Find sample names that are NOT in the fq_sample_table
     # bq query --max_rows check: enlarged max rows in case we get a lot of missing samples
@@ -867,7 +861,6 @@ task ValidateSampleNamesInSampleInfoTable {
       WHERE samples.sample_name IS NULL
       " | sed 1d > missing_samples.txt
 
-    echo "E"
     # Now check if any of the input sample names are listed as withdrawn in the sample table
 
     # bq query --max_rows check: enlarged max rows in case we get a lot of missing samples
@@ -879,7 +872,6 @@ task ValidateSampleNamesInSampleInfoTable {
       WHERE samples.withdrawn IS NOT NULL
       " | sed 1d > withdrawn_samples.txt
 
-    echo "F"
     # Check if any samples are missing or are withdrawn
     if [ -s missing_samples.txt ] || [ -s withdrawn_samples.txt ]; then
       if [ -s missing_samples.txt ]; then

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -861,16 +861,6 @@ task ValidateSampleNamesInSampleInfoTable {
 
     echo "B"
 
-    # Check if any samples are missing
-    if [ -s missing_samples.txt ]; then
-      echo "ERROR: The following sample names were not found in ~{fq_sample_table}:"
-      cat missing_samples.txt
-
-      # Clean up temp table
-      bq --apilog=false rm -f -t ~{project_id}.~{dataset_name}.${TEMP_TABLE}
-      exit 1
-    fi
-
     # Now check if any of the input sample names are listed as withdrawn in the sample table
 
     # Find sample names that are NOT in the fq_sample_table

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -837,8 +837,9 @@ task ValidateSampleNamesInSampleInfoTable {
     echo "project_id = ~{project_id}" > ~/.bigqueryrc
 
     echo "A"
-    # Create a temporary table with the input sample names
-    CREATE TEMP TABLE sample_validation(sample_name STRING)
+    # Name a temporary table with the input sample names
+    TEMP_TABLE="temp_sample_validation_${RANDOM}"
+
     echo "B"
 
     # Upload sample names to a temporary BQ table
@@ -846,33 +847,39 @@ task ValidateSampleNamesInSampleInfoTable {
       --autodetect \
       --source_format=CSV \
       --replace \
-      sample_validation \
-      ~{sample_names_file}
+      ~{dataset_name}.${TEMP_TABLE} \
+      ~{sample_names_file} \
+      sample_name:STRING
     echo "C"
+
+    # Set expiration on temp table to 1 hour
+    bq --apilog=false update --expiration 3600 ~{project_id}:~{dataset_name}.${TEMP_TABLE}
+
+    echo "D"
 
     # Find sample names that are NOT in the fq_sample_table
     # bq query --max_rows check: enlarged max rows in case we get a lot of missing samples
     bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false --max_rows=1000000 "
       SELECT DISTINCT input.sample_name
-      FROM sample_validation AS input
+      FROM ~{project_id}.~{dataset_name}.${TEMP_TABLE} AS input
       LEFT JOIN \`~{fq_sample_table}\` AS samples
       ON input.sample_name = samples.sample_name
       WHERE samples.sample_name IS NULL
       " | sed 1d > missing_samples.txt
 
-    echo "D"
+    echo "E"
     # Now check if any of the input sample names are listed as withdrawn in the sample table
 
     # bq query --max_rows check: enlarged max rows in case we get a lot of missing samples
     bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false --max_rows=1000000 "
       SELECT DISTINCT input.sample_name
-      FROM sample_validation AS input
+      FROM ~{project_id}.~{dataset_name}.${TEMP_TABLE} AS input
       JOIN \`~{fq_sample_table}\` AS samples
       ON input.sample_name = samples.sample_name
       WHERE samples.withdrawn IS NOT NULL
       " | sed 1d > withdrawn_samples.txt
 
-    echo "E"
+    echo "F"
     # Check if any samples are missing or are withdrawn
     if [ -s missing_samples.txt ] || [ -s withdrawn_samples.txt ]; then
       if [ -s missing_samples.txt ]; then
@@ -885,16 +892,10 @@ task ValidateSampleNamesInSampleInfoTable {
       fi
 
       echo "ERROR: Sample name validation failed."
-
-      # Clean up temp table
-      bq --apilog=false DROP TABLE sample_validation
       exit 1
     fi
 
     echo "All sample names validated successfully"
-
-    # Clean up temp table
-    bq --apilog=false DROP TABLE sample_validation
   >>>
 
   output {

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -811,6 +811,79 @@ task GetNumSamplesLoaded {
   }
 }
 
+task ValidateSampleNamesInSampleInfoTable {
+  input {
+    File sample_names_file
+    String fq_sample_table
+    String project_id
+    String cloud_sdk_docker
+  }
+  meta {
+    description: "Validates that all sample names in the input file exist in the fq_sample_table"
+    # Not `volatile: true` since there shouldn't be a need to re-run this if there has already been a successful execution.
+  }
+
+  File monitoring_script = "gs://gvs_quickstart_storage/cromwell_monitoring_script.sh"
+
+  command <<<
+    # Prepend date, time and pwd to xtrace log entries.
+    PS4='\D{+%F %T} \w $ '
+    set -o errexit -o nounset -o pipefail -o xtrace
+
+    bash ~{monitoring_script} > monitoring.log &
+
+    echo "project_id = ~{project_id}" > ~/.bigqueryrc
+
+    # Create a temporary table with the input sample names
+    TEMP_TABLE="temp_sample_validation_${RANDOM}"
+
+    # Upload sample names to a temporary BQ table
+    bq --apilog=false load --project_id=~{project_id} \
+      --autodetect \
+      --source_format=CSV \
+      --replace \
+      ${TEMP_TABLE} \
+      ~{sample_names_file}
+
+    # Find sample names that are NOT in the fq_sample_table
+    # bq query --max_rows check: enlarged max rows in case we get a lot of missing samples
+    bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false --max_rows=1000000 "
+      SELECT DISTINCT input.sample_name
+      FROM \`~{project_id}.${TEMP_TABLE}\` AS input
+      LEFT JOIN \`~{fq_sample_table}\` AS samples
+      ON input.sample_name = samples.sample_name
+      WHERE samples.sample_name IS NULL
+      " | sed 1d > missing_samples.txt
+
+    # Check if any samples are missing
+    if [ -s missing_samples.txt ]; then
+      echo "ERROR: The following sample names were not found in ~{fq_sample_table}:"
+      cat missing_samples.txt
+
+      # Clean up temp table
+      bq --apilog=false rm -f -t ${TEMP_TABLE}
+      exit 1
+    fi
+
+    echo "All sample names validated successfully"
+
+    # Clean up temp table
+    bq --apilog=false rm -f -t ${TEMP_TABLE}
+  >>>
+
+  output {
+    Boolean done = true
+    File monitoring_log = "monitoring.log"
+  }
+
+  runtime {
+    docker: cloud_sdk_docker
+    memory: "3 GB"
+    disks: "local-disk 10 HDD"
+    preemptible: 3
+    cpu: 1
+  }
+}
 
 task CountSuperpartitions {
     meta {

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -820,8 +820,9 @@ task ValidateSampleNamesInSampleInfoTable {
     String cloud_sdk_docker
   }
   meta {
-    description: "Validates that all sample names in the input file exist in the fq_sample_table"
-    # Not `volatile: true` since there shouldn't be a need to re-run this if there has already been a successful execution.
+    # because this is being used to determine if the data has changed, never use call cache
+    volatile: true
+    description: "Validates that all sample names in the input file exist in the fq_sample_table and are not withdrawn."
   }
 
   File monitoring_script = "gs://gvs_quickstart_storage/cromwell_monitoring_script.sh"
@@ -847,8 +848,6 @@ task ValidateSampleNamesInSampleInfoTable {
       ~{sample_names_file} \
       sample_name:STRING
 
-    echo "A"
-
     # Find sample names that are NOT in the fq_sample_table
     # bq query --max_rows check: enlarged max rows in case we get a lot of missing samples
     bq --apilog=false query --project_id=~{project_id} --format=csv --use_legacy_sql=false --max_rows=1000000 "
@@ -858,8 +857,6 @@ task ValidateSampleNamesInSampleInfoTable {
       ON input.sample_name = samples.sample_name
       WHERE samples.sample_name IS NULL
       " | sed 1d > missing_samples.txt
-
-    echo "B"
 
     # Now check if any of the input sample names are listed as withdrawn in the sample table
 
@@ -873,8 +870,6 @@ task ValidateSampleNamesInSampleInfoTable {
       WHERE samples.withdrawn IS NOT NULL
       " | sed 1d > withdrawn_samples.txt
 
-    echo "D"
-
     # Check if any samples are missing or are withdrawn
     if [ -s missing_samples.txt ] || [ -s withdrawn_samples.txt ]; then
       if [ -s missing_samples.txt ]; then
@@ -882,7 +877,7 @@ task ValidateSampleNamesInSampleInfoTable {
         cat missing_samples.txt
       fi
       if [ -s withdrawn_samples.txt ]; then
-        echo "ERROR: The following sample names are listed as withdrawn  ~{fq_sample_table}:"
+        echo "ERROR: The following sample names are listed as withdrawn in ~{fq_sample_table}:"
         cat withdrawn_samples.txt
       fi
 


### PR DESCRIPTION
VS-1747 Have GvsExtractCohortFromSampleNames optionally fail if any of the samples are either NOT in the sample_info table or have been withdrawn.

[Here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/submission_history/991fefe1-d479-4713-82b6-d89372079ef9) is a passing run
[Here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/submission_history/059b9d77-854d-4eef-8c1b-4678dc1e2ace) is a failure where one of the samples is withdrawn
[Here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/submission_history/d531ee44-9961-43eb-974f-2347a7f98b77) is a failure where one of the samples is withdrawn AND one is not in sample_info
[Here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/submission_history/fab52269-4ada-43ff-a71c-6bcaf80bd53d) is a passing run where we didn't run the validation (default behavior)