### PR TITLE
VS-1794 parquet removal strategy

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -222,6 +222,7 @@ workflows:
              - master
              - ah_var_store
              - VS-1736
+             - gg_VS-1794_ParquetRemovalStrategy
          tags:
              - /.*/
    - name: GvsPrepareRangesCallset

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,6 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# F
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# M
+# 1
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# 7
+# 8
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# E
+# F
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# B
+# C
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# 1
+# 2
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# A
+# B
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,6 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
+# 10
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# I
+# M
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,6 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# 10a
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# 2
+# 3
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# 3
+# 4
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# 6
+# 7
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# D
+# E
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,6 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
+# I
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# 4
+# 5
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# 5
+# 6
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,6 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# 8
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,6 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# A
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# C
+# D
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,6 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
+# 10a
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,6 +3,7 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
+# A
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -3,7 +3,6 @@ version 1.0
 import "GvsUtils.wdl" as Utils
 import "GvsAssignIds.wdl" as AssignIds
 import "GvsImportGenomes.wdl" as ImportGenomes
-# 10
 
 workflow GvsBulkIngestGenomes {
     input {

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -736,10 +736,8 @@ task ConfigureParquetLifecycle {
     # Extract bucket name from GCS path
     BUCKET_NAME=$(echo ~{output_gcs_dir} | sed 's|gs://||' | cut -d'/' -f1)
     # Extract bucket path prefix (if any) to ensure lifecycle rules are applied to the correct subdirectories
-    BUCKET_PATH_PREFIX=$(echo ~{output_gcs_dir} | sed 's|gs://||' | cut -d'/' -f2-)
-    if [ -n "$BUCKET_PATH_PREFIX" ]; then
-      BUCKET_PATH_PREFIX="$BUCKET_PATH_PREFIX/"
-    fi
+    # For example, if output_gcs_dir is gs://my-bucket/path/to/data/, we want the prefix to be path/to/data to apply rules to that subdirectory rather than the whole bucket
+    BUCKET_PATH_PREFIX=$(echo ~{output_gcs_dir} | sed 's|gs://||' | sed 's/\/$//' | cut -d'/' -f2-)
 
     echo "Configuring lifecycle for bucket: ${BUCKET_NAME}"
     
@@ -752,7 +750,7 @@ task ConfigureParquetLifecycle {
         "action": {"type": "Delete"},
         "condition": {
           "age": 14,
-          "matchesPrefix": ["${BUCKET_PATH_PREFIX}vet/", "${BUCKET_PATH_PREFIX}ref_ranges/"]
+          "matchesPrefix": ["${BUCKET_PATH_PREFIX}/vet/", "${BUCKET_PATH_PREFIX}/ref_ranges/"]
         }
       }
     ]

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -1083,7 +1083,7 @@ task ConfigureParquetLifecycle {
       "action": {"type": "Delete"},
       "condition": {
         "age": 14,
-        "matchesPrefix": ["${BUCKET_PATH_PREFIX}vet/", "${BUCKET_PATH_PREFIX}ref_ranges/"]
+        "matchesPrefix": ["${BUCKET_PATH_PREFIX}vet/", "${BUCKET_PATH_PREFIX}ref_ranges/", "${BUCKET_PATH_PREFIX}sample_chromosome_ploidy/"]
       }
     }
 EOF

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -744,7 +744,7 @@ task ConfigureParquetLifecycle {
     echo "Configuring lifecycle for bucket: ${BUCKET_NAME}"
     
     # Create lifecycle configuration for parquet directories
-    cat > lifecycle.json << 'EOF'
+    cat > lifecycle.json << EOF
 {
   "lifecycle": {
     "rule": [
@@ -773,7 +773,7 @@ EOF
     set -e
 
     echo "Here's the existing lifecycle config (if any):"
-    cat existing_lifecycle.json || echo "No existing lifecycle configuration"
+    cat existing_lifecycle.json
     echo "that's it"
     
     if [ $EXISTING_RC -eq 0 ] && [ -s existing_lifecycle.json ] && [ "$(cat existing_lifecycle.json)" != "None" ]; then
@@ -791,6 +791,7 @@ EOF
 #      --lifecycle-file=lifecycle.json
 #
 #    echo "✓ Lifecycle rule applied: Delete files in vet/ and ref_ranges/ after 14 days"
+    exit 1 # Temporarily exit with error to prevent actual lifecycle changes while testing
   >>>
   
   runtime {

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -1087,6 +1087,9 @@ task ConfigureParquetLifecycle {
     if [ -s existing_lifecycle.json ]; then
       echo "Existing lifecycle configuration:"
       cat existing_lifecycle.json
+      cp existing_lifecycle.json temp.json
+      sed 's/lifecycle_config/lifecycle/g' temp.json > existing_lifecycle.json
+      rm temp.json
 
       # Create the new lifecycle configuration for parquet directories
       cat > new_lifecycle_rule.json << EOF
@@ -1132,7 +1135,7 @@ EOF
     fi
 
     # Now use jq to merge the new lifecycle rule with the existing lifecycle configuration
-    jq --slurpfile new_rule new_lifecycle_rule.json '.lifecycle_config.rule += $new_rule' existing_lifecycle.json > updated_lifecycle.json
+    jq --slurpfile new_rule new_lifecycle_rule.json '.lifecycle.rule += $new_rule' existing_lifecycle.json > updated_lifecycle.json
 
 #    if [ $EXISTING_RC -eq 0 ] && [ -s existing_lifecycle.json ] && [ "$(cat existing_lifecycle.json)" != "None" ]; then
 #    echo "Bucket has existing lifecycle rules, merging with parquet cleanup rules"

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -268,7 +268,7 @@ workflow GvsImportGenomes {
           project_id = project_id,
           dataset_name = dataset_name,
           table_prefixes = ["vet", "ref_ranges"],
-          go = select_all(GenerateParquetFilesFromInputGVCFs.done),
+          go = ConfigureParquetLifecycle && select_all(GenerateParquetFilesFromInputGVCFs.done),
           variants_docker = effective_variants_docker,
       }
 
@@ -1073,7 +1073,7 @@ task ConfigureParquetLifecycle {
     set -e
 
     if [ $EXISTING_RC -ne 0 ]; then
-      echo "Bucket $BUCKET_NAME does not have existing lifecycle rules or bucket does not exist"
+      echo "Error encountered retrieving lifecycle rules for bucket $BUCKET_NAME - does that bucket exist?"
       exit 1;
     fi
 

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -738,11 +738,16 @@ task ConfigureParquetLifecycle {
 
     # Extract bucket path prefix (if any) to ensure lifecycle rules are applied to the correct subdirectories
     # For example, if output_gcs_dir is gs://my-bucket/path/to/data/, we want the prefix to be path/to/data/ to apply rules to that subdirectory rather than the whole bucket
-    BUCKET_PATH_PREFIX=$(echo ~{output_gcs_dir} | sed 's|gs://||' | sed 's/\/$//' | cut -d'/' -f2-)
+    # First, remove gs:// prefix and trailing slash, then check if there's a path component
+    TEMP_PATH=$(echo ~{output_gcs_dir} | sed 's|gs://||' | sed 's/\/$//')
 
-    # If BUCKET_PATH_PREFIX is not empty (i.e., output_gcs_dir is not just gs://bucket-name), append a trailing slash
-    if [ -n "$BUCKET_PATH_PREFIX" ]; then
+    # If TEMP_PATH contains a /, extract everything after the first /, otherwise set to empty
+    if [[ "$TEMP_PATH" == */* ]]; then
+      BUCKET_PATH_PREFIX=$(echo "$TEMP_PATH" | cut -d'/' -f2-)
+      # Append trailing slash since we have a path
       BUCKET_PATH_PREFIX="${BUCKET_PATH_PREFIX}/"
+    else
+      BUCKET_PATH_PREFIX=""
     fi
 
     echo "Configuring lifecycle for bucket: ${BUCKET_NAME}"

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -1123,7 +1123,7 @@ EOF
       ~{"--billing-project " + billing_project_id} \
       --lifecycle-file=updated_lifecycle.json
 
-    echo "✓ Lifecycle rule applied: After 14 days, it will delete files in the bucket: ${BUCKET_NAME}, with path prefixes ${BUCKET_PATH_PREFIX}vet/ and ${BUCKET_PATH_PREFIX}ref_ranges/"
+    echo "✓ Lifecycle rule applied: After 14 days, it will delete files in the bucket: ${BUCKET_NAME}, with path prefixes ${BUCKET_PATH_PREFIX}vet/, ${BUCKET_PATH_PREFIX}ref_ranges/ and ${BUCKET_PATH_PREFIX}/sample_chromosome_ploidy"
   >>>
 
   runtime {

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -1090,9 +1090,8 @@ EOF
     # If here, we successfully found a lifecycle config (even if it's empty), check if it's empty or null
     if [ -s existing_lifecycle.json ] && [ "$(cat existing_lifecycle.json)" != "null" ]; then
       # Note: The gcloud command returns lifecycle_config with a key of "lifecycle_config" but the gcloud buckets update command expects the key to be "lifecycle", so we need to rename that key before merging with jq
-      cp existing_lifecycle.json temp.json
-      sed 's/lifecycle_config/lifecycle/g' temp.json > existing_lifecycle.json
-      rm temp.json
+      jq '{lifecycle: .lifecycle_config}' existing_lifecycle.json > temp.json
+      mv temp.json existing_lifecycle.json
     else
       echo "No existing lifecycle configuration found (file is empty or contains the string 'null'), starting with empty lifecycle configuration"
       # Create the new lifecycle configuration with no rules (we'll add the rule further on) for parquet directories

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -784,12 +784,12 @@ EOF
     fi
     
     # Apply the lifecycle configuration
-#    gcloud storage buckets update gs://${BUCKET_NAME} \
-#      ~{"--billing-project " + billing_project_id} \
-#      --lifecycle-file=lifecycle.json
-#
-#    echo "✓ Lifecycle rule applied: Delete files in vet/ and ref_ranges/ after 14 days"
-    exit 1 # Temporarily exit with error to prevent actual lifecycle changes while testing
+    gcloud storage buckets update gs://${BUCKET_NAME} \
+      ~{"--billing-project " + billing_project_id} \
+      --lifecycle-file=lifecycle.json
+
+    echo "✓ Lifecycle rule applied: Delete files Bucket: ${BUCKET_NAME}, path prefixes ${BUCKET_PATH_PREFIX}vet/ and ${BUCKET_PATH_PREFIX}/ref_ranges/ after 14 days"
+#    exit 1 # Temporarily exit with error to prevent actual lifecycle changes while testing
   >>>
   
   runtime {

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -1066,11 +1066,30 @@ task ConfigureParquetLifecycle {
     echo "Configuring lifecycle for bucket: ${BUCKET_NAME}"
     echo "Path prefix: '${BUCKET_PATH_PREFIX}'"
 
-    # Create lifecycle configuration for parquet directories
-    cat > lifecycle.json << EOF
-{
-  "lifecycle": {
-    "rule": [
+    # Get existing lifecycle configuration if any
+    set +e
+    gcloud storage buckets describe gs://${BUCKET_NAME} \
+      ~{"--billing-project " + billing_project_id} \
+      --format="json(lifecycle_config)" > existing_lifecycle.json 2>/dev/null
+    EXISTING_RC=$?
+    set -e
+
+    echo "Hello"
+    echo $EXISTING_RC
+    echo "There"
+
+    if [ $EXISTING_RC -ne 0 ]; then
+      echo "Bucket $BUCKET_NAME does not have existing lifecycle rules or bucket does not exist"
+      exit 1;
+    fi
+
+    # If here, we successfully got lifecycle config (even if it's empty), check if it's empty or None
+    if [ -s existing_lifecycle.json ]; then
+      echo "Existing lifecycle configuration:"
+      cat existing_lifecycle.json
+
+      # Create the new lifecycle configuration for parquet directories
+      cat > new_lifecycle_rule.json << EOF
       {
         "action": {"type": "Delete"},
         "condition": {
@@ -1078,27 +1097,41 @@ task ConfigureParquetLifecycle {
           "matchesPrefix": ["${BUCKET_PATH_PREFIX}vet/", "${BUCKET_PATH_PREFIX}ref_ranges/"]
         }
       }
-    ]
-  }
-}
 EOF
 
-    # Get existing lifecycle configuration if any
-    set +e
-    gcloud storage buckets describe gs://${BUCKET_NAME} \
-      ~{"--billing-project " + billing_project_id} \
-      --format="value(lifecycle_config)" > existing_lifecycle.json 2>/dev/null
-    EXISTING_RC=$?
-    set -e
+    # Now use jq to merge the new lifecycle rule with the existing lifecycle configuration
+    jq --slurpfile new_rule new_lifecycle_rule.json '.lifecycle_config.rule += $new_rule' existing_lifecycle.json > updated_lifecycle.json
 
-    if [ $EXISTING_RC -eq 0 ] && [ -s existing_lifecycle.json ] && [ "$(cat existing_lifecycle.json)" != "None" ]; then
-      echo "Bucket has existing lifecycle rules, merging with parquet cleanup rules"
-      # Note: In production, you might want more sophisticated merging
-      # For now, we'll apply our rules and note that existing rules remain
-      echo "Existing lifecycle rules will be preserved alongside new parquet rules"
+
     else
-      echo "No existing lifecycle rules found"
+      echo "No existing lifecycle configuration found (file is empty)"
+      # Create the new lifecycle configuration for parquet directories
+      cat > updated_lifecycle.json << EOF
+      {
+        "lifecycle": {
+          "rule": [
+            {
+              "action": {"type": "Delete"},
+              "condition": {
+                "age": 14,
+                "matchesPrefix": ["${BUCKET_PATH_PREFIX}vet/", "${BUCKET_PATH_PREFIX}ref_ranges/"]
+              }
+            }
+          ]
+        }
+      }
+EOF
     fi
+
+
+#    if [ $EXISTING_RC -eq 0 ] && [ -s existing_lifecycle.json ] && [ "$(cat existing_lifecycle.json)" != "None" ]; then
+#    echo "Bucket has existing lifecycle rules, merging with parquet cleanup rules"
+#    # Note: In production, you might want more sophisticated merging
+#    # For now, we'll apply our rules and note that existing rules remain
+#    echo "Existing lifecycle rules will be preserved alongside new parquet rules"
+#    else
+#    echo "No existing lifecycle rules found"
+#    fi
 
     # Apply the lifecycle configuration
     # Lies! This will overwrite existing lifecycle rules rather than merging any existing lifecycle rules with the to-be-applied rules,
@@ -1121,7 +1154,8 @@ EOF
 
   output {
     Boolean done = true
-    File lifecycle_config = "lifecycle.json"
+    File new_lifecycle_config = "new_lifecycle_rule.json"
+    File updated_lifecycle_config = "updated_lifecycle.json"
     File existing_lifecycle_config = "existing_lifecycle.json"
   }
 }

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -735,12 +735,19 @@ task ConfigureParquetLifecycle {
     
     # Extract bucket name from GCS path
     BUCKET_NAME=$(echo ~{output_gcs_dir} | sed 's|gs://||' | cut -d'/' -f1)
+
     # Extract bucket path prefix (if any) to ensure lifecycle rules are applied to the correct subdirectories
-    # For example, if output_gcs_dir is gs://my-bucket/path/to/data/, we want the prefix to be path/to/data to apply rules to that subdirectory rather than the whole bucket
+    # For example, if output_gcs_dir is gs://my-bucket/path/to/data/, we want the prefix to be path/to/data/ to apply rules to that subdirectory rather than the whole bucket
     BUCKET_PATH_PREFIX=$(echo ~{output_gcs_dir} | sed 's|gs://||' | sed 's/\/$//' | cut -d'/' -f2-)
 
+    # If BUCKET_PATH_PREFIX is not empty (i.e., output_gcs_dir is not just gs://bucket-name), append a trailing slash
+    if [ -n "$BUCKET_PATH_PREFIX" ]; then
+      BUCKET_PATH_PREFIX="${BUCKET_PATH_PREFIX}/"
+    fi
+
     echo "Configuring lifecycle for bucket: ${BUCKET_NAME}"
-    
+    echo "Path prefix: '${BUCKET_PATH_PREFIX}'"
+
     # Create lifecycle configuration for parquet directories
     cat > lifecycle.json << EOF
 {
@@ -750,7 +757,7 @@ task ConfigureParquetLifecycle {
         "action": {"type": "Delete"},
         "condition": {
           "age": 14,
-          "matchesPrefix": ["${BUCKET_PATH_PREFIX}/vet/", "${BUCKET_PATH_PREFIX}/ref_ranges/"]
+          "matchesPrefix": ["${BUCKET_PATH_PREFIX}vet/", "${BUCKET_PATH_PREFIX}ref_ranges/"]
         }
       }
     ]
@@ -782,7 +789,7 @@ EOF
       ~{"--billing-project " + billing_project_id} \
       --lifecycle-file=lifecycle.json
 
-    echo "✓ Lifecycle rule applied: After 14 days, it will delete files in the bucket: ${BUCKET_NAME}, with path prefixes ${BUCKET_PATH_PREFIX}vet/ and ${BUCKET_PATH_PREFIX}/ref_ranges/"
+    echo "✓ Lifecycle rule applied: After 14 days, it will delete files in the bucket: ${BUCKET_NAME}, with path prefixes ${BUCKET_PATH_PREFIX}vet/ and ${BUCKET_PATH_PREFIX}ref_ranges/"
   >>>
   
   runtime {

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -1108,6 +1108,7 @@ EOF
       --lifecycle-file=lifecycle.json
 
     echo "✓ Lifecycle rule applied: After 14 days, it will delete files in the bucket: ${BUCKET_NAME}, with path prefixes ${BUCKET_PATH_PREFIX}vet/ and ${BUCKET_PATH_PREFIX}ref_ranges/"
+    exit 1 # Temporary exit to prevent accidental lifecycle application during testing - remove this line in production
   >>>
 
   runtime {

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -735,6 +735,12 @@ task ConfigureParquetLifecycle {
     
     # Extract bucket name from GCS path
     BUCKET_NAME=$(echo ~{output_gcs_dir} | sed 's|gs://||' | cut -d'/' -f1)
+    # Extract bucket path prefix (if any) to ensure lifecycle rules are applied to the correct subdirectories
+    BUCKET_PATH_PREFIX=$(echo ~{output_gcs_dir} | sed 's|gs://||' | cut -d'/' -f2-)
+    if [ -n "$BUCKET_PATH_PREFIX" ]; then
+      BUCKET_PATH_PREFIX="$BUCKET_PATH_PREFIX/"
+    fi
+
     echo "Configuring lifecycle for bucket: ${BUCKET_NAME}"
     
     # Create lifecycle configuration for parquet directories
@@ -746,21 +752,29 @@ task ConfigureParquetLifecycle {
         "action": {"type": "Delete"},
         "condition": {
           "age": 14,
-          "matchesPrefix": ["vet/", "ref_ranges/"]
+          "matchesPrefix": ["${BUCKET_PATH_PREFIX}vet/", "${BUCKET_PATH_PREFIX}ref_ranges/"]
         }
       }
     ]
   }
 }
 EOF
+
+    echo "Here's the file:"
+    cat lifecycle.json
+    echo "that's it"
     
     # Get existing lifecycle configuration if any
     set +e
     gcloud storage buckets describe gs://${BUCKET_NAME} \
       ~{"--billing-project " + billing_project_id} \
-      --format="value(lifecycle)" > existing_lifecycle.json 2>/dev/null
+      --format="value(lifecycle_config)" > existing_lifecycle.json 2>/dev/null
     EXISTING_RC=$?
     set -e
+
+    echo "Here's the existing lifecycle config (if any):"
+    cat existing_lifecycle.json || echo "No existing lifecycle configuration"
+    echo "that's it"
     
     if [ $EXISTING_RC -eq 0 ] && [ -s existing_lifecycle.json ] && [ "$(cat existing_lifecycle.json)" != "None" ]; then
       echo "Bucket has existing lifecycle rules, merging with parquet cleanup rules"
@@ -772,11 +786,11 @@ EOF
     fi
     
     # Apply the lifecycle configuration
-    gcloud storage buckets update gs://${BUCKET_NAME} \
-      ~{"--billing-project " + billing_project_id} \
-      --lifecycle-file=lifecycle.json
-    
-    echo "✓ Lifecycle rule applied: Delete files in vet/ and ref_ranges/ after 14 days"
+#    gcloud storage buckets update gs://${BUCKET_NAME} \
+#      ~{"--billing-project " + billing_project_id} \
+#      --lifecycle-file=lifecycle.json
+#
+#    echo "✓ Lifecycle rule applied: Delete files in vet/ and ref_ranges/ after 14 days"
   >>>
   
   runtime {

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -1105,8 +1105,17 @@ EOF
 EOF
     fi
 
-    # Now use jq to merge the new lifecycle rule with the existing lifecycle configuration
-    jq --slurpfile new_rule new_lifecycle_rule.json '.lifecycle.rule += $new_rule' existing_lifecycle.json > updated_lifecycle.json
+    # Now use jq to merge the new lifecycle rule with the existing lifecycle configuration,
+    # but only add it if there isn't already a rule with the same condition.matchesPrefix values
+    jq --slurpfile new_rule new_lifecycle_rule.json '
+      . as $cfg
+      | $new_rule[0] as $nr
+      | ($cfg.lifecycle.rule // []) as $rules
+      | if ($rules | any(.condition.matchesPrefix == $nr.condition.matchesPrefix))
+        then $cfg
+        else $cfg | .lifecycle.rule += [$nr]
+        end
+    ' existing_lifecycle.json > updated_lifecycle.json
 
     # Apply the updated lifecycle configuration
     gcloud storage buckets update gs://${BUCKET_NAME} \

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -268,7 +268,7 @@ workflow GvsImportGenomes {
           project_id = project_id,
           dataset_name = dataset_name,
           table_prefixes = ["vet", "ref_ranges"],
-          go = ConfigureParquetLifecycle && select_all(GenerateParquetFilesFromInputGVCFs.done),
+          go = flatten([[ConfigureParquetLifecycle.done], select_all(GenerateParquetFilesFromInputGVCFs.done)]),
           variants_docker = effective_variants_docker,
       }
 

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -758,10 +758,6 @@ task ConfigureParquetLifecycle {
 }
 EOF
 
-    echo "Here's the file:"
-    cat lifecycle.json
-    echo "that's it"
-    
     # Get existing lifecycle configuration if any
     set +e
     gcloud storage buckets describe gs://${BUCKET_NAME} \
@@ -769,10 +765,6 @@ EOF
       --format="value(lifecycle_config)" > existing_lifecycle.json 2>/dev/null
     EXISTING_RC=$?
     set -e
-
-    echo "Here's the existing lifecycle config (if any):"
-    cat existing_lifecycle.json
-    echo "that's it"
     
     if [ $EXISTING_RC -eq 0 ] && [ -s existing_lifecycle.json ] && [ "$(cat existing_lifecycle.json)" != "None" ]; then
       echo "Bucket has existing lifecycle rules, merging with parquet cleanup rules"
@@ -784,12 +776,13 @@ EOF
     fi
     
     # Apply the lifecycle configuration
+    # Lies! This will overwrite existing lifecycle rules rather than merging any existing lifecycle rules with the to-be-applied rules,
+    #  but gcloud doesn't have a way to do an actual merge. In the future, we would need to implement merging logic.
     gcloud storage buckets update gs://${BUCKET_NAME} \
       ~{"--billing-project " + billing_project_id} \
       --lifecycle-file=lifecycle.json
 
-    echo "✓ Lifecycle rule applied: Delete files Bucket: ${BUCKET_NAME}, path prefixes ${BUCKET_PATH_PREFIX}vet/ and ${BUCKET_PATH_PREFIX}/ref_ranges/ after 14 days"
-#    exit 1 # Temporarily exit with error to prevent actual lifecycle changes while testing
+    echo "✓ Lifecycle rule applied: After 14 days, it will delete files in the bucket: ${BUCKET_NAME}, with path prefixes ${BUCKET_PATH_PREFIX}vet/ and ${BUCKET_PATH_PREFIX}/ref_ranges/"
   >>>
   
   runtime {
@@ -802,6 +795,8 @@ EOF
   
   output {
     String done = "lifecycle_configured"
+    File lifecycle_config = "lifecycle.json"
+    File existing_lifecycle_config = "existing_lifecycle.json"
   }
 }
 

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -257,6 +257,7 @@ workflow GvsImportGenomes {
         input:
           project_id = project_id,
           dataset_name = dataset_name,
+          go = ConfigureParquetLifecycle.done,
           variants_docker = effective_variants_docker,
       }
 
@@ -1140,6 +1141,7 @@ EOF
 
 task CreateParquetTrackingTable {
   input {
+    Boolean go
     String project_id
     String dataset_name
     String variants_docker

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -252,7 +252,7 @@ workflow GvsImportGenomes {
           input:
             output_gcs_dir = defined_parquet_output_dir,
             billing_project_id = billing_project_id,
-            cloud_sdk_docker = effective_cloud_sdk_docker,
+            variants_docker = effective_variants_docker,
         }
       }
 
@@ -1039,7 +1039,7 @@ task ConfigureParquetLifecycle {
   input {
     String output_gcs_dir
     String? billing_project_id
-    String cloud_sdk_docker
+    String variants_docker
   }
 
   command <<<
@@ -1112,7 +1112,7 @@ EOF
   >>>
 
   runtime {
-    docker: cloud_sdk_docker
+    docker: variants_docker
     memory: "1 GB"
     disks: "local-disk 10 HDD"
     preemptible: 3

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -47,7 +47,7 @@ workflow GvsImportGenomes {
 
     # Dump these parquet files to a bucket
     String output_gcs_dir
-    Boolean configure_parquet_bucket_lifecycle = false
+    Boolean configure_parquet_bucket_lifecycle = true
 
     Boolean is_wgs = true
   }

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -1083,29 +1083,27 @@ task ConfigureParquetLifecycle {
       exit 1;
     fi
 
-    # If here, we successfully got lifecycle config (even if it's empty), check if it's empty or None
-    if [ -s existing_lifecycle.json ]; then
+    # Create the new lifecycle rule for parquet directories
+    cat > new_lifecycle_rule.json << EOF
+    {
+      "action": {"type": "Delete"},
+      "condition": {
+        "age": 14,
+        "matchesPrefix": ["${BUCKET_PATH_PREFIX}vet/", "${BUCKET_PATH_PREFIX}ref_ranges/"]
+      }
+    }
+EOF
+
+    # If here, we successfully got lifecycle config (even if it's empty), check if it's empty or null
+    if [ -s existing_lifecycle.json ] && [ "$(cat existing_lifecycle.json)" != "null" ]; then
       echo "Existing lifecycle configuration:"
       cat existing_lifecycle.json
       cp existing_lifecycle.json temp.json
       sed 's/lifecycle_config/lifecycle/g' temp.json > existing_lifecycle.json
       rm temp.json
-
-      # Create the new lifecycle configuration for parquet directories
-      cat > new_lifecycle_rule.json << EOF
-      {
-        "action": {"type": "Delete"},
-        "condition": {
-          "age": 14,
-          "matchesPrefix": ["${BUCKET_PATH_PREFIX}vet/", "${BUCKET_PATH_PREFIX}ref_ranges/"]
-        }
-      }
-EOF
-
     else
-      echo "No existing lifecycle configuration found (file is empty)"
-      # Create the new lifecycle configuration (actually just the outer structure since there are no existing rules) for parquet directories
-      # Create the new lifecycle configuration for parquet directories
+      echo "No existing lifecycle configuration found (file is empty or contains the string 'null'), starting with empty lifecycle configuration"
+      # Create the new lifecycle configuration (we'll add the rule further on) for parquet directories
       cat > existing_lifecycle.json << EOF
       {
         "lifecycle": {

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -1103,12 +1103,12 @@ EOF
     # Apply the lifecycle configuration
     # Lies! This will overwrite existing lifecycle rules rather than merging any existing lifecycle rules with the to-be-applied rules,
     #  but gcloud doesn't have a way to do an actual merge. In the future, we would need to implement merging logic.
-    gcloud storage buckets update gs://${BUCKET_NAME} \
-      ~{"--billing-project " + billing_project_id} \
-      --lifecycle-file=lifecycle.json
+#    gcloud storage buckets update gs://${BUCKET_NAME} \
+#      ~{"--billing-project " + billing_project_id} \
+#      --lifecycle-file=lifecycle.json
 
     echo "✓ Lifecycle rule applied: After 14 days, it will delete files in the bucket: ${BUCKET_NAME}, with path prefixes ${BUCKET_PATH_PREFIX}vet/ and ${BUCKET_PATH_PREFIX}ref_ranges/"
-    exit 1 # Temporary exit to prevent accidental lifecycle application during testing - remove this line in production
+    exit 0 # Temporary exit to prevent accidental lifecycle application during testing - remove this line in production
   >>>
 
   runtime {

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -47,7 +47,7 @@ workflow GvsImportGenomes {
 
     # Dump these parquet files to a bucket
     String output_gcs_dir
-    Boolean configure_parquet_bucket_lifecycle = true
+    Boolean configure_parquet_bucket_lifecycle = false
 
     Boolean is_wgs = true
   }

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -1126,8 +1126,6 @@ EOF
 
   output {
     Boolean done = true
-    File existing_lifecycle_config = "existing_lifecycle.json"
-    File updated_lifecycle_config = "updated_lifecycle.json"
   }
 }
 

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -1099,30 +1099,40 @@ task ConfigureParquetLifecycle {
       }
 EOF
 
-    # Now use jq to merge the new lifecycle rule with the existing lifecycle configuration
-    jq --slurpfile new_rule new_lifecycle_rule.json '.lifecycle_config.rule += $new_rule' existing_lifecycle.json > updated_lifecycle.json
-
-
     else
       echo "No existing lifecycle configuration found (file is empty)"
+      # Create the new lifecycle configuration (actually just the outer structure since there are no existing rules) for parquet directories
       # Create the new lifecycle configuration for parquet directories
-      cat > updated_lifecycle.json << EOF
+      cat > existing_lifecycle.json << EOF
       {
         "lifecycle": {
           "rule": [
-            {
-              "action": {"type": "Delete"},
-              "condition": {
-                "age": 14,
-                "matchesPrefix": ["${BUCKET_PATH_PREFIX}vet/", "${BUCKET_PATH_PREFIX}ref_ranges/"]
-              }
-            }
           ]
         }
       }
 EOF
+
+# Old
+#      cat > updated_lifecycle.json << EOF
+#      {
+#        "lifecycle": {
+#          "rule": [
+#            {
+#              "action": {"type": "Delete"},
+#              "condition": {
+#                "age": 14,
+#                "matchesPrefix": ["${BUCKET_PATH_PREFIX}vet/", "${BUCKET_PATH_PREFIX}ref_ranges/"]
+#              }
+#            }
+#          ]
+#        }
+#      }
+#EOF
+# OLD
     fi
 
+    # Now use jq to merge the new lifecycle rule with the existing lifecycle configuration
+    jq --slurpfile new_rule new_lifecycle_rule.json '.lifecycle_config.rule += $new_rule' existing_lifecycle.json > updated_lifecycle.json
 
 #    if [ $EXISTING_RC -eq 0 ] && [ -s existing_lifecycle.json ] && [ "$(cat existing_lifecycle.json)" != "None" ]; then
 #    echo "Bucket has existing lifecycle rules, merging with parquet cleanup rules"
@@ -1133,15 +1143,12 @@ EOF
 #    echo "No existing lifecycle rules found"
 #    fi
 
-    # Apply the lifecycle configuration
-    # Lies! This will overwrite existing lifecycle rules rather than merging any existing lifecycle rules with the to-be-applied rules,
-    #  but gcloud doesn't have a way to do an actual merge. In the future, we would need to implement merging logic.
-#    gcloud storage buckets update gs://${BUCKET_NAME} \
-#      ~{"--billing-project " + billing_project_id} \
-#      --lifecycle-file=lifecycle.json
+    # Apply the updated lifecycle configuration
+    gcloud storage buckets update gs://${BUCKET_NAME} \
+      ~{"--billing-project " + billing_project_id} \
+      --lifecycle-file=updated_lifecycle.json
 
     echo "✓ Lifecycle rule applied: After 14 days, it will delete files in the bucket: ${BUCKET_NAME}, with path prefixes ${BUCKET_PATH_PREFIX}vet/ and ${BUCKET_PATH_PREFIX}ref_ranges/"
-#    exit 0 # Temporary exit to prevent accidental lifecycle application during testing - remove this line in production
   >>>
 
   runtime {

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -1108,7 +1108,7 @@ EOF
 #      --lifecycle-file=lifecycle.json
 
     echo "✓ Lifecycle rule applied: After 14 days, it will delete files in the bucket: ${BUCKET_NAME}, with path prefixes ${BUCKET_PATH_PREFIX}vet/ and ${BUCKET_PATH_PREFIX}ref_ranges/"
-    exit 0 # Temporary exit to prevent accidental lifecycle application during testing - remove this line in production
+#    exit 0 # Temporary exit to prevent accidental lifecycle application during testing - remove this line in production
   >>>
 
   runtime {
@@ -1121,7 +1121,6 @@ EOF
 
   output {
     Boolean done = true
-    String done = "lifecycle_configured"
     File lifecycle_config = "lifecycle.json"
     File existing_lifecycle_config = "existing_lifecycle.json"
   }

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -1074,16 +1074,12 @@ task ConfigureParquetLifecycle {
     EXISTING_RC=$?
     set -e
 
-    echo "Hello"
-    echo $EXISTING_RC
-    echo "There"
-
     if [ $EXISTING_RC -ne 0 ]; then
       echo "Bucket $BUCKET_NAME does not have existing lifecycle rules or bucket does not exist"
       exit 1;
     fi
 
-    # Create the new lifecycle rule for parquet directories
+    # Create the new lifecycle *rule* for parquet directories
     cat > new_lifecycle_rule.json << EOF
     {
       "action": {"type": "Delete"},
@@ -1094,16 +1090,15 @@ task ConfigureParquetLifecycle {
     }
 EOF
 
-    # If here, we successfully got lifecycle config (even if it's empty), check if it's empty or null
+    # If here, we successfully found a lifecycle config (even if it's empty), check if it's empty or null
     if [ -s existing_lifecycle.json ] && [ "$(cat existing_lifecycle.json)" != "null" ]; then
-      echo "Existing lifecycle configuration:"
-      cat existing_lifecycle.json
+      # Note: The gcloud command returns lifecycle_config with a key of "lifecycle_config" but the gcloud buckets update command expects the key to be "lifecycle", so we need to rename that key before merging with jq
       cp existing_lifecycle.json temp.json
       sed 's/lifecycle_config/lifecycle/g' temp.json > existing_lifecycle.json
       rm temp.json
     else
       echo "No existing lifecycle configuration found (file is empty or contains the string 'null'), starting with empty lifecycle configuration"
-      # Create the new lifecycle configuration (we'll add the rule further on) for parquet directories
+      # Create the new lifecycle configuration with no rules (we'll add the rule further on) for parquet directories
       cat > existing_lifecycle.json << EOF
       {
         "lifecycle": {
@@ -1112,37 +1107,10 @@ EOF
         }
       }
 EOF
-
-# Old
-#      cat > updated_lifecycle.json << EOF
-#      {
-#        "lifecycle": {
-#          "rule": [
-#            {
-#              "action": {"type": "Delete"},
-#              "condition": {
-#                "age": 14,
-#                "matchesPrefix": ["${BUCKET_PATH_PREFIX}vet/", "${BUCKET_PATH_PREFIX}ref_ranges/"]
-#              }
-#            }
-#          ]
-#        }
-#      }
-#EOF
-# OLD
     fi
 
     # Now use jq to merge the new lifecycle rule with the existing lifecycle configuration
     jq --slurpfile new_rule new_lifecycle_rule.json '.lifecycle.rule += $new_rule' existing_lifecycle.json > updated_lifecycle.json
-
-#    if [ $EXISTING_RC -eq 0 ] && [ -s existing_lifecycle.json ] && [ "$(cat existing_lifecycle.json)" != "None" ]; then
-#    echo "Bucket has existing lifecycle rules, merging with parquet cleanup rules"
-#    # Note: In production, you might want more sophisticated merging
-#    # For now, we'll apply our rules and note that existing rules remain
-#    echo "Existing lifecycle rules will be preserved alongside new parquet rules"
-#    else
-#    echo "No existing lifecycle rules found"
-#    fi
 
     # Apply the updated lifecycle configuration
     gcloud storage buckets update gs://${BUCKET_NAME} \
@@ -1162,9 +1130,8 @@ EOF
 
   output {
     Boolean done = true
-    File new_lifecycle_config = "new_lifecycle_rule.json"
-    File updated_lifecycle_config = "updated_lifecycle.json"
     File existing_lifecycle_config = "existing_lifecycle.json"
+    File updated_lifecycle_config = "updated_lifecycle.json"
   }
 }
 

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -49,7 +49,6 @@ workflow GvsImportGenomes {
     Boolean use_parquet_ingest = true
     # Dump these Parquet files to a bucket.
     String? parquet_output_gcs_dir
-    Boolean configure_parquet_bucket_lifecycle = false
 
     Boolean is_wgs = true
   }
@@ -245,15 +244,13 @@ workflow GvsImportGenomes {
   if (load_vet_and_ref_ranges) {
     if (use_parquet_ingest) {
       String defined_parquet_output_dir = select_first([parquet_output_gcs_dir])
-      if (configure_parquet_bucket_lifecycle) {
-        # Set up lifecycle rules for parquet directories before loading
-        # TODO - I'm having trouble getting this to run and so am hiding it behind a boolean for now.
-        call ConfigureParquetLifecycle {
-          input:
-            output_gcs_dir = defined_parquet_output_dir,
-            billing_project_id = billing_project_id,
-            variants_docker = effective_variants_docker,
-        }
+
+      # Set up lifecycle rules for parquet directories before loading
+      call ConfigureParquetLifecycle {
+        input:
+          output_gcs_dir = defined_parquet_output_dir,
+          billing_project_id = billing_project_id,
+          variants_docker = effective_variants_docker,
       }
 
       call CreateParquetTrackingTable {


### PR DESCRIPTION
This PR updates the functionality for lifecycle rules to apply them to the prefix corresponding to the 'subdirectory' in which the parquet files are stored.

Here is a [test](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/submission_history/f39eacd8-8592-45fd-9743-d424d44478e3) where there are no existing lifecycle rules (we create the first)
Here is a [test](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/submission_history/f6a54564-0e0c-47ee-b334-0256e53d58cd) where there is an existing lifecycle rule (we append another)
Here is a [test](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Quickstart%20v3%20ggrant/submission_history/548e08ac-7747-46c6-8ec9-4448e633534e) where there is a duplicate lifecycle rule (we ignore it)