### PR TITLE
Use ID file for Variants Docker building [VS-1788]

### DIFF
--- a/scripts/variantstore/scripts/build_docker.sh
+++ b/scripts/variantstore/scripts/build_docker.sh
@@ -31,8 +31,13 @@ fi
 docker buildx use singlebuilder
 echo "Using the single platform builder"
 
-docker buildx build --platform linux/amd64 --load .
-IMAGE_ID=$(docker image ls -q | head -n 1)
+# Build and write the full image id to an id file.
+docker buildx build --platform linux/amd64 --load . --iidfile idfile.txt
+
+# Scrape out the first 12 hex digits of the SHA256 hash to use for the tag.
+IMAGE_ID=$(cut -d : -f 2 idfile.txt | cut -c 1-12)
+
+rm idfile.txt
 
 # The Variants Docker image is alpine-based.
 IMAGE_TYPE="alpine"


### PR DESCRIPTION
The newest version of Docker seems to have changed the way images are displayed by `docker image ls` in a way that breaks `scripts/variantstore/scripts/build_docker.sh`.  This PR works around the problem by having the image id explicitly written to an id file rather than making assumptions about the display output of `docker image ls`.

