### PR TITLE
Fix VCF integration assertion, revert extract scatters [VS-1820]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -343,7 +343,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1777_build_failure
+             - vs_1820_fix_vcf_integration_assertion
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -193,7 +193,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1820_fix_vcf_integration_assertion
          tags:
              - /.*/
    - name: GvsExtractCallsetShard30603

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -193,6 +193,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - vs_1820_fix_vcf_integration_assertion
          tags:
              - /.*/
    - name: GvsExtractCallsetShard30603

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -344,7 +344,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1777_build_failure
+             - vs_1820_fix_vcf_integration_assertion
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -343,7 +343,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1820_fix_vcf_integration_assertion
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -193,7 +193,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1820_fix_vcf_integration_assertion
          tags:
              - /.*/
    - name: GvsExtractCallsetShard30603
@@ -344,7 +343,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1820_fix_vcf_integration_assertion
+             - vs_1777_build_failure
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -136,12 +136,12 @@ workflow GvsExtractCallset {
 
   Int effective_scatter_count = if defined(scatter_count) then select_first([scatter_count])
                                 else if is_wgs then
-                                     if GetNumSamplesLoaded.num_samples < 5000 then 1
+                                     if GetNumSamplesLoaded.num_samples < 5000 then 500
                                      else if GetNumSamplesLoaded.num_samples < 20000 then 2000
                                           else if GetNumSamplesLoaded.num_samples < 50000 then 10000
                                                else 20000
                                      else
-                                     if GetNumSamplesLoaded.num_samples < 5000 then 1
+                                     if GetNumSamplesLoaded.num_samples < 5000 then 500
                                      else if GetNumSamplesLoaded.num_samples < 20000 then 1000
                                           else if GetNumSamplesLoaded.num_samples < 50000 then 2500
                                                else 7500

--- a/scripts/variantstore/wdl/GvsExtractCallset.wdl
+++ b/scripts/variantstore/wdl/GvsExtractCallset.wdl
@@ -136,12 +136,12 @@ workflow GvsExtractCallset {
 
   Int effective_scatter_count = if defined(scatter_count) then select_first([scatter_count])
                                 else if is_wgs then
-                                     if GetNumSamplesLoaded.num_samples < 5000 then 500
+                                     if GetNumSamplesLoaded.num_samples < 5000 then 1
                                      else if GetNumSamplesLoaded.num_samples < 20000 then 2000
                                           else if GetNumSamplesLoaded.num_samples < 50000 then 10000
                                                else 20000
                                      else
-                                     if GetNumSamplesLoaded.num_samples < 5000 then 500
+                                     if GetNumSamplesLoaded.num_samples < 5000 then 1
                                      else if GetNumSamplesLoaded.num_samples < 20000 then 1000
                                           else if GetNumSamplesLoaded.num_samples < 50000 then 2500
                                                else 7500

--- a/scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
+++ b/scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
@@ -38,7 +38,7 @@ workflow GvsQuickstartIntegration {
     }
 
     String expected_subdir = if (!chr20_X_Y_only) then "all_chrs/"  else ""
-    File expected_output_prefix = "gs://gvs-internal-quickstart/integration/2025-07-21/" + expected_subdir
+    File expected_output_prefix = "gs://gvs-internal-quickstart/integration/2026-03-09/" + expected_subdir
     File truth_data_prefix = "gs://gvs-internal-quickstart/integration/test_data/2025-07-21/" + expected_subdir
 
     # WDL 1.0 trick to set a variable ('none') to be undefined.

--- a/scripts/variantstore/wdl/test/GvsQuickstartVcfIntegration.wdl
+++ b/scripts/variantstore/wdl/test/GvsQuickstartVcfIntegration.wdl
@@ -444,7 +444,7 @@ task AssertCostIsTrackedAndExpected {
                 DIFF_FOUND=$(echo $EXP_BYTES $OBS_BYTES | awk '{print ($1-$2)/$1}')
               fi
 
-              if ! awk "BEGIN{ exit ($DIFF_FOUND -gt $TOLERANCE) }"
+              if ! awk "BEGIN{ exit ($DIFF_FOUND > $TOLERANCE) }"
               then
                 echo "FAIL!!! The relative difference between these is $DIFF_FOUND, which is greater than the allowed tolerance ($TOLERANCE)"
                 echo "1" > ret_val.txt


### PR DESCRIPTION
awk does not use `-gt` for numeric comparisons; this should be (and used to be) `>`.  Unfortunately our version of awk doesn't seem to complain when we _try_ to use `-gt` and instead just silently exits with rc 0. 😞 


```
$ DIFF_FOUND=0.2
$ TOLERANCE=0.1
$ awk "BEGIN{ exit ($DIFF_FOUND -gt $TOLERANCE) }"
$ echo $?
0
$ awk "BEGIN{ exit ($DIFF_FOUND > $TOLERANCE) }"
$ echo $?
1
$ awk "BEGIN{ exit ($DIFF_FOUND -lt $TOLERANCE) }"
$ echo $?
0
$ awk "BEGIN{ exit ($DIFF_FOUND < $TOLERANCE) }"
$ echo $?
0
```

Appropriately failing integration test [here](https://job-manager.dsde-prod.broadinstitute.org/jobs/5bcfb647-db1d-46ae-a94d-11f881374710) with just the comparison fixed. 

After further research, I found that these large discrepancies between expected and actual values only seem to happen with 3 sample integration runs. For AnVIL 3K, using the 500-wide scatter actually significantly *reduced* Storage API bytes scanned during extract. Shards appear to have downloaded only the data they needed (more or less) and were far less subject to preemptions due to their much shorter runtimes.

The final changes here were to update the `cost_observability.tsv` file for Exome, BGE, VETS and VQSR for both 20/X/Y and all chromosomes to match the currently observed Storage API usage with a 500 wide extract scatter.