### PR TITLE
Large disk, more CPUs for VEP annotation loading [VS-1854]

### DIFF
--- a/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
@@ -980,8 +980,9 @@ task BigQueryLoadRawVepAndLofteeAnnotations {
     runtime {
         docker: variants_docker
         cpu: 16
-        memory: "7 GB"
+        memory: "16 GB"
         disks: "local-disk 4000 SSD"
+        preemptible: 0
     }
 
     output {

--- a/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
@@ -979,9 +979,9 @@ task BigQueryLoadRawVepAndLofteeAnnotations {
 
     runtime {
         docker: variants_docker
-        preemptible: 2
+        cpu: 16
         memory: "7 GB"
-        disks: "local-disk 1000 HDD"
+        disks: "local-disk 4000 SSD"
     }
 
     output {


### PR DESCRIPTION
Changes:

- 1 TiB disk was not enough for Foxtrot which had at least 2 TiB of VEP annotations to assemble.
- CPU bump for faster network speeds for transferring these TiBs of data around. 
- SSD so we can write data as fast as we transfer it. 
- `preemptible: 0` so we run this task only once with this pricey disk. Non-local disks are always full price; confusingly this "local-disk" is not actually a GCE `LOCAL` disk which can have preemptible pricing.