### PR TITLE
VS-1810 add sample id to parquet tracking table

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -222,6 +222,7 @@ workflows:
              - master
              - ah_var_store
              - VS-1736
+             - vs_1810_add_sample_id_to_parquet_tracking
          tags:
              - /.*/
    - name: GvsPrepareRangesCallset

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -222,7 +222,6 @@ workflows:
              - master
              - ah_var_store
              - VS-1736
-             - vs_1810_add_sample_id_to_parquet_tracking
          tags:
              - /.*/
    - name: GvsPrepareRangesCallset

--- a/scripts/variantstore/parquet_loading/README.md
+++ b/scripts/variantstore/parquet_loading/README.md
@@ -47,7 +47,7 @@ gs://bucket/output_dir/
 ...
 └── ref_ranges/
 │   ├── 001/
-│   │   ├── vet_001_2_sample1.parquet
+│   │   ├── ref_ranges_001_2_sample1.parquet
 ...
 ```
 

--- a/scripts/variantstore/parquet_loading/README.md
+++ b/scripts/variantstore/parquet_loading/README.md
@@ -51,7 +51,7 @@ gs://bucket/output_dir/
 ...
 ```
 
-**Mapping**: `vet/001/` → BigQuery table `vet_001`, `ref_ranges/042/` → table `ref_042`
+**Mapping**: `vet/001/` → BigQuery table `vet_001`, `ref_ranges/042/` → BigQuery table `ref_ranges_042`
 
 ## Prerequisites
 

--- a/scripts/variantstore/parquet_loading/README.md
+++ b/scripts/variantstore/parquet_loading/README.md
@@ -25,17 +25,30 @@ This implementation loads Parquet files into BigQuery with:
 
 ### GCS Directory Structure
 
+Individual Parquet files are named like
+
+```
+<data type>_<superpartition>_<sample id>_<VCF filename>.parquet
+```
+
+where `<data type>` is `vet` or `ref_ranges`.
+
+Sample GCS directory structure:
+
 ```
 gs://bucket/output_dir/
 ├── vet/
-│   ├── 000/
-│   │   ├── vet_000_sample1.parquet
-│   │   └── vet_000_sample2.parquet
-│   └── 001/
-│       └── vet_001_sample1.parquet
+│   ├── 001/
+│   │   ├── vet_001_1_sample1.parquet
+│   │   ├── vet_001_2_sample1.parquet
+...
+│   └── 002/
+│       ├── vet_002_4001_sample1.parquet
+...
 └── ref_ranges/
-    └── 000/
-        └── ref_000_sample1.parquet
+│   ├── 001/
+│   │   ├── vet_001_2_sample1.parquet
+...
 ```
 
 **Mapping**: `vet/001/` → BigQuery table `vet_001`, `ref_ranges/042/` → table `ref_042`

--- a/scripts/variantstore/scripts/create_tracking_table.py
+++ b/scripts/variantstore/scripts/create_tracking_table.py
@@ -25,6 +25,7 @@ def create_tracking_table(project_id, dataset_name):
     schema = [
         bigquery.SchemaField("file_path", "STRING", mode="REQUIRED"),
         bigquery.SchemaField("table_name", "STRING", mode="REQUIRED"),
+        bigquery.SchemaField("sample_id", "INT64", mode="REQUIRED"),
         bigquery.SchemaField("load_timestamp", "TIMESTAMP", mode="REQUIRED"),
         bigquery.SchemaField("load_job_id", "STRING", mode="REQUIRED"),
         bigquery.SchemaField("file_size_bytes", "INT64", mode="NULLABLE"),

--- a/scripts/variantstore/scripts/load_parquet_to_bq.py
+++ b/scripts/variantstore/scripts/load_parquet_to_bq.py
@@ -15,41 +15,6 @@ from google.cloud import bigquery
 from google.api_core import exceptions
 
 
-def extract_sample_id_from_path(file_path, table_name):
-    """
-    Extract sample_id from file path.
-
-    Example:
-        file_path: "gs://.../ref_ranges_001_1_input_vcf_0_ERS4367795.vcf.gz.parquet"
-        table_name: "ref_ranges_001"
-        Returns: 1
-
-    The pattern is: {table_name}_{sample_id}_
-    """
-    try:
-        # Get just the filename from the path
-        filename = file_path.split('/')[-1]
-
-        # Find the pattern: table_name followed by underscore and sample_id
-        pattern = f"{table_name}_"
-        if pattern in filename:
-            # Find where the pattern starts
-            start_idx = filename.index(pattern) + len(pattern)
-
-            # Extract the part after the pattern
-            remainder = filename[start_idx:]
-
-            # The sample_id is everything up to the next underscore
-            if '_' in remainder:
-                sample_id_str = remainder.split('_')[0]
-                return int(sample_id_str)
-
-        # If pattern not found, return None
-        return None
-    except (ValueError, IndexError):
-        return None
-
-
 def load_table_from_parquet_files(
     project_id,
     dataset_name,
@@ -189,9 +154,7 @@ def load_table_from_parquet_files(
             # For single-file batches, we know exact row count; for multi-file, set to None
             rows_per_file = rows_loaded if len(batch) == 1 else None
             for file_path in batch:
-                print(f" about to extract sample_id from {file_path} for table {table_name}")
                 sample_id = extract_sample_id_from_path(file_path, table_name)
-                print(f" extracted {sample_id} from {file_path} for table {table_name}")
                 successful_loads.append({
                     "file_path": file_path,
                     "table_name": table_name,
@@ -462,6 +425,40 @@ def _execute_query_with_retry(client, query, job_config=None, max_retries=3):
             raise
     
     raise Exception("Unexpected error in query retry logic")
+
+def extract_sample_id_from_path(file_path, table_name):
+    """
+    Extract sample_id from file path.
+
+    Example:
+        file_path: "gs://.../ref_ranges_001_1_input_vcf_0_ERS4367795.vcf.gz.parquet"
+        table_name: "ref_ranges_001"
+        Returns: 1
+
+    The pattern is: {table_name}_{sample_id}_
+    """
+    try:
+        # Get just the filename from the path
+        filename = file_path.split('/')[-1]
+
+        # Find the pattern: table_name followed by underscore and sample_id
+        pattern = f"{table_name}_"
+        if pattern in filename:
+            # Find where the pattern starts
+            start_idx = filename.index(pattern) + len(pattern)
+
+            # Extract the part after the pattern
+            remainder = filename[start_idx:]
+
+            # The sample_id is everything up to the next underscore
+            if '_' in remainder:
+                sample_id_str = remainder.split('_')[0]
+                return int(sample_id_str)
+
+        # If pattern not found, return None
+        return None
+    except (ValueError, IndexError):
+        return None
 
 
 def main():

--- a/scripts/variantstore/scripts/load_parquet_to_bq.py
+++ b/scripts/variantstore/scripts/load_parquet_to_bq.py
@@ -250,14 +250,15 @@ def insert_tracking_records(client, tracking_table_id, records):
         USING UNNEST(@records) S
         ON T.file_path = S.file_path
         WHEN NOT MATCHED THEN
-          INSERT (file_path, table_name, file_size_bytes, load_timestamp, load_job_id, rows_loaded)
-          VALUES (S.file_path, S.table_name, S.file_size_bytes, CURRENT_TIMESTAMP(), S.load_job_id, S.rows_loaded)
+          INSERT (file_path, table_name, sample_id, file_size_bytes, load_timestamp, load_job_id, rows_loaded)
+          VALUES (S.file_path, S.table_name, S.sample_id, S.file_size_bytes, CURRENT_TIMESTAMP(), S.load_job_id, S.rows_loaded)
         """
         
         # Define the struct type for the array parameter
         struct_fields = [
             bigquery.ScalarQueryParameter("file_path", "STRING", None),
             bigquery.ScalarQueryParameter("table_name", "STRING", None),
+            bigquery.ScalarQueryParameter("sample_id", "INT64", None),
             bigquery.ScalarQueryParameter("file_size_bytes", "INT64", None),
             bigquery.ScalarQueryParameter("load_job_id", "STRING", None),
             bigquery.ScalarQueryParameter("rows_loaded", "INT64", None),
@@ -271,6 +272,7 @@ def insert_tracking_records(client, tracking_table_id, records):
                     None,  # No name needed for array elements
                     bigquery.ScalarQueryParameter("file_path", "STRING", r["file_path"]),
                     bigquery.ScalarQueryParameter("table_name", "STRING", r["table_name"]),
+                    bigquery.ScalarQueryParameter("sample_id", "INT64", r["sample_id"]),
                     bigquery.ScalarQueryParameter("file_size_bytes", "INT64", r["file_size_bytes"]),
                     bigquery.ScalarQueryParameter("load_job_id", "STRING", r["load_job_id"]),
                     bigquery.ScalarQueryParameter("rows_loaded", "INT64", r["rows_loaded"]),

--- a/scripts/variantstore/scripts/load_parquet_to_bq.py
+++ b/scripts/variantstore/scripts/load_parquet_to_bq.py
@@ -15,6 +15,41 @@ from google.cloud import bigquery
 from google.api_core import exceptions
 
 
+def extract_sample_id_from_path(file_path, table_name):
+    """
+    Extract sample_id from file path.
+
+    Example:
+        file_path: "gs://.../ref_ranges_001_1_input_vcf_0_ERS4367795.vcf.gz.parquet"
+        table_name: "ref_ranges_001"
+        Returns: 1
+
+    The pattern is: {table_name}_{sample_id}_
+    """
+    try:
+        # Get just the filename from the path
+        filename = file_path.split('/')[-1]
+
+        # Find the pattern: table_name followed by underscore and sample_id
+        pattern = f"{table_name}_"
+        if pattern in filename:
+            # Find where the pattern starts
+            start_idx = filename.index(pattern) + len(pattern)
+
+            # Extract the part after the pattern
+            remainder = filename[start_idx:]
+
+            # The sample_id is everything up to the next underscore
+            if '_' in remainder:
+                sample_id_str = remainder.split('_')[0]
+                return int(sample_id_str)
+
+        # If pattern not found, return None
+        return None
+    except (ValueError, IndexError):
+        return None
+
+
 def load_table_from_parquet_files(
     project_id,
     dataset_name,
@@ -154,9 +189,13 @@ def load_table_from_parquet_files(
             # For single-file batches, we know exact row count; for multi-file, set to None
             rows_per_file = rows_loaded if len(batch) == 1 else None
             for file_path in batch:
+                print(f" about to extract sample_id from {file_path} for table {table_name}")
+                sample_id = extract_sample_id_from_path(file_path, table_name)
+                print(f" extracted {sample_id} from {file_path} for table {table_name}")
                 successful_loads.append({
                     "file_path": file_path,
                     "table_name": table_name,
+                    "sample_id": sample_id,
                     "file_size_bytes": None,  # Could populate via storage API
                     "load_job_id": load_job.job_id,
                     "rows_loaded": rows_per_file,

--- a/scripts/variantstore/scripts/load_parquet_to_bq.py
+++ b/scripts/variantstore/scripts/load_parquet_to_bq.py
@@ -155,6 +155,11 @@ def load_table_from_parquet_files(
             rows_per_file = rows_loaded if len(batch) == 1 else None
             for file_path in batch:
                 sample_id = extract_sample_id_from_path(file_path, table_name)
+                if sample_id is None:
+                    raise ValueError(
+                        f"Failed to extract sample_id from file path: {file_path}. "
+                        f"Expected pattern '{table_name}_<sample_id>_' not found in filename."
+                    )
                 successful_loads.append({
                     "file_path": file_path,
                     "table_name": table_name,

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# B
+# C
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# A
+# B
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# C
+
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-
+# A
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -131,7 +131,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-02-18-alpine-d3e63fd7349b"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-02-18-alpine-7d4c93f9477f"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-02-17-gatkbase-666727620856"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -131,7 +131,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-02-18-alpine-0352f4105320"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-02-18-alpine-d3e63fd7349b"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-02-17-gatkbase-666727620856"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -131,7 +131,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-01-27-alpine-31607c946ac7"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-02-18-alpine-0352f4105320"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-02-17-gatkbase-666727620856"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -133,7 +133,7 @@ task GetToolVersions {
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
     String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-01-27-alpine-31607c946ac7"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
-    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2025-12-09-gatkbase-cda718c731d5"
+    String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-02-17-gatkbase-666727620856"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"
     String gotc_imputation_docker = "us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.5-1.10.2-0.1.16-1649948623"
     String plink_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/plink2:2024-04-23-slim-a0a65f52cc0e"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -131,7 +131,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-02-18-alpine-7d4c93f9477f"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-02-19-alpine-3d7b437e4e46"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-02-17-gatkbase-666727620856"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/IngestUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/common/IngestUtils.java
@@ -25,8 +25,8 @@ public class IngestUtils {
 
     public static Long getSampleId(final String sampleName, final File sampleMap) {
         Long sampleId = null;
-        //  Because BigQuery only supports partitioning based on timestamp or integer,
-        // sample names will be remapped into sample_id integers
+        // Because BigQuery only supports partitioning based on timestamp or integer,
+        // sample names will be remapped into sample_id integers.
         try {
             BufferedReader br = new BufferedReader(new FileReader(sampleMap));
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/RefCreator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/RefCreator.java
@@ -95,7 +95,11 @@ public final class RefCreator {
 
         try {
             if (writeReferenceRanges) {
-                final File refOutputFile = new File(outputDirectory, REF_RANGES_FILETYPE_PREFIX + tableNumber + PREFIX_SEPARATOR + sampleIdentifierForOutputFileName + "." + outputType.toString().toLowerCase());
+                String[] sampleComponents = {tableNumber, sampleId.toString(), sampleIdentifierForOutputFileName};
+                String filename = REF_RANGES_FILETYPE_PREFIX + String.join(PREFIX_SEPARATOR, sampleComponents) +
+                        "." + outputType.toString().toLowerCase();
+
+                final File refOutputFile = new File(outputDirectory, filename);
                 switch (outputType) {
                     case BQ:
                         if (projectId == null || datasetName == null) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/VetCreator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/VetCreator.java
@@ -65,7 +65,10 @@ public class VetCreator {
                     vetWriter.setHeaderLine(getHeaders());
                     break;
                 case PARQUET:
-                    final File parquetOutputFile = new File(outputDirectory, VET_FILETYPE_PREFIX + tableNumber + PREFIX_SEPARATOR + sampleIdentifierForOutputFileName + ".parquet");
+                    String[] sampleComponents = {tableNumber, sampleId.toString(), sampleIdentifierForOutputFileName};
+                    String filename = VET_FILETYPE_PREFIX + String.join(PREFIX_SEPARATOR, sampleComponents) +
+                            "." + outputType.toString().toLowerCase();
+                    final File parquetOutputFile = new File(outputDirectory, filename);
                     vetParquetFileWriter = new GvsVariantParquetFileWriter(new Path(parquetOutputFile.toURI()), parquetSchema, CompressionCodecName.SNAPPY);
                     break;
             }


### PR DESCRIPTION
VS-1810. This PR adds the sample_id to the parquet file name and then uses that to store it in the parquet tracking table.

Co-written with @mcovarr 

Example run [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/submission_history/5267bb11-0c51-4027-b0e8-c0e8aa53b7a2).