### PR TITLE
VAT documentation cleanup [VS-1854]

### DIFF
--- a/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
+++ b/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
@@ -23,6 +23,9 @@
   - [GvsCreateVDS](https://dockstore.org/workflows/github.com/broadinstitute/gatk/GvsCreateVDS) workflow
   - [GvsCreateVATfromVDS](https://dockstore.org/workflows/github.com/broadinstitute/gatk/GvsCreateVATfromVDS) workflow
   - [GvsValidateVat](https://dockstore.org/my-workflows/github.com/broadinstitute/gatk/GvsValidateVat) workflow
+  - [GvsCreateParticipantMappingTable](https://dockstore.org/my-workflows/github.com/broadinstitute/gatk/GvsCreateParticipantMappingTable) workflow
+  - [GvsMapUnmappedVIDs](https://dockstore.org/my-workflows/github.com/broadinstitute/gatk/GvsMapUnmappedVIDs) workflow
+  - [GvsMapDroppedDuplicateVIDs](https://dockstore.org/my-workflows/github.com/broadinstitute/gatk/GvsMapDroppedDuplicateVIDs) workflow
 - Once the Foxtrot sample list becomes available, perform some checks:
   - Make sure there are columns for reblocked VCFs and reblocked VCF indexes. The column headers will likely be
     `reblocked_gvcf` and `reblocked_gvcf_index`. Do not be alarmed by the presence of "hard-filtered" in file names,
@@ -191,13 +194,6 @@ To create a BigQuery table of variant annotations, you may follow the instructio
 [process to create variant annotations table](../../variant-annotations-table/README.md)
 The pipeline takes in the VDS and outputs a variant annotations table in BigQuery.
 
-Once the VAT table is created and a tsv is exported, the AoU research workbench team should be notified of its creation and permission should be granted so that several members of the team have view permission.
-
-- Grant `BigQuery Data Viewer` permission to specific people's PMI-OPS accounts. This will include members of the AoU research workbench team.
-- Copy the tarred and bgzipped export of the VAT into the pre-delivery bucket.
-- Send an email out notifying the AoU research workbench team of the readiness of the VAT. Additionally, a RW Jira ticket will be made by project management to request copying the VAT to pre-prod.
-- A document describing how this information was shared (for previous callsets) is located [here](https://docs.google.com/document/d/1caqgCS1b_dDJXQT4L-tRxjOkLGDgRNkO9eac1xd9ib0/edit)
-
 ## Additional Deliverables
 
 ### Smaller Interval Lists
@@ -255,12 +251,3 @@ You can take advantage of our existing sub-cohort WDL, `GvsExtractCohortFromSamp
     - For `GvsExtractCallsetPgen` (which is called by `GvsExtractCallsetPgenMerged`), if one (or several) of the `PgenExtractTask` shards fail because of angry cloud, you can re-run the workflow with the exact same inputs with call caching turned on; the successful shards will cache and only the failed ones will re-run.
     - If you want to collect the monitoring logs from a large number of `Extract` shards, the `summarize_task_monitor_logs.py` script will not work if the task is scattered too wide.  Use the `summarize_task_monitor_logs_from_file.py` script, instead, which takes a FOFN of GCS paths instead of a space-separated series of localized files.
     - This workflow does not use the Terra Data Entity Model to run, so be sure to select the `Run workflow with inputs defined by file paths` workflow submission option.
-
-
-### VID to Participant ID Mapping Table
-Once the VAT has been created, you will need to create the VID to Participant ID Mapping Table by following the
-[instructions in the VAT README](../../variant-annotations-table/README.md#vid-to-participant-id-mapping-table).
-
-#### Delivery Steps
-1. Copy the created mapping table to the dataset specified by the All of Us DRC. I specifically reached out to Justin Cook and Brian Freeman for the dataset to copy to.
-

--- a/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
+++ b/scripts/variantstore/docs/aou/AOU_DELIVERABLES.md
@@ -258,34 +258,9 @@ You can take advantage of our existing sub-cohort WDL, `GvsExtractCohortFromSamp
 
 
 ### VID to Participant ID Mapping Table
-Once the VAT has been created, you will need to create a database table mapping the VIDs (Variant IDs) from that table to all the participants in the dataset that share that VID. This table is used by the AoU Researcher Workbench, and will need to be copied over to a location specified by them. 
-
-1. First run `GvsCreateParticipantMappingTable.wdl` to create this participant ID mapping table and most of its data.
-   Specify the `project_id`, `dataset` and `vat_table_name` for the VAT created above. Also specify the `participant_mapping_table_name` that
-   will be created to hold the VID to participant mapping information.
-1. Next run `GvsMapUnmappedVIDs.wdl` to recover participant ID mappings for "unmapped VIDs" (a.k.a "pseudo VIDs"). These unmapped VIDs have
-   VAT table entries but no corresponding `alt_allele` entries and correspond to data that appeared in
-   input VCFs only in non-left aligned representations. During the process of creating the VAT these variants were left-aligned and thus
-   disconnected from their `alt_allele` representations. Specify the following parameters:
-   1. `project_id`, `dataset`, `vat_table_name`, `participant_mapping_table_name`: use the same values as in the step above for `GvsCreateParticipantMappingTable.wdl`.
-   1. `sites_only_vcf`: the GCS path to the sites-only VCF file that was generated in the process of creating the VAT. This corresponds to the `output_file_path` output of the `CopySitesOnlyVcf` task in `GvsCreateVATFromVDS.wdl`.
-   1. `unmapped_vid_mapping_table_name`: the name to use for a table that will hold the mapping information from input
-       position/ref/alt to left-aligned position/ref/alt. This should be a new table.
-1. Finally run `GvsMapDroppedDuplicateVIDs.wdl` to recover all participant ID mappings for VIDs which had multiple variant synonyms with AC != 0. The logic in `GvsCreateVATFromVDS` currently preserves a left-aligned version of the
-   synonym with the highest AC, but before running `GvsMapDroppedDuplicateVIDs.wdl` the actual participant mapping will only contain samples whose input synonym was left-aligned, which do not necessarily correspond to the synonym with highest AC.
-   1. `project_id`, `dataset`, `vat_table_name`, `participant_mapping_table_name`: use the same values as in the step above for `GvsCreateParticipantMappingTable.wdl`.
-   1. `sites_only_vcf`: the GCS path to the sites-only VCF file that was generated in the process of creating the VAT. This corresponds to the `output_file_path` output of the `CopySitesOnlyVcf` task in `GvsCreateVATFromVDS.wdl`.
-       This should be the same value as specified for the `GvsMapUnmappedVIDs.wdl` step above.
-   1. `filtered_synonyms`: the GCS path to the file of variant synonyms that were filtered as duplicates. This corresponds to the value of the `output_file` output of the `MergeDroppedSynonyms` task in `GvsCreateVATFromVDS.wdl`.
-   1. `dropped_duplicate_table_name`: the name to use for a table that will hold the mapping information from input
-      position/ref/alt to left-aligned position/ref/alt. This should be a new table.
+Once the VAT has been created, you will need to create the VID to Participant ID Mapping Table by following the
+[instructions in the VAT README](../../variant-annotations-table/README.md#vid-to-participant-id-mapping-table).
 
 #### Delivery Steps
 1. Copy the created mapping table to the dataset specified by the All of Us DRC. I specifically reached out to Justin Cook and Brian Freeman for the dataset to copy to.
 
-1. Note well that there will be a small difference in the number of vids in the VAT and that in the new mapping table that you have just created. For the Echo callset there are 3595 vids in the VAT that don't exist in the new mapping table (use the query below to determine them). The difference occurs because when we generate annotations using Nirvana, Nirvana left align and truncates the indels. For some of these indels, they now are remapped to a slightly different location than we had defined them as in the `alt_allele` table. This is a known issue that will be resolved in a future release.
-
-    ```
-   select distinct vid from `<dataset>.<vat_table_name>` where vid not in (select vid from `<dataset>.<mapping_table_name>`) ;
-    ```
-   Instructions for adding these "unmapped VIDs" into the participant mapping table are forthcoming.

--- a/scripts/variantstore/variant-annotations-table/GvsMapDroppedDuplicateVIDs.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsMapDroppedDuplicateVIDs.wdl
@@ -7,7 +7,7 @@ workflow GvsMapDroppedDuplicateVIDs {
     input {
         File sites_only_vcf
         File filtered_synonyms
-        String project
+        String project_id
         String dataset
         String participant_mapping_table_name
         String duplicate_mapping_table_name
@@ -25,7 +25,7 @@ workflow GvsMapDroppedDuplicateVIDs {
 
     call MapDroppedDuplicateVIDs {
         input:
-            project = project,
+            project_id = project_id,
             dataset = dataset,
             participant_mapping_table_name = participant_mapping_table_name,
             sites_only_vcf = sites_only_vcf,
@@ -39,7 +39,7 @@ workflow GvsMapDroppedDuplicateVIDs {
 
 task MapDroppedDuplicateVIDs {
     input {
-        String project
+        String project_id
         String dataset
         String participant_mapping_table_name
         File sites_only_vcf
@@ -118,7 +118,7 @@ task MapDroppedDuplicateVIDs {
         python /app/map_input_alignments_to_left_alignments.py to_search.sort.dedup.vcf hits_only.vcf > dropped_duplicate_mappings.tsv
 
         # 12. Load the duplicate vid mapping into BigQuery
-        bq load --project_id ~{project} --source_format=CSV --skip_leading_rows=1 --field_delimiter="\t" \
+        bq load --project_id ~{project_id} --source_format=CSV --skip_leading_rows=1 --field_delimiter="\t" \
             ~{dataset}.~{duplicate_mapping_table_name} dropped_duplicate_mappings.tsv \
             vid:STRING,chr:STRING,input_location:INTEGER,input_position:INTEGER,input_ref:STRING,input_alt:STRING,left_aligned_location:INTEGER,left_aligned_position:INTEGER,left_aligned_ref:STRING,left_aligned_alt:STRING,info_field:STRING
 
@@ -126,7 +126,7 @@ task MapDroppedDuplicateVIDs {
         #
         # bq query --max_rows check: ok delete
         #
-        bq --apilog=false query --nouse_legacy_sql --project_id=~{project} --format=csv '
+        bq --apilog=false query --nouse_legacy_sql --project_id=~{project_id} --format=csv '
 
         DELETE `~{dataset}.~{participant_mapping_table_name}` WHERE vid IN (
             SELECT dup.vid FROM `~{dataset}.~{duplicate_mapping_table_name}` dup
@@ -139,7 +139,7 @@ task MapDroppedDuplicateVIDs {
         #
         # bq query --max_rows check: ok insert
         #
-        bq --apilog=false query --nouse_legacy_sql --project_id=~{project} --format=csv '
+        bq --apilog=false query --nouse_legacy_sql --project_id=~{project_id} --format=csv '
 
         INSERT into `~{dataset}.~{participant_mapping_table_name}` (vid, person_ids)
         SELECT

--- a/scripts/variantstore/variant-annotations-table/GvsMapUnmappedVIDs.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsMapUnmappedVIDs.wdl
@@ -6,7 +6,7 @@ import "../structs/Range.wdl" as Range
 workflow GvsMapUnmappedVIDs {
     input {
         File sites_only_vcf
-        String project
+        String project_id
         String dataset
         String vat_table_name
         String participant_mapping_table_name
@@ -25,7 +25,7 @@ workflow GvsMapUnmappedVIDs {
 
     call MapUnmappedVIDs {
         input:
-            project = project,
+            project_id = project_id,
             dataset = dataset,
             vat_table_name = vat_table_name,
             participant_mapping_table_name = participant_mapping_table_name,
@@ -39,7 +39,7 @@ workflow GvsMapUnmappedVIDs {
 
 task MapUnmappedVIDs {
     input {
-        String project
+        String project_id
         String dataset
         String vat_table_name
         String participant_mapping_table_name
@@ -60,7 +60,7 @@ task MapUnmappedVIDs {
         set -o errexit -o nounset -o pipefail -o xtrace
 
         # 1. Get the unmapped VIDs.
-        bq --apilog=false query --use_legacy_sql=false --project_id=~{project} --format=csv --max_rows 1000000000 '
+        bq --apilog=false query --use_legacy_sql=false --project_id=~{project_id} --format=csv --max_rows 1000000000 '
 
             CREATE TEMP FUNCTION vidToLocation(vid string)
              RETURNS int64
@@ -122,12 +122,12 @@ task MapUnmappedVIDs {
         python /app/map_input_alignments_to_left_alignments.py to_search.sort.dedup.vcf hits_only.vcf > unmapped_vid_mappings.tsv
 
         # 11. Load the unmapped vid mapping into BigQuery
-        bq load --project_id ~{project} --source_format=CSV --skip_leading_rows=1 --field_delimiter="\t" \
+        bq load --project_id ~{project_id} --source_format=CSV --skip_leading_rows=1 --field_delimiter="\t" \
             ~{dataset}.~{unmapped_vid_mapping_table_name} unmapped_vid_mappings.tsv \
             vid:STRING,chr:STRING,input_location:INTEGER,input_position:INTEGER,input_ref:STRING,input_alt:STRING,left_aligned_location:INTEGER,left_aligned_position:INTEGER,left_aligned_ref:STRING,left_aligned_alt:STRING,info_field:STRING
 
         # 12. Add the mappings for these no-longer-unmapped VIDs into the mapping table.
-        bq --apilog=false query --nouse_legacy_sql --project_id=~{project} --format=csv '
+        bq --apilog=false query --nouse_legacy_sql --project_id=~{project_id} --format=csv '
 
         INSERT into `~{dataset}.~{participant_mapping_table_name}` (vid, person_ids)
         SELECT

--- a/scripts/variantstore/variant-annotations-table/README.md
+++ b/scripts/variantstore/variant-annotations-table/README.md
@@ -12,7 +12,7 @@ The pipeline takes in a Hail Variant Dataset (VDS) or a sites only VCF, creates 
 
 The Variants team created a Cromwell reference image containing all reference files used by Nirvana 3.18.1. This is
 useful to avoid having to download tens of GiBs of Nirvana references in each shard of the scattered `AnnotateVCF` task.
-In order to use this reference disk, the 'Use reference disk' option in Terra must be selected as shown below:
+In order to use this reference disk, the 'Use reference disks' option in Terra must be selected as shown below:
 
 ![Terra Use reference disks](Reference%20Disk%20Terra%20Opt%20In.png)
 
@@ -64,23 +64,23 @@ Once the VAT has been created, you will need to create a database table mapping 
    input VCFs only in non-left aligned representations. During the process of creating the VAT these variants were left-aligned and thus
    disconnected from their `alt_allele` representations. Specify the following parameters:
    1. `project_id`, `dataset`, `vat_table_name`, `participant_mapping_table_name`: use the same values as in the step above for `GvsCreateParticipantMappingTable.wdl`.
-   1. `sites_only_vcf`: the GCS path to the sites-only VCF file that was generated in the process of creating the VAT. This corresponds to the `output_file_path` output of the `CopySitesOnlyVcf` task in `GvsCreateVATFromVDS.wdl`.
+   1. `sites_only_vcf`: the GCS path to the sites-only VCF file that was generated in the process of creating the VAT. This corresponds to the `output_file_path` output of the `CopySitesOnlyVcf` task in `GvsCreateVATfromVDS.wdl`.
    1. `unmapped_vid_mapping_table_name`: the name to use for a table that will hold the mapping information from input
        position/ref/alt to left-aligned position/ref/alt. This should be a new table.
-1. Finally run `GvsMapDroppedDuplicateVIDs.wdl` to recover all participant ID mappings for VIDs which had multiple variant synonyms with AC != 0. The logic in `GvsCreateVATFromVDS` currently preserves a left-aligned version of the
+1. Finally run `GvsMapDroppedDuplicateVIDs.wdl` to recover all participant ID mappings for VIDs which had multiple variant synonyms with AC != 0. The logic in `GvsCreateVATfromVDS` currently preserves a left-aligned version of the
    synonym with the highest AC, but before running `GvsMapDroppedDuplicateVIDs.wdl` the actual participant mapping will only contain samples whose input synonym was left-aligned, which do not necessarily correspond to the synonym with highest AC.
    Specify the following parameters:
    1. `project_id`, `dataset`, `vat_table_name`, `participant_mapping_table_name`: use the same values as in the step above for `GvsCreateParticipantMappingTable.wdl`.
-   1. `sites_only_vcf`: the GCS path to the sites-only VCF file that was generated in the process of creating the VAT. This corresponds to the `output_file_path` output of the `CopySitesOnlyVcf` task in `GvsCreateVATFromVDS.wdl`.
+   1. `sites_only_vcf`: the GCS path to the sites-only VCF file that was generated in the process of creating the VAT. This corresponds to the `output_file_path` output of the `CopySitesOnlyVcf` task in `GvsCreateVATfromVDS.wdl`.
        This should be the same value as specified for the `GvsMapUnmappedVIDs.wdl` step above.
-   1. `filtered_synonyms`: the GCS path to the file of variant synonyms that were filtered as duplicates. This corresponds to the value of the `output_file` output of the `MergeDroppedSynonyms` task in `GvsCreateVATFromVDS.wdl`.
-   1. `dropped_duplicate_table_name`: the name to use for a table that will hold the mapping information from input
+   1. `filtered_synonyms`: the GCS path to the file of variant synonyms that were filtered as duplicates. This corresponds to the value of the `output_file` output of the `MergeDroppedSynonyms` task in `GvsCreateVATfromVDS.wdl`.
+   1. `duplicate_mapping_table_name`: the name to use for a table that will hold the mapping information from input
       position/ref/alt to left-aligned position/ref/alt. This should be a new table.
 
 ### Delivery Steps
-1. Once the VAT table is created and a TSV is exported, the AoU researcher workbench team should be notified of its creation and permission should be granted so that several members of the team have view permission.
-    - Grant `BigQuery Data Viewer` permission to specific people's PMI-OPS accounts. This will include members of the AoU research workbench team.
+1. Once the VAT table is created and a TSV is exported, the AoU Researcher Workbench team should be notified of its creation and permission should be granted so that several members of the team have view permission.
+    - Grant `BigQuery Data Viewer` permission to specific people's PMI-OPS accounts. This will include members of the AoU Researcher Workbench team.
     - Copy the tarred and bgzipped export of the VAT into the pre-delivery bucket.
-    - Send an email out notifying the AoU research workbench team of the readiness of the VAT. Additionally, a RW Jira ticket will be made by project management to request copying the VAT to pre-prod.
+    - Send an email out notifying the AoU Researcher Workbench team of the readiness of the VAT. Additionally, a RW Jira ticket will be made by project management to request copying the VAT to pre-prod.
     - A document describing how this information was shared (for previous callsets) is located [here](https://docs.google.com/document/d/1caqgCS1b_dDJXQT4L-tRxjOkLGDgRNkO9eac1xd9ib0/edit)
 1. Copy the created mapping table to the dataset specified by the All of Us DRC. I specifically reached out to Justin Cook and Brian Freeman for the dataset to copy to.

--- a/scripts/variantstore/variant-annotations-table/README.md
+++ b/scripts/variantstore/variant-annotations-table/README.md
@@ -8,6 +8,14 @@ The pipeline takes in a Hail Variant Dataset (VDS) or a sites only VCF, creates 
 - [GvsCreateVATfromVDS.wdl](/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl) creates a sites only VCF from a VDS if no input sites only VCF is specified, and then uses that and an ancestry file TSV to build the VAT.
 - [GvsValidateVAT.wdl](/scripts/variantstore/variant-annotations-table/GvsValidateVAT.wdl) checks and validates the created VAT and prints a report of any failing validation.
 
+### Using the Nirvana reference image in Terra (AoU Echo and later callsets)
+
+The Variants team created a Cromwell reference image containing all reference files used by Nirvana 3.18.1. This is
+useful to avoid having to download tens of GiBs of Nirvana references in each shard of the scattered `AnnotateVCF` task.
+In order to use this reference disk, the 'Use reference disk' option in Terra must be selected as shown below:
+
+![Terra Use reference disks](Reference%20Disk%20Terra%20Opt%20In.png)
+
 ### Run GvsCreateVATfromVDS
 
 - **Note:** in order for this workflow to run successfully the 'Use reference disks' option must be selected in Terra workflow
@@ -69,10 +77,3 @@ Once the VAT has been created, you will need to create a database table mapping 
    1. `dropped_duplicate_table_name`: the name to use for a table that will hold the mapping information from input
       position/ref/alt to left-aligned position/ref/alt. This should be a new table.
 
-### Using the Nirvana reference image in Terra (AoU Echo and later callsets)
-
-The Variants team created a Cromwell reference image containing all reference files used by Nirvana 3.18.1. This is
-useful to avoid having to download tens of GiBs of Nirvana references in each shard of the scattered `AnnotateVCF` task.
-In order to use this reference disk, the 'Use reference disk' option in Terra must be selected as shown below:
-
-![Terra Use reference disks](Reference%20Disk%20Terra%20Opt%20In.png)

--- a/scripts/variantstore/variant-annotations-table/README.md
+++ b/scripts/variantstore/variant-annotations-table/README.md
@@ -83,4 +83,4 @@ Once the VAT has been created, you will need to create a database table mapping 
     - Copy the tarred and bgzipped export of the VAT into the pre-delivery bucket.
     - Send an email out notifying the AoU Researcher Workbench team of the readiness of the VAT. Additionally, a RW Jira ticket will be made by project management to request copying the VAT to pre-prod.
     - A document describing how this information was shared (for previous callsets) is located [here](https://docs.google.com/document/d/1caqgCS1b_dDJXQT4L-tRxjOkLGDgRNkO9eac1xd9ib0/edit)
-1. Copy the created mapping table to the dataset specified by the All of Us DRC. I specifically reached out to Justin Cook and Brian Freeman for the dataset to copy to.
+1. Copy the created mapping table to the dataset specified by the All of Us DRC. Further details of this process are included in the Google Doc linked in the previous step.

--- a/scripts/variantstore/variant-annotations-table/README.md
+++ b/scripts/variantstore/variant-annotations-table/README.md
@@ -11,7 +11,7 @@ The pipeline takes in a Hail Variant Dataset (VDS) or a sites only VCF, creates 
 ### Run GvsCreateVATfromVDS
 
 - **Note:** in order for this workflow to run successfully the 'Use reference disks' option must be selected in Terra workflow
-configuration. If this option is not selected the `AnnotateVCF` tasks will refuse to run. If you forget and it fails, re-run it with call-caching on and all the same inputs, and it will resume at the right point.
+configuration. If this option is not selected the `AnnotateVCF` tasks will fail because the Nirvana reference files will not be found. If you forget and it fails, re-run it with call-caching on and all the same inputs, and it will resume at the right point.
 - **Note:** due to an [open issue with GCP Batch](https://partnerissuetracker.corp.google.com/issues/449751210) it is expected that some shards of `GenerateVepAndLofteeAnnotations` will fail
 with 50002 errors that are caused by this task consuming all the memory on the VM, leaving the Batch agent unable to checkin with the Batch service.
 If and when the workflow fails in this manner, double the value in the `memory` runtime attribute of the `GenerateVepAndLofteeAnnotations` task  and rerun `GvsCreateVATfromVDS` with call caching enabled.
@@ -30,30 +30,15 @@ Optional inputs of note:
 - `vat_version`: if you are creating multiple VATs for one callset, you can distinguish between them (and not overwrite others) by passing in increasing numbers
 - If you are debugging a Hail-related issue, you may want to set `leave_hail_cluster_running_at_end` to `true` and refer to [the suggestions for debugging issues with Hail](../docs/aou/HAIL_DEBUGGING.md). 
 
-There are two temporary tables that are created in addition to the main VAT table: the Genes and VT tables. They have a time to live of 24 hours.  The VAT table is created by that query fresh each time so that there is no risk of duplicates.
+There are several temporary tables that are created in addition to the main VAT table. The Genes, VT (variant transcripts), and intermediate `_w_dups` VAT tables all have a time to live of 24 hours. The VEP/LOFTEE raw and cooked tables have a time to live of 3 days. The final VAT table is (re)created fresh each time so that there is no risk of duplicates.
 
 Variants may be filtered out of the VAT (that were in the VDS) for the following reasons:
 
 - they are hard-filtered out based on the initial soft filtering from the GVS extract (site- and GT-level filtering)
 - they have excess alternate alleles, currently that cut off is 50 alternate alleles
 - they are spanning deletions
-- they are duplicate variants; they are tracked via the `GvsCreateVATfromVDS` workflow's scattered `RemoveDuplicatesFromSites` task and then merged into one file by the `MergeTsvs` task
+- they are duplicate variants; they are tracked via the `GvsCreateVATfromVDS` workflow's scattered `RemoveDuplicatesFromSitesOnlyVCF` task and then merged into one file by the `MergeTsvs` task
 
-### Remove duplicates from the VAT table.
-
-There is a bug in the way we build the VAT table from the shards. If a variant (e.g. for an insertion or deletion) spans between the end of one shard and the beginning of the next shard, it will be entered TWICE into the resultant vat table as there will be duplicate entries in each of the shards. To address this issue, we run a manual SQL statement in BigQuery in order to remove these duplicates.
-**Note:** The purpose of this query is to create a NEW copy of the VAT table with the duplicates removed. So, when you run it, have BigQuery write the output to a new table (More -> Query Settings -> Destination )
-
->     select * except(row_number) from (
->      SELECT
->       *,
->       row_number()
->       over (partition by vid, transcript)
->       row_number
->       FROM
->        `<project_id>.<dataset>.<vat_table_name>`    
->       )
->     where row_number = 1;
 
 ### Run GvsValidateVAT
 

--- a/scripts/variantstore/variant-annotations-table/README.md
+++ b/scripts/variantstore/variant-annotations-table/README.md
@@ -44,6 +44,31 @@ Variants may be filtered out of the VAT (that were in the VDS) for the following
 
 This workflow does not use the Terra Data Entity Model to run, so be sure to select the `Run workflow with inputs defined by file paths` workflow submission option. The `project_id` and `dataset_name` are the same as those used for `GvsCreateVATfromVDS`, and `vat_table_name` is `filter_set_name` + "_vat" (+ "_v" + `vat_version`, if used).
 
+### VID to Participant ID Mapping Table
+
+Once the VAT has been created, you will need to create a database table mapping the VIDs (Variant IDs) from that table to all the participants in the dataset that share that VID. This table is used by the AoU Researcher Workbench, and will need to be copied over to a location specified by them.
+
+1. First run `GvsCreateParticipantMappingTable.wdl` to create this participant ID mapping table and most of its data.
+   Specify the `project_id`, `dataset` and `vat_table_name` for the VAT created above. Also specify the `participant_mapping_table_name` that
+   will be created to hold the VID to participant mapping information.
+1. Next run `GvsMapUnmappedVIDs.wdl` to recover participant ID mappings for "unmapped VIDs" (a.k.a "pseudo VIDs"). These unmapped VIDs have
+   VAT table entries but no corresponding `alt_allele` entries and correspond to data that appeared in
+   input VCFs only in non-left aligned representations. During the process of creating the VAT these variants were left-aligned and thus
+   disconnected from their `alt_allele` representations. Specify the following parameters:
+   1. `project_id`, `dataset`, `vat_table_name`, `participant_mapping_table_name`: use the same values as in the step above for `GvsCreateParticipantMappingTable.wdl`.
+   1. `sites_only_vcf`: the GCS path to the sites-only VCF file that was generated in the process of creating the VAT. This corresponds to the `output_file_path` output of the `CopySitesOnlyVcf` task in `GvsCreateVATFromVDS.wdl`.
+   1. `unmapped_vid_mapping_table_name`: the name to use for a table that will hold the mapping information from input
+       position/ref/alt to left-aligned position/ref/alt. This should be a new table.
+1. Finally run `GvsMapDroppedDuplicateVIDs.wdl` to recover all participant ID mappings for VIDs which had multiple variant synonyms with AC != 0. The logic in `GvsCreateVATFromVDS` currently preserves a left-aligned version of the
+   synonym with the highest AC, but before running `GvsMapDroppedDuplicateVIDs.wdl` the actual participant mapping will only contain samples whose input synonym was left-aligned, which do not necessarily correspond to the synonym with highest AC.
+   Specify the following parameters:
+   1. `project_id`, `dataset`, `vat_table_name`, `participant_mapping_table_name`: use the same values as in the step above for `GvsCreateParticipantMappingTable.wdl`.
+   1. `sites_only_vcf`: the GCS path to the sites-only VCF file that was generated in the process of creating the VAT. This corresponds to the `output_file_path` output of the `CopySitesOnlyVcf` task in `GvsCreateVATFromVDS.wdl`.
+       This should be the same value as specified for the `GvsMapUnmappedVIDs.wdl` step above.
+   1. `filtered_synonyms`: the GCS path to the file of variant synonyms that were filtered as duplicates. This corresponds to the value of the `output_file` output of the `MergeDroppedSynonyms` task in `GvsCreateVATFromVDS.wdl`.
+   1. `dropped_duplicate_table_name`: the name to use for a table that will hold the mapping information from input
+      position/ref/alt to left-aligned position/ref/alt. This should be a new table.
+
 ### Using the Nirvana reference image in Terra (AoU Echo and later callsets)
 
 The Variants team created a Cromwell reference image containing all reference files used by Nirvana 3.18.1. This is

--- a/scripts/variantstore/variant-annotations-table/README.md
+++ b/scripts/variantstore/variant-annotations-table/README.md
@@ -77,3 +77,10 @@ Once the VAT has been created, you will need to create a database table mapping 
    1. `dropped_duplicate_table_name`: the name to use for a table that will hold the mapping information from input
       position/ref/alt to left-aligned position/ref/alt. This should be a new table.
 
+### Delivery Steps
+1. Once the VAT table is created and a TSV is exported, the AoU researcher workbench team should be notified of its creation and permission should be granted so that several members of the team have view permission.
+    - Grant `BigQuery Data Viewer` permission to specific people's PMI-OPS accounts. This will include members of the AoU research workbench team.
+    - Copy the tarred and bgzipped export of the VAT into the pre-delivery bucket.
+    - Send an email out notifying the AoU research workbench team of the readiness of the VAT. Additionally, a RW Jira ticket will be made by project management to request copying the VAT to pre-prod.
+    - A document describing how this information was shared (for previous callsets) is located [here](https://docs.google.com/document/d/1caqgCS1b_dDJXQT4L-tRxjOkLGDgRNkO9eac1xd9ib0/edit)
+1. Copy the created mapping table to the dataset specified by the All of Us DRC. I specifically reached out to Justin Cook and Brian Freeman for the dataset to copy to.


### PR DESCRIPTION
Assorted VAT documentation cleanup as we prepare to create the V9 r2 VAT. Centralize VAT docs in the VAT `README.md`, update parameter names for consistency, remove outdated steps, etc.