### PR TITLE
Symlink CLAUDE.md to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
My previously merged PR #9382 renamed `CLAUDE.md` to `AGENTS.md`. However after discussion with Nalini I learned that Claude actually does not read `AGENTS.md`. This PR creates a symlink that points `CLAUDE.md` to `AGENTS.md`.

git actually does support symlinks, although the way they are displayed in Github is rather strange...