### PR TITLE
Fix gCNV retry seed being deterministic and potentially negative

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/GermlineCNVCaller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/GermlineCNVCaller.java
@@ -371,8 +371,7 @@ public final class GermlineCNVCaller extends CommandLineProgram {
         if (pythonProcessOutput.getExitValue() != 0) {
             // We restart once if the inference diverged
             if (pythonProcessOutput.getExitValue() == DIVERGED_INFERENCE_EXIT_CODE) {
-                final Random generator = new Random(STARTING_SEED);
-                final int nextGCNVSeed = generator.nextInt();
+                final int nextGCNVSeed = generateRetrySeed();
                 logger.info("The inference failed to converge and will be restarted once with a different random seed.");
                 pythonProcessOutput = executor.executeScriptAndGetOutput(
                         new Resource(script, GermlineCNVCaller.class),
@@ -476,6 +475,10 @@ public final class GermlineCNVCaller extends CommandLineProgram {
                     intervalSubsetReadCountFiles.add(intervalSubsetReadCountFile);
                 });
         return intervalSubsetReadCountFiles;
+    }
+
+    static int generateRetrySeed() {
+        return new Random().nextInt(Integer.MAX_VALUE);
     }
 
     private List<String> composePythonArguments(final List<File> intervalSubsetReadCountFiles, final int randomSeed) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/copynumber/GermlineCNVCallerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/copynumber/GermlineCNVCallerUnitTest.java
@@ -1,0 +1,39 @@
+package org.broadinstitute.hellbender.tools.copynumber;
+
+import org.broadinstitute.hellbender.GATKBaseTest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Unit tests for {@link GermlineCNVCaller}.
+ */
+public final class GermlineCNVCallerUnitTest extends GATKBaseTest {
+
+    @Test
+    public void testGenerateRetrySeedIsNonNegative() {
+        for (int i = 0; i < 1000; i++) {
+            final int seed = GermlineCNVCaller.generateRetrySeed();
+            Assert.assertTrue(seed >= 0, "Retry seed must be non-negative (valid for numpy RandomState), but got: " + seed);
+        }
+    }
+
+    @Test
+    public void testGenerateRetrySeedIsLessThanMaxInt() {
+        for (int i = 0; i < 1000; i++) {
+            final int seed = GermlineCNVCaller.generateRetrySeed();
+            Assert.assertTrue(seed < Integer.MAX_VALUE, "Retry seed must be less than Integer.MAX_VALUE, but got: " + seed);
+        }
+    }
+
+    @Test
+    public void testGenerateRetrySeedIsNonDeterministic() {
+        final Set<Integer> seeds = new HashSet<>();
+        for (int i = 0; i < 100; i++) {
+            seeds.add(GermlineCNVCaller.generateRetrySeed());
+        }
+        Assert.assertTrue(seeds.size() > 1, "Retry seeds should not all be identical across calls");
+    }
+}


### PR DESCRIPTION
When inference diverges and we retry, we were initializing Random with a constant seed via `new Random(STARTING_SEED).nextInt()`. This had two problems: the retry seed was always the same value, and nextInt() can return negative integers, which are rejected by numpy's RandomState in the Python script, This caused the retry to immediately crash rather than attempt convergence.

Fixed by using `new Random().nextInt(Integer.MAX_VALUE)` so the retry gets a genuinely different, non-negative seed each time.

Added a unit test to cover the new generateRetrySeed method.