### PR TITLE
Silence CodeQL JavaScript / TypeScript errors [VS-1777]

### DIFF
--- a/src/main/resources/placate_codeql.js
+++ b/src/main/resources/placate_codeql.js
@@ -1,0 +1,9 @@
+const hush = `
+
+This file exists solely to prevent CodeQL from failing its "Analyze (javascript-typescript)" action with:
+
+CodeQL detected code written in Java/Kotlin, Python and GitHub Actions, but not any written in JavaScript/TypeScript. Confirm that there is some source code for JavaScript/TypeScript in the project.
+
+Because apart from the contents of this file, there is currently no JavaScript or TypeScript in the GATK repo.
+
+`;

--- a/src/main/resources/placate_codeql.js
+++ b/src/main/resources/placate_codeql.js
@@ -1,4 +1,4 @@
-const hush = `
+`
 
 This file exists solely to prevent CodeQL from failing its "Analyze (javascript-typescript)" action with:
 


### PR DESCRIPTION
As [currently configured in the GATK repo](https://broadinstitute.slack.com/archives/C4P1S6KB8/p1719248901162939), CodeQL runs a JavaScript / TypeScript checker action on all PRs. This checker seems to assume that there should always be some JavaScript / TypeScript code to check, and that the absence of any code to check is an error. As of now there is currently no "real" JavaScript or TypeScript code to check, so this checker action always fails ([example PR](https://github.com/broadinstitute/gatk/pull/9303) with the same content as current `master`). 

This PR adds a dummy JavaScript file to placate the CodeQL checker.