### PR TITLE
Refresh GATK docker after build updates [VS-1789]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -346,16 +346,6 @@ workflows:
              - vs_1777_build_failure
          tags:
              - /.*/
-   - name: GvsQuickstartIntegrationEverything
-     subclass: WDL
-     primaryDescriptorPath: /scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
-     filters:
-       branches:
-         - master
-         - ah_var_store
-         - vs_1789_refresh_gatk_docker
-       tags:
-         - /.*/
    - name: GvsIngestTieout
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/test/GvsIngestTieout.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -346,6 +346,16 @@ workflows:
              - vs_1777_build_failure
          tags:
              - /.*/
+   - name: GvsQuickstartIntegrationEverything
+     subclass: WDL
+     primaryDescriptorPath: /scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
+     filters:
+       branches:
+         - master
+         - ah_var_store
+         - vs_1789_refresh_gatk_docker
+       tags:
+         - /.*/
    - name: GvsIngestTieout
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/test/GvsIngestTieout.wdl

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -133,7 +133,7 @@ task GetToolVersions {
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
     String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2025-12-09-alpine-11ede1e609a0"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
-    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2025-12-09-gatkbase-cda718c731d5"
+    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-02-02-gatkbase-82a70f3846da"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"
     String gotc_imputation_docker = "us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.5-1.10.2-0.1.16-1649948623"
     String plink_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/plink2:2024-04-23-slim-a0a65f52cc0e"


### PR DESCRIPTION
Build an up-to-date Variants GATK Docker image after the recent updates to the build. Integration run [here](https://job-manager.dsde-prod.broadinstitute.org/jobs/bea941ee-927e-4e6d-8f96-9c796af41bf5).