### PR TITLE
Document --arguments_file format

### DIFF
--- a/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.template.html
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.template.html
@@ -86,6 +86,14 @@
 			<b><@flagDeprecated arg=arg/>${arg.summary}</b><br />
 			${arg.fulltext}
 		</p>
+		<#if arg.name == "--arguments_file">
+			<p>Write argument files as whitespace-separated tokens, the same way the arguments would appear on the command line. A common style is one argument and its value per line:</p>
+			<pre><code>--variant sample1.g.vcf.gz
+--variant sample2.g.vcf.gz
+-O cohort.g.vcf.gz</code></pre>
+			<p>Blank lines are ignored. To add a comment, put <code>#</code> as the first character on the line. The file is split on whitespace and is not parsed by a shell, so quoting does not preserve spaces inside paths or values; avoid spaces in values used in an arguments file.</p>
+			<p>Repeat list-valued arguments just as you would on the command line. For example, provide multiple <code>--variant</code> lines when passing many inputs to a tool such as <code>CombineGVCFs</code>.</p>
+		</#if>
 		<#if arg.otherArgumentRequired != "NA">
 			<p><b>Dependency:</b> This argument requires that you also specify <code>${arg.otherArgumentRequired}</code>.</p>
 		</#if>


### PR DESCRIPTION
Addresses #8722

## Summary

- document the `--arguments_file` format in the generated argument detail for that shared argument
- clarify that argument files are whitespace-tokenized, not shell-parsed
- document blank lines, first-column `#` comments, and repeated list-valued arguments

## Validation

- `git diff --check` - passed
- `git lfs install --local && git lfs pull --include src/main/resources/large` - passed; fetched the LFS resources required by the documented docs generation task
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@17/bin:$PATH ./gradlew gatkDoc --no-daemon` - passed; final run reported `BUILD SUCCESSFUL in 2m 3s`
- `rg -n "Write argument files|Blank lines are ignored|Repeat list-valued|<a name=\"--arguments_file\"" build/docs/gatkdoc/org_broadinstitute_hellbender_tools_walkers_CombineGVCFs.html` - passed; generated CombineGVCFs docs include the new guidance under `--arguments_file`
- `coderabbit review --agent -t uncommitted` - passed; raised 0 issues

## Notes

- This is a docs-template-only change; no parser, CLI, or workflow behavior changed.
- I did not run the full unit test suite because the changed surface is generated documentation and `gatkDoc` is the relevant documented check.
