### PR TITLE
Fix wrong calibration sensitivities in VDS [VS-1945]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -340,6 +340,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - vs_1945_fix_wrong_calibration_sensitivities
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -340,7 +340,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1945_fix_wrong_calibration_sensitivities
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/scripts/import_gvs.py
+++ b/scripts/variantstore/scripts/import_gvs.py
@@ -338,8 +338,13 @@ def import_gvs(refs: 'List[List[str]]',
 
         vd = vd.annotate_rows(filters=hl.coalesce(site[vd.locus].filters, hl.empty_set(hl.tstr)))
 
-        # vets ref/alt come in normalized individually, so need to renormalize to the dataset ref allele
+        # vets ref/alt come in normalized individually, so need to renormalize to the dataset ref allele.
+        # Filter out records whose ref is longer than the dataset ref allele — these correspond to alleles from samples
+        # not present in this VDS (e.g. control or withdrawn samples). Without this filter, the renormalization formula
+        # produces a truncated key that can collide with a legitimate allele, silently replacing its
+        # calibration_sensitivity value in the dict.
         vd = vd.annotate_rows(as_vets = hl.dict(vets_filter.index(vd.locus, all_matches=True)
+                                                .filter(lambda record: hl.len(record.ref) <= hl.len(vd.alleles[0]))
                                                 .map(lambda record: (record.alt + vd.alleles[0][hl.len(record.ref):], record.drop('ref', 'alt')))))
 
         vd = vd.annotate_globals(truth_sensitivity_snp_threshold=truth_sensitivity_snp_threshold,

--- a/scripts/variantstore/scripts/merge_and_rescore_vdses.py
+++ b/scripts/variantstore/scripts/merge_and_rescore_vdses.py
@@ -102,10 +102,16 @@ def patch_variant_data(vd: hl.MatrixTable, site_filters: hl.Table, vets_filters:
         filters=hl.coalesce(site_filters[vd.locus].filters, hl.empty_set(hl.tstr))
     )
 
-    # vets ref/alt come in normalized individually, so need to renormalize to the dataset ref allele
+    # vets ref/alt come in normalized individually, so need to renormalize to the dataset ref allele.
+    # Filter out records whose ref is longer than the dataset ref allele — these correspond to alleles from samples
+    # not present in this VDS (e.g. control or withdrawn samples). Without this filter, the renormalization formula
+    # produces a truncated key that can collide with a legitimate allele, silently replacing its
+    # calibration_sensitivity value in the dict.
     vd = vd.annotate_rows(
         as_vets=hl.dict(
-            vets_filters.index(vd.locus, all_matches=True).map(
+            vets_filters.index(vd.locus, all_matches=True)
+            .filter(lambda record: hl.len(record.ref) <= hl.len(vd.alleles[0]))
+            .map(
                 lambda record: (
                     record.alt + vd.alleles[0][hl.len(record.ref) :],
                     record.drop("ref", "alt"),

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -131,7 +131,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-04-22-alpine-636408a165ee"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-05-22-alpine-a84ddd68b9fe"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-04-08-gatkbase-9434f9e8577f"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"


### PR DESCRIPTION
Successful integration run [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration%20mcovarr/submission_history/7ff9ef8d-bccd-4b72-b147-be14d5879cd0). This is really the same one-line fix in two spots, though the formatting of the surrounding code is very different in each spot.

**Background**

While the Hail VDS as produced by GVS represents variants in a joined variant context, the variant and VETS filter data exported from BigQuery to Avro files represents variants in non-joined (aka split or split multi-allelic) form. When importing these Avro files to make the VDS, there is a renormalization step that needs to map from the non-joined variant representation of the Avro files to the joined representation of the VDS.


GVS exports variant and reference data for only non-withdrawn, non-control samples, but exports *all* filter set data, even for variants carried only by control or withdrawn (after the filter set is created) samples. 


The reference allele in the VDS joined variant context will represent the longest deletion in the non-withdrawn, non-control data, or a single base if there are only SNPs and/or insertions at that locus.


**The collision mechanism**

The renormalization formula is:

```
record.alt + vd.alleles[0][hl.len(record.ref):]
```

When a long deletion that is carried only by control or withdrawn samples has a ref that is longer than the VDS reference allele given by `vd.alleles[0]`, the expression `vd.alleles[0][hl.len(record.ref):]` slices past the end of the reference allele, thus evaluating to an empty string. So the renormalized key becomes just `record.alt`, which will collide with a legitimate allele's key if there is a deletion in the VDS at that site.

A specific example:

1. Let's say the VDS reference allele at a locus is `vd.alleles[0]` = `"CCA"` (length 3). This implies existence of a variant allele `"C"` representing a two base deletion of `"CA"`.
1. If a control sample is the sole carrier of a long deletion its reference would be `"CCA<long suffix>"` (length >> 3), and its variant allele would be `"C"`.
1. Renormalization: `"C" + "CCA"[long_length:]` = `"C" + ""` = `"C"`.
1. This collides with the deletion `CCA => C` described in step 1 whose variant is also `"C"`.

**The fix**

Filter out VETS filter records whose reference sequence is longer than `vd.alleles[0]`, since those records cannot correspond to any allele in the current row's context and must be data from an allele carried only by control or withdrawn samples.