### PR TITLE
Bug fix for CleanVcf

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVReviseMultiallelicCnvs.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVReviseMultiallelicCnvs.java
@@ -245,8 +245,8 @@ public class SVReviseMultiallelicCnvs extends VariantWalker {
             if (sampleRdCn.values().stream().filter(value -> value > 4).count() > maxVF) {
                 multiallelicFilter = true;
             }
-            if (sampleRdCn.values().stream().filter(value -> (value < 1 || value > 4)).count() > 4) {
-                if (sampleRdCn.values().stream().filter(value -> (value < 1 || value > 4)).distinct().count() > maxVF) {
+            if (sampleRdCn.values().stream().filter(value -> (value < 1 || value > 4)).distinct().count() > 4) {
+                if (sampleRdCn.values().stream().filter(value -> (value < 1 || value > 4)).count() > maxVF) {
                     multiallelicFilter = true;
                 }
             }


### PR DESCRIPTION
Fix for _CleanVcf_ logic inconsistency identified by @epiercehoffman.

Comparisons of runs can be found in https://app.terra.bio/#workspaces/broad-firecloud-dsde-methods/kj-cleanvcf-bugfix/submission_history?dateRange=30. 4 variants dropped from the original VCF, 5 variants added to the new VCF. 