### PR TITLE
Pin gcnvkernel dependency for Python 3.10, other build fixes [VS-1789]

### DIFF
--- a/.github/workflows/gatk-tests.yml
+++ b/.github/workflows/gatk-tests.yml
@@ -104,7 +104,7 @@ jobs:
       #Google Cloud stuff
       - id: 'gcloud-auth'
         if: needs.check-secrets.outputs.google-credentials == 'true'
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
           project_id: ${{ env.HELLBENDER_TEST_PROJECT }}
@@ -175,7 +175,7 @@ jobs:
 
       #Google Cloud stuff
       - id: 'gcloud-auth'
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v3
         if: needs.check-secrets.outputs.google-credentials == 'true'
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}

--- a/scripts/gatkcondaenv.yml.template
+++ b/scripts/gatkcondaenv.yml.template
@@ -17,6 +17,7 @@ channels:
 # if channels other than conda-forge are added and the channel order is changed (note that conda channel_priority is currently set to flexible),
 # verify that key dependencies are installed from the correct channel
 - conda-forge
+- bioconda
 
 dependencies:
 
@@ -26,6 +27,7 @@ dependencies:
 - conda-forge:blas=1.0=mkl            # our official environment uses MKL versions of various packages; if other versions are desired, users should edit this YML accordingly
 - conda-forge::numpy=1.26.2
 - conda-forge::pymc=5.10.1
+- conda-forge:fastprogress=1.0.3
 - conda-forge::pytensor=2.18.3
 - conda-forge::scipy=1.11.4
 - conda-forge::h5py=3.10.0


### PR DESCRIPTION
GATK tests involving `gcnvkernel` are currently broken due to an unpinned transitive dependency that has floated to a version incompatible with Python 3.10 (the version of Python used in the GATK Docker image). Example broken build of current `master` [here](https://github.com/broadinstitute/gatk/pull/9314).

Changes in this PR:

1. Pin `fastprogress` (a transitive dependency of `gcnvkernel`) to a version that's compatible with Python 3.10.
2. Upgrade `google-github-actions/auth` from the now-unsupported `v0` to `v3`.
3. "Declare" the `bioconda` channel before referencing it.


