### PR TITLE
VS-1772 Allow additional padding of intervals for GvsPrepareRangesCallset.

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -232,6 +232,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_VS-1772_PadPrepareIntervals
          tags:
              - /.*/
    - name: GvsCreateVATfromVDS

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -346,6 +346,7 @@ workflows:
              - master
              - ah_var_store
              - vs_1777_build_failure
+             - gg_VS-1772_PadPrepareIntervals
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -193,7 +193,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_VS-1772_PadPrepareIntervals
          tags:
              - /.*/
    - name: GvsExtractCallsetShard30603
@@ -232,7 +231,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - gg_VS-1772_PadPrepareIntervals
          tags:
              - /.*/
    - name: GvsCreateVATfromVDS
@@ -346,7 +344,6 @@ workflows:
              - master
              - ah_var_store
              - vs_1777_build_failure
-             - gg_VS-1772_PadPrepareIntervals
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -193,6 +193,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - gg_VS-1772_PadPrepareIntervals
          tags:
              - /.*/
    - name: GvsExtractCallsetShard30603

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-
+# A
 workflow GvsExtractCallset {
   input {
     Boolean go = true
@@ -146,9 +146,7 @@ workflow GvsExtractCallset {
                                           else if GetNumSamplesLoaded.num_samples < 50000 then 2500
                                                else 7500
 
-  Int effective_split_intervals_disk_size_override = select_first([split_intervals_disk_size_override,
-                                                                  if GetNumSamplesLoaded.num_samples < 100 then 50 # Quickstart
-                                                                  else 500])
+  Int effective_split_intervals_disk_size_override = select_first([split_intervals_disk_size_override, 500])
 
   Int effective_extract_memory_gib = if defined(extract_memory_override_gib) then select_first([extract_memory_override_gib])
                                      else if effective_scatter_count <= 100 then 37 + extract_overhead_memory_override_gib

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# A
+
 workflow GvsExtractCallset {
   input {
     Boolean go = true
@@ -146,8 +146,6 @@ workflow GvsExtractCallset {
                                           else if GetNumSamplesLoaded.num_samples < 50000 then 2500
                                                else 7500
 
-  Int effective_split_intervals_disk_size_override = select_first([split_intervals_disk_size_override, 500])
-
   Int effective_extract_memory_gib = if defined(extract_memory_override_gib) then select_first([extract_memory_override_gib])
                                      else if effective_scatter_count <= 100 then 37 + extract_overhead_memory_override_gib
                                           else if effective_scatter_count <= 500 then 17 + extract_overhead_memory_override_gib
@@ -166,7 +164,7 @@ workflow GvsExtractCallset {
       intervals_file_extension = intervals_file_extension,
       scatter_count = effective_scatter_count,
       output_gcs_dir = output_gcs_dir,
-      split_intervals_disk_size_override = effective_split_intervals_disk_size_override,
+      split_intervals_disk_size_override = split_intervals_disk_size_override,
       split_intervals_mem_override = split_intervals_mem_override,
       gatk_docker = effective_gatk_docker,
       gatk_override = gatk_override,

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-
+# A
 workflow GvsPrepareCallset {
   input {
     Boolean go = true
@@ -31,7 +31,7 @@ workflow GvsPrepareCallset {
     String? git_branch_or_tag
     String? git_hash
     File? interval_list
-    Int? interval_list_padding
+    Int interval_list_padding = 1000
   }
 
   String full_extract_prefix = if (control_samples) then "~{extract_table_prefix}_controls" else extract_table_prefix
@@ -52,10 +52,10 @@ workflow GvsPrepareCallset {
   String effective_cloud_sdk_docker = select_first([cloud_sdk_docker, GetToolVersions.cloud_sdk_docker])
   String effective_git_hash = select_first([git_hash, GetToolVersions.git_hash])
 
-  if (!defined(interval_list) && defined(interval_list_padding)) {
-    call Utils.TerminateWorkflow as IntervalListPaddingWithoutIntervalList {
+  if (interval_list_padding < 0) {
+    call Utils.TerminateWorkflow as NoNegativeIntervalListPaddingAllowed {
       input:
-        message = "Cannot define `interval_list_padding` without defining `interval_list`, exiting!",
+        message = "`interval_list_padding`must be >= 0, exiting!",
         basic_docker = effective_basic_docker,
     }
   }
@@ -85,17 +85,17 @@ workflow GvsPrepareCallset {
       cloud_sdk_docker = effective_cloud_sdk_docker,
   }
 
-  if (defined(interval_list) && defined(interval_list_padding)) {
+  if (defined(interval_list) && interval_list_padding > 0) {
     call Utils.PadIntervalList {
       input:
         interval_list_file = select_first([interval_list]),
-        padding_size = select_first([interval_list_padding]),
+        padding_size = interval_list_padding,
         output_basename = "padded_intervals",
         gatk_docker = effective_gatk_docker,
     }
   }
 
-  File? effective_interval_list = if (defined(interval_list) && defined(interval_list_padding)) then PadIntervalList.padded_interval_list_file else interval_list
+  File? effective_interval_list = if (defined(interval_list) && interval_list_padding > 0) then PadIntervalList.padded_interval_list_file else interval_list
 
   call PrepareRangesCallsetTask {
     input:

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# C
+# D
 workflow GvsPrepareCallset {
   input {
     Boolean go = true
@@ -95,6 +95,8 @@ workflow GvsPrepareCallset {
     }
   }
 
+  File? effective_interval_list = if (defined(interval_list) && defined(interval_list_padding)) then PadIntervalList.padded_interval_list_file else interval_list
+
   call PrepareRangesCallsetTask {
     input:
       call_set_identifier             = call_set_identifier,
@@ -114,7 +116,7 @@ workflow GvsPrepareCallset {
       use_compressed_references       = IsUsingCompressedReferences.is_using_compressed_references,
       vet_extract_table_version       = GetExtractVetTableVersion.version,
       enable_extract_table_ttl        = enable_extract_table_ttl,
-      interval_list                   = select_first([PadIntervalList.padded_interval_list_file, interval_list]),
+      interval_list                   = effective_interval_list,
   }
 
   output {

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# A
+# B
 workflow GvsPrepareCallset {
   input {
     Boolean go = true
@@ -55,7 +55,7 @@ workflow GvsPrepareCallset {
   if (!defined(interval_list) && defined(interval_list_padding)) {
     call Utils.TerminateWorkflow as IntervalListPaddingWithoutIntervalList {
       input:
-        message = "Cannot define `interval_list_padding` without defining `interval_list`, exiting.",
+        message = "Cannot define `interval_list_padding` without defining `interval_list`, exiting!",
         basic_docker = effective_basic_docker,
     }
   }

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# A
+
 workflow GvsPrepareCallset {
   input {
     Boolean go = true
@@ -55,7 +55,7 @@ workflow GvsPrepareCallset {
   if (interval_list_padding < 0) {
     call Utils.TerminateWorkflow as NoNegativeIntervalListPaddingAllowed {
       input:
-        message = "`interval_list_padding`must be >= 0, exiting!",
+        message = "`interval_list_padding` must be >= 0, exiting!",
         basic_docker = effective_basic_docker,
     }
   }

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# D
+
 workflow GvsPrepareCallset {
   input {
     Boolean go = true

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-# B
+# C
 workflow GvsPrepareCallset {
   input {
     Boolean go = true

--- a/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
+++ b/scripts/variantstore/wdl/GvsPrepareRangesCallset.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "GvsUtils.wdl" as Utils
-
+# A
 workflow GvsPrepareCallset {
   input {
     Boolean go = true
@@ -24,11 +24,14 @@ workflow GvsPrepareCallset {
     File? sample_names_to_extract
     Boolean only_output_vet_tables = false
     Boolean write_cost_to_db = true
+    String? basic_docker
+    String? gatk_docker
     String? cloud_sdk_docker
     String? variants_docker
     String? git_branch_or_tag
     String? git_hash
     File? interval_list
+    Int? interval_list_padding
   }
 
   String full_extract_prefix = if (control_samples) then "~{extract_table_prefix}_controls" else extract_table_prefix
@@ -36,16 +39,26 @@ workflow GvsPrepareCallset {
   String fq_sample_mapping_table = "~{project_id}.~{dataset_name}.sample_info"
   String fq_destination_dataset = "~{destination_project}.~{destination_dataset}"
 
-  if (!defined(git_hash) || !defined(variants_docker) || !defined(cloud_sdk_docker)) {
+  if (!defined(git_hash) || !defined(variants_docker) || !defined(basic_docker) || !defined(gatk_docker) || !defined(cloud_sdk_docker)) {
     call Utils.GetToolVersions {
       input:
         git_branch_or_tag = git_branch_or_tag,
     }
   }
 
+  String effective_basic_docker = select_first([basic_docker, GetToolVersions.basic_docker])
+  String effective_gatk_docker = select_first([gatk_docker, GetToolVersions.gatk_docker])
   String effective_variants_docker = select_first([variants_docker, GetToolVersions.variants_docker])
   String effective_cloud_sdk_docker = select_first([cloud_sdk_docker, GetToolVersions.cloud_sdk_docker])
   String effective_git_hash = select_first([git_hash, GetToolVersions.git_hash])
+
+  if (!defined(interval_list) && defined(interval_list_padding)) {
+    call Utils.TerminateWorkflow as IntervalListPaddingWithoutIntervalList {
+      input:
+        message = "Cannot define `interval_list_padding` without defining `interval_list`, exiting.",
+        basic_docker = effective_basic_docker,
+    }
+  }
 
   call Utils.GetBQTableLastModifiedDatetime as RefTableDatetimeCheck {
     input:
@@ -72,6 +85,16 @@ workflow GvsPrepareCallset {
       cloud_sdk_docker = effective_cloud_sdk_docker,
   }
 
+  if (defined(interval_list) && defined(interval_list_padding)) {
+    call Utils.PadIntervalList {
+      input:
+        interval_list_file = select_first([interval_list]),
+        padding_size = select_first([interval_list_padding]),
+        output_basename = "padded_intervals",
+        gatk_docker = effective_gatk_docker,
+    }
+  }
+
   call PrepareRangesCallsetTask {
     input:
       call_set_identifier             = call_set_identifier,
@@ -91,7 +114,7 @@ workflow GvsPrepareCallset {
       use_compressed_references       = IsUsingCompressedReferences.is_using_compressed_references,
       vet_extract_table_version       = GetExtractVetTableVersion.version,
       enable_extract_table_ttl        = enable_extract_table_ttl,
-      interval_list                   = interval_list,
+      interval_list                   = select_first([PadIntervalList.padded_interval_list_file, interval_list]),
   }
 
   output {

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -225,7 +225,7 @@ task SplitIntervals {
     # Not `volatile: true` since there shouldn't be a need to re-run this if there has already been a successful execution.
   }
 
-  Int disk_size = select_first([split_intervals_disk_size_override, 50]) # Note: disk size is cheap and lack of it can increase probability of preemption
+  Int disk_size = select_first([split_intervals_disk_size_override, 500]) # Note: disk size is cheap and lack of it can increase probability of preemption
   Int memory_size = select_first([split_intervals_mem_override, 16])
   Int java_memory = memory_size - 4
 
@@ -304,7 +304,7 @@ task SplitIntervalsTarred {
     # Not `volatile: true` since there shouldn't be a need to re-run this if there has already been a successful execution.
   }
 
-  Int disk_size = select_first([split_intervals_disk_size_override, 10])
+  Int disk_size = select_first([split_intervals_disk_size_override, 500])
   Int memory_size = select_first([split_intervals_mem_override, 16])
   Int java_memory = memory_size - 4
 

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -1361,6 +1361,73 @@ task SelectVariants {
     }
 }
 
+task PadIntervalList {
+  input {
+    File interval_list_file
+    Int padding_size
+    String output_basename
+
+    Int memory_gib = 3
+    Int overhead_memory_gib = 1
+    Int disk_size_gb = ceil(2 * size(interval_list_file, "GiB")) + 200
+    String gatk_docker
+  }
+
+  parameter_meta {
+    interval_list: {
+       localization_optional: true
+     }
+  }
+  File monitoring_script = "gs://gvs_quickstart_storage/cromwell_monitoring_script.sh"
+
+  String padded_interval_list_filename = output_basename + ".interval_list"
+
+  command <<<
+    # Prepend date, time and pwd to xtrace log entries.
+    PS4='\D{+%F %T} \w $ '
+    set -o errexit -o nounset -o pipefail -o xtrace
+
+    bash ~{monitoring_script} > monitoring.log &
+
+
+    # This tool may get invoked with "Retry with more memory" with a different amount of memory than specified in
+    # the input `memory_gib`. If so, use the memory-related environment variables rather than the `memory_gib` input.
+    # But also be prepared if those memory-related variables are not set and fall back to using `memory_gib`.
+    # https://support.terra.bio/hc/en-us/articles/4403215299355-Out-of-Memory-Retry
+    if [[ -z "${MEM_UNIT:-}" ]]
+    then
+      memory_mb=$(python3 -c "from math import floor; print(floor((~{memory_gib} - ~{overhead_memory_gib}) * 1000))")
+    elif [[ ${MEM_UNIT} == "GB" ]]
+    then
+      memory_mb=$(python3 -c "from math import floor; print(floor((${MEM_SIZE} - ~{overhead_memory_gib}) * 1000))")
+    else
+      echo "Unexpected memory unit: ${MEM_UNIT}" 1>&2
+      exit 1
+    fi
+
+    gatk --java-options "-Xmx${memory_mb}m" \
+      IntervalListTools \
+        --INPUT ~{interval_list_file} \
+        --PADDING ~{padding_size} \
+        --OUTPUT ~{padded_interval_list_filename}
+  >>>
+
+  runtime {
+    docker: gatk_docker
+    cpu: 1
+    memory: "${memory_gib} GiB"
+    disks: "local-disk ${disk_size_gb} HDD"
+    bootDiskSizeGb: 15
+    preemptible: 3
+    noAddress: true
+  }
+
+  output {
+    File padded_interval_list_file = padded_interval_list_filename
+    File monitoring_log = "monitoring.log"
+  }
+}
+
 task MergeJSONs {
     input {
         Array[File] input_files
@@ -1434,7 +1501,7 @@ task SummarizeTaskMonitorLogs {
         Array[File] inputs
         String variants_docker
         File log_fofn = write_lines(inputs)
-        }
+    }
     parameter_meta {
         inputs: {
             localization_optional: true

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -1373,11 +1373,6 @@ task PadIntervalList {
     String gatk_docker
   }
 
-  parameter_meta {
-    interval_list: {
-       localization_optional: true
-     }
-  }
   File monitoring_script = "gs://gvs_quickstart_storage/cromwell_monitoring_script.sh"
 
   String padded_interval_list_filename = output_basename + ".interval_list"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -1404,7 +1404,8 @@ task PadIntervalList {
       IntervalListTools \
         --INPUT ~{interval_list_file} \
         --PADDING ~{padding_size} \
-        --OUTPUT ~{padded_interval_list_filename}
+        --OUTPUT ~{padded_interval_list_filename} \
+        --UNIQUE true
   >>>
 
   runtime {

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -1367,13 +1367,15 @@ task PadIntervalList {
     Int padding_size
     String output_basename
 
-    Int memory_gib = 3
-    Int overhead_memory_gib = 1
+    Int memory_mb = 3000
     Int disk_size_gb = ceil(2 * size(interval_list_file, "GiB")) + 200
     String gatk_docker
   }
 
   File monitoring_script = "gs://gvs_quickstart_storage/cromwell_monitoring_script.sh"
+
+  Int command_mem = memory_mb - 1000
+  Int max_heap = memory_mb - 500
 
   String padded_interval_list_filename = output_basename + ".interval_list"
 
@@ -1384,23 +1386,7 @@ task PadIntervalList {
 
     bash ~{monitoring_script} > monitoring.log &
 
-
-    # This tool may get invoked with "Retry with more memory" with a different amount of memory than specified in
-    # the input `memory_gib`. If so, use the memory-related environment variables rather than the `memory_gib` input.
-    # But also be prepared if those memory-related variables are not set and fall back to using `memory_gib`.
-    # https://support.terra.bio/hc/en-us/articles/4403215299355-Out-of-Memory-Retry
-    if [[ -z "${MEM_UNIT:-}" ]]
-    then
-      memory_mb=$(python3 -c "from math import floor; print(floor((~{memory_gib} - ~{overhead_memory_gib}) * 1000))")
-    elif [[ ${MEM_UNIT} == "GB" ]]
-    then
-      memory_mb=$(python3 -c "from math import floor; print(floor((${MEM_SIZE} - ~{overhead_memory_gib}) * 1000))")
-    else
-      echo "Unexpected memory unit: ${MEM_UNIT}" 1>&2
-      exit 1
-    fi
-
-    gatk --java-options "-Xmx${memory_mb}m" \
+    gatk --java-options "-Xms~{command_mem}m -Xmx~{max_heap}m" \
       IntervalListTools \
         --INPUT ~{interval_list_file} \
         --PADDING ~{padding_size} \
@@ -1411,7 +1397,7 @@ task PadIntervalList {
   runtime {
     docker: gatk_docker
     cpu: 1
-    memory: "${memory_gib} GiB"
+    memory: "${memory_mb} MiB"
     disks: "local-disk ${disk_size_gb} HDD"
     bootDiskSizeGb: 15
     preemptible: 3


### PR DESCRIPTION
VS-1772. This PR modifies GvsPrepareRangesCallset to allow for an optional interval padding that will (if defined) be used to pad an (also optional) interval list. This allows the prepared tables to cover a wider range than the potentially very narrow interval list and extract relevant data (e.g. wide indels).

Test run with no (thus default) padding specified [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/submission_history/ac9d4614-8972-4c60-8cda-cce073cc062c)
Passing Integration test [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/submission_history/4070d18c-e8bd-4d78-8b5b-b8886c9e1c3a)