### PR TITLE
Variants Docker image improvements [VS-1771]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -340,6 +340,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - vs_1771_leavings
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -337,9 +337,10 @@ workflows:
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
      filters:
-          branches:
-              - master
-              - ah_var_store
+         branches:
+             - master
+             - ah_var_store
+         tags:
              - /.*/
    - name: GvsIngestTieout
      subclass: WDL

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -337,11 +337,9 @@ workflows:
      subclass: WDL
      primaryDescriptorPath: /scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
      filters:
-         branches:
-             - master
-             - ah_var_store
-             - vs_1771_leavings
-         tags:
+          branches:
+              - master
+              - ah_var_store
              - /.*/
    - name: GvsIngestTieout
      subclass: WDL

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,11 @@ funcotator_tmp
 #Test generated dot files
 test*.dot
 .vscode/
+
+# To support headroom proxy caching and token compression
+# python -m venv venv
+# . ./venv/bin/activate
+# pip install "headroom-ai[all]"
+# HEADROOM_WORKSPACE_DIR=$PWD/.headroom_data headroom wrap claude --port <unique port>
+venv
+.headroom_data

--- a/scripts/variantstore/scripts/Dockerfile
+++ b/scripts/variantstore/scripts/Dockerfile
@@ -6,7 +6,7 @@
 # expensive to create and isn't expected to change often, while the steps in this Dockerfile are much less expensive and
 # more likely to change. Using a build-base image essentially allows the expensive layers to be globally cached which
 # should make building the final image much faster in most cases.
-FROM us.gcr.io/broad-dsde-methods/variantstore:2025-06-08-alpine-build-base AS build
+FROM us.gcr.io/broad-dsde-methods/variantstore:2026-06-16-alpine-build-base AS build
 
 # Install all of our variantstore Python requirements.
 # We constrain the version of setuptools to sidestep an issue in `terra-notebook-util`'s FISS dependency.
@@ -29,7 +29,6 @@ RUN mkdir /fiss-build && \
     . /localvenv/bin/activate && \
     python setup.py install
 
-
 # The main layer does not install development tools, instead copies artifacts from the build layer above.
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-alpine AS main
 
@@ -46,6 +45,8 @@ COPY --from=build /htslib /htslib
 COPY --from=build /bcftools /bcftools
 # Copy vcftools artifacts
 COPY --from=build /vcftools /vcftools
+# Copy bedtools artifacts
+COPY --from=build /bedtools /bedtools
 
 # Copy the application source code.
 RUN mkdir /app
@@ -58,7 +59,7 @@ RUN mkdir -p /data/variant_annotation_table/schema
 COPY ./variant_annotation_table/schema/*.json /data/variant_annotation_table/schema/
 
 ENV PERL5LIB=/vcftools/share/perl5/site_perl/
-ENV PATH=/bcftools/bin:/vcftools/bin:$PATH
+ENV PATH=/bcftools/bin:/vcftools/bin:/bedtools/bin:$PATH
 ENV LD_LIBRARY_PATH=/htslib/lib
 
 # Have the bash shell of the command script automatically activate the Python virtual environment.

--- a/scripts/variantstore/scripts/Dockerfile
+++ b/scripts/variantstore/scripts/Dockerfile
@@ -45,8 +45,6 @@ COPY --from=build /htslib /htslib
 COPY --from=build /bcftools /bcftools
 # Copy vcftools artifacts
 COPY --from=build /vcftools /vcftools
-# Copy bedtools artifacts
-COPY --from=build /bedtools /bedtools
 
 # Copy the application source code.
 RUN mkdir /app
@@ -59,7 +57,7 @@ RUN mkdir -p /data/variant_annotation_table/schema
 COPY ./variant_annotation_table/schema/*.json /data/variant_annotation_table/schema/
 
 ENV PERL5LIB=/vcftools/share/perl5/site_perl/
-ENV PATH=/bcftools/bin:/vcftools/bin:/bedtools/bin:$PATH
+ENV PATH=/bcftools/bin:/vcftools/bin:$PATH
 ENV LD_LIBRARY_PATH=/htslib/lib
 
 # Have the bash shell of the command script automatically activate the Python virtual environment.

--- a/scripts/variantstore/scripts/Dockerfile
+++ b/scripts/variantstore/scripts/Dockerfile
@@ -6,7 +6,7 @@
 # expensive to create and isn't expected to change often, while the steps in this Dockerfile are much less expensive and
 # more likely to change. Using a build-base image essentially allows the expensive layers to be globally cached which
 # should make building the final image much faster in most cases.
-FROM us.gcr.io/broad-dsde-methods/variantstore:2026-06-16-alpine-build-base AS build
+FROM us.gcr.io/broad-dsde-methods/variantstore:2026-06-23-alpine-build-base AS build
 
 # Install all of our variantstore Python requirements.
 # We constrain the version of setuptools to sidestep an issue in `terra-notebook-util`'s FISS dependency.

--- a/scripts/variantstore/scripts/build_base.Dockerfile
+++ b/scripts/variantstore/scripts/build_base.Dockerfile
@@ -6,7 +6,7 @@
 # Cromwell.
 #
 # Because this is an Alpine-based image it is more bare-bones than its Debian-based peers. Several tools used by GVS
-# (htslib, bcftools, vcftools, bedtools) are not available as Alpine packages and must be compiled from source.
+# (htslib, bcftools, vcftools) are not available as Alpine packages and must be compiled from source.
 # Compiling these tools makes this a moderately expensive image to create. Since this image isn't expected to change
 # often it's broken out into a separate "build-base" image that can effectively be globally cached and referenced from
 # the main Dockerfile.
@@ -64,15 +64,5 @@ RUN mkdir /vcftools /vcftools-build && \
     cd / && \
     rm -rf /vcftools-build
 
-ARG BEDTOOLS_VERSION=2.31.1
-RUN mkdir -p /bedtools /bedtools-build/src && \
-    cd /bedtools-build && \
-    curl -L -O https://github.com/arq5x/bedtools2/releases/download/v${BEDTOOLS_VERSION}/bedtools-${BEDTOOLS_VERSION}.tar.gz && \
-    tar -xzf bedtools-${BEDTOOLS_VERSION}.tar.gz -C src --strip-components=1 && \
-    cd src && \
-    make CXXFLAGS="-g -Wall -O2 -std=c++11 -include cstdint" && \
-    make prefix=/bedtools install && \
-    cd / && \
-    rm -rf /bedtools-build
 
 ENV PERL5LIB="/vcftools/share/perl5/site_perl/"

--- a/scripts/variantstore/scripts/build_base.Dockerfile
+++ b/scripts/variantstore/scripts/build_base.Dockerfile
@@ -1,9 +1,6 @@
 # This Dockerfile creates a "build-base" image with tools and libraries required to build the tools and libraries used
-# in the Genomic Variant Store pipeline. The Alpine version of the Google Cloud SDK is used as the base image which is
-# not only the most compact of the Google Cloud SDK Docker images, but is also the image currently used by Cromwell for
-# (de)localization of files in Google Cloud Storage. Sharing the base image with Cromwell's GCS localization should
-# result in reuse of a cached copy of this base (and by far largest) image layer when running GVS pipelines in Terra /
-# Cromwell.
+# in the Genomic Variant Store pipeline. The Alpine version of the Google Cloud SDK is used as the base image as it is
+# the most compact of the Google Cloud SDK Docker images.
 #
 # Because this is an Alpine-based image it is more bare-bones than its Debian-based peers. Several tools used by GVS
 # (htslib, bcftools, vcftools) are not available as Alpine packages and must be compiled from source.

--- a/scripts/variantstore/scripts/build_base.Dockerfile
+++ b/scripts/variantstore/scripts/build_base.Dockerfile
@@ -12,8 +12,7 @@
 # the main Dockerfile.
 #
 # Note: pyarrow was previously built from source here because Alpine's musl libc was incompatible with PyPI's
-# manylinux wheels. Apache Arrow 24+ ships musllinux wheels on PyPI, so pyarrow is now installed via pip in the
-# main Dockerfile's requirements.txt instead.
+# manylinux wheels. It has since been removed from the image entirely as no production code requires it.
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-alpine
 
 RUN apk update && apk upgrade

--- a/scripts/variantstore/scripts/build_base.Dockerfile
+++ b/scripts/variantstore/scripts/build_base.Dockerfile
@@ -5,64 +5,25 @@
 # result in reuse of a cached copy of this base (and by far largest) image layer when running GVS pipelines in Terra /
 # Cromwell.
 #
-# Because this is an Alpine-based image it is more bare-bones than its Debian-based peers. Key components missing here
-# are the Apache Arrow library (a requirement for pyarrow which in turn is a requirement for the google-cloud-bigquery
-# Python module) and bcftools. Compiling all these tools makes this a fairly expensive image to create (an hour or so
-# under ideal circumstances, potentially much longer on low memory and/or non-x86 build hosts). Since this image isn't
-# expected to change often it's broken out into a separate "build-base" image that can effectively be globally cached
-# and referenced from the main Dockerfile.
+# Because this is an Alpine-based image it is more bare-bones than its Debian-based peers. Several tools used by GVS
+# (htslib, bcftools, vcftools, bedtools) are not available as Alpine packages and must be compiled from source.
+# Compiling these tools makes this a moderately expensive image to create. Since this image isn't expected to change
+# often it's broken out into a separate "build-base" image that can effectively be globally cached and referenced from
+# the main Dockerfile.
+#
+# Note: pyarrow was previously built from source here because Alpine's musl libc was incompatible with PyPI's
+# manylinux wheels. Apache Arrow 24+ ships musllinux wheels on PyPI, so pyarrow is now installed via pip in the
+# main Dockerfile's requirements.txt instead.
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-alpine
 
 RUN apk update && apk upgrade
 
-# Add all required build tools. These will not be added to the main stage as they are only required to build PyArrow
-# and bcftools but not to use them.
-RUN apk add autoconf bash cmake g++ gcc make ninja python3-dev git openssl-dev zlib-dev xz-dev bzip2-dev curl-dev re2 re2-dev
+# Add all required build tools. These are not added to the main stage as they are only needed at compile time.
+RUN apk add autoconf bash g++ gcc make python3-dev git openssl-dev zlib-dev xz-dev bzip2-dev curl-dev
 RUN python3 -m venv /localvenv && . /localvenv/bin/activate && python3 -m ensurepip --upgrade
 
-# Unfortunately neither pyarrow nor google-cloud-bigquery will fetch or build Apache Arrow when `pip install`ed from
-# this base image. Therefore we do the Apache Arrow build ourselves. In order to keep the final image size small this
-# Dockerfile is set up to do a multi-stage build following the usual pattern of "build" stage / "main" stage.
-# https://docs.docker.com/build/building/multi-stage/#use-multi-stage-builds
-#
-# The build stage installs the required development tools, downloads the Apache Arrow source bundle and builds all
-# required components including Apache Arrow C++ libraries, pyarrow Python module, and all pyarrow dependencies
-# including the numpy Python module. The main stage will then use the same base image and copy over the artifacts
-# produced by the build stage without having to install development tools or clean up after a build.
 
-ARG ARROW_VERSION=20.0.0
-RUN cd / && \
-    curl -O https://archive.apache.org/dist/arrow/arrow-$ARROW_VERSION/apache-arrow-$ARROW_VERSION.tar.gz && \
-    tar xfz apache-arrow-$ARROW_VERSION.tar.gz
-
-# Pyarrow build instructions from https://arrow.apache.org/docs/developers/python.html#python-development
-# Modified slightly for the requirements of this installation:
-# - Download a static source tarball rather than cloning the git repo.
-# - Use `ninja` to build the C++ libraries as the `make` system doesn't seem to work as of Arrow 10.0.0.
-# - Install PyArrow and its dependencies
-ARG ARROW_SRC_DIR=/apache-arrow-$ARROW_VERSION
-RUN . /localvenv/bin/activate && pip3 install -r $ARROW_SRC_DIR/python/requirements-build.txt
-
-RUN mkdir $ARROW_SRC_DIR/cpp/build && \
-    cd $ARROW_SRC_DIR/cpp/build && \
-    cmake .. --preset ninja-release-python && \
-    cmake --build . && \
-    cmake --install . && \
-    rm /apache-arrow-$ARROW_VERSION.tar.gz
-
-ARG PYARROW_WITH_PARQUET=1
-ARG PYARROW_WITH_DATASET=1
-ARG PYARROW_PARALLEL=4
-RUN cd $ARROW_SRC_DIR/python && \
-    . /localvenv/bin/activate && \
-    python3 setup.py build_ext --inplace && \
-    pip3 install wheel && \
-    python3 setup.py build_ext --build-type=release \
-              --bundle-arrow-cpp bdist_wheel && \
-    pip3 install /apache-arrow-$ARROW_VERSION/python/dist/pyarrow-$ARROW_VERSION-*.whl
-
-
-ARG HTSLIB_VERSION=1.22
+ARG HTSLIB_VERSION=1.23.1
 RUN mkdir /htslib /htslib-build && \
     cd /htslib-build && \
     curl -L -O https://github.com/samtools/htslib/releases/download/${HTSLIB_VERSION}/htslib-${HTSLIB_VERSION}.tar.bz2 && \
@@ -76,7 +37,7 @@ RUN mkdir /htslib /htslib-build && \
     rm -rf /htslib-build
 
 
-ARG BCFTOOLS_VERSION=1.22
+ARG BCFTOOLS_VERSION=1.23.1
 RUN mkdir /bcftools /bcftools-build && \
     cd /bcftools-build && \
     curl -L -O https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2 && \
@@ -103,4 +64,15 @@ RUN mkdir /vcftools /vcftools-build && \
     cd / && \
     rm -rf /vcftools-build
 
-ENV PERL5LIB /vcftools/share/perl5/site_perl/:$PERL5LIB
+ARG BEDTOOLS_VERSION=2.31.1
+RUN mkdir -p /bedtools /bedtools-build/src && \
+    cd /bedtools-build && \
+    curl -L -O https://github.com/arq5x/bedtools2/releases/download/v${BEDTOOLS_VERSION}/bedtools-${BEDTOOLS_VERSION}.tar.gz && \
+    tar -xzf bedtools-${BEDTOOLS_VERSION}.tar.gz -C src --strip-components=1 && \
+    cd src && \
+    make CXXFLAGS="-g -Wall -O2 -std=c++11 -include cstdint" && \
+    make prefix=/bedtools install && \
+    cd / && \
+    rm -rf /bedtools-build
+
+ENV PERL5LIB="/vcftools/share/perl5/site_perl/"

--- a/scripts/variantstore/scripts/create_ranges_cohort_extract_data_table.py
+++ b/scripts/variantstore/scripts/create_ranges_cohort_extract_data_table.py
@@ -138,13 +138,22 @@ def create_extract_samples_table(control_samples, fq_destination_table_samples, 
 
 
 def _parse_interval_list(interval_list):
-    """Parse an interval_list file, yielding (chrom, start, end) tuples.
+    """Parse a Picard interval_list file, yielding (chrom, start, end) tuples.
     interval_list format is 1-based closed; GVS location encoding is also 1-based,
-    so coordinates are passed through unchanged."""
+    so coordinates are passed through unchanged.
+    Raises ValueError if the file has no '@' header lines (e.g. a BED file was passed)."""
+    saw_header = False
     with open(interval_list) as f:
         for line in f:
             if line.startswith('@'):
+                saw_header = True
                 continue
+            if not saw_header:
+                raise ValueError(
+                    f"{interval_list} does not appear to be a Picard interval_list file "
+                    f"(no '@' header lines found before the first data line). "
+                    f"BED files and other 0-based formats are not currently supported."
+                )
             parts = line.strip().split('\t')
             if len(parts) < 3:
                 continue

--- a/scripts/variantstore/scripts/create_ranges_cohort_extract_data_table.py
+++ b/scripts/variantstore/scripts/create_ranges_cohort_extract_data_table.py
@@ -134,9 +134,9 @@ def create_extract_samples_table(control_samples, fq_destination_table_samples, 
 
 
 def _parse_interval_list(interval_list):
-    """Parse an interval_list file, yielding (chrom, start_0based, end_0based_excl) tuples.
-    interval_list format is 1-based closed; we convert to 0-based half-open to match
-    the coordinate system previously used via pybedtools."""
+    """Parse an interval_list file, yielding (chrom, start, end) tuples.
+    interval_list format is 1-based closed; GVS location encoding is also 1-based,
+    so coordinates are passed through unchanged."""
     with open(interval_list) as f:
         for line in f:
             if line.startswith('@'):
@@ -144,11 +144,18 @@ def _parse_interval_list(interval_list):
             parts = line.strip().split('\t')
             if len(parts) < 3:
                 continue
-            yield parts[0], int(parts[1]) - 1, int(parts[2])
+            yield parts[0], int(parts[1]), int(parts[2])
 
 
 def get_location_filters_from_interval_list(interval_list):
     intervals = list(_parse_interval_list(interval_list))
+    if not intervals:
+        return ""
+
+    unknown_chroms = {chrom for chrom, _, _ in intervals if chrom not in CHROM_MAP}
+    if unknown_chroms:
+        raise ValueError(f"Interval list contains contigs not recognized by GVS: {sorted(unknown_chroms)}")
+
     # check to make sure there aren't too many locations to build a SQL query from
     if len(intervals) > 5000:
         print(f"\n\nTrying to query over the limit of 5,000 locations; {interval_list} will be discarded, and all locations will be queried.\n\n")
@@ -156,8 +163,7 @@ def get_location_filters_from_interval_list(interval_list):
 
     location_clause_list = [f"""(location >= {CHROM_MAP[chrom]}{'0' * (12 - len(str(start)))}{start}
             AND location <= {CHROM_MAP[chrom]}{'0' * (12 - len(str(end)))}{end})"""
-                            for chrom, start, end in intervals
-                            if chrom in CHROM_MAP]
+                            for chrom, start, end in intervals]
     return "WHERE (" + " OR ".join(location_clause_list) + ")"
 
 

--- a/scripts/variantstore/scripts/create_ranges_cohort_extract_data_table.py
+++ b/scripts/variantstore/scripts/create_ranges_cohort_extract_data_table.py
@@ -2,7 +2,6 @@
 import uuid
 import datetime
 import argparse
-import pybedtools
 import re
 
 from google.cloud import bigquery
@@ -134,16 +133,31 @@ def create_extract_samples_table(control_samples, fq_destination_table_samples, 
     return query_return['results']
 
 
+def _parse_interval_list(interval_list):
+    """Parse an interval_list file, yielding (chrom, start_0based, end_0based_excl) tuples.
+    interval_list format is 1-based closed; we convert to 0-based half-open to match
+    the coordinate system previously used via pybedtools."""
+    with open(interval_list) as f:
+        for line in f:
+            if line.startswith('@'):
+                continue
+            parts = line.strip().split('\t')
+            if len(parts) < 3:
+                continue
+            yield parts[0], int(parts[1]) - 1, int(parts[2])
+
+
 def get_location_filters_from_interval_list(interval_list):
-    interval_test = pybedtools.BedTool(interval_list)
+    intervals = list(_parse_interval_list(interval_list))
     # check to make sure there aren't too many locations to build a SQL query from
-    if len(interval_test) > 5000:
+    if len(intervals) > 5000:
         print(f"\n\nTrying to query over the limit of 5,000 locations; {interval_list} will be discarded, and all locations will be queried.\n\n")
         return ""
 
-    location_clause_list = [f"""(location >= {CHROM_MAP[interval.chrom]}{'0' * (12 - len(str(interval.start)))}{interval.start} 
-            AND location <= {CHROM_MAP[interval.chrom]}{'0' * (12 - len(str(interval.end)))}{interval.end})"""
-                            for interval in interval_test]
+    location_clause_list = [f"""(location >= {CHROM_MAP[chrom]}{'0' * (12 - len(str(start)))}{start}
+            AND location <= {CHROM_MAP[chrom]}{'0' * (12 - len(str(end)))}{end})"""
+                            for chrom, start, end in intervals
+                            if chrom in CHROM_MAP]
     return "WHERE (" + " OR ".join(location_clause_list) + ")"
 
 

--- a/scripts/variantstore/scripts/create_ranges_cohort_extract_data_table.py
+++ b/scripts/variantstore/scripts/create_ranges_cohort_extract_data_table.py
@@ -54,6 +54,10 @@ AS (
 
 CHROM_MAP = {'chr1': '1', 'chr2': '2', 'chr3': '3', 'chr4': '4', 'chr5': '5', 'chr6': '6', 'chr7': '7', 'chr8': '8', 'chr9': '9', 'chr10': '10', 'chr11': '11', 'chr12': '12', 'chr13': '13', 'chr14': '14', 'chr15': '15', 'chr16': '16', 'chr17': '17', 'chr18': '18', 'chr19': '19', 'chr20': '20', 'chr21': '21', 'chr22': '22', 'chrX': '23', 'chrY': '24', 'chrM': '25'}
 
+# Maximum number of intervals for which an inline SQL WHERE clause is generated.
+# Larger interval lists (e.g. ACAF at ~58 M intervals) are discarded and all locations are queried.
+MAX_INLINE_INTERVAL_COUNT = 5000
+
 
 def get_partition_range(i):
     if i < 1 or i > REF_VET_TABLE_COUNT:
@@ -148,18 +152,26 @@ def _parse_interval_list(interval_list):
 
 
 def get_location_filters_from_interval_list(interval_list):
-    intervals = list(_parse_interval_list(interval_list))
+    # Stream only as many rows as needed to detect an oversized list, avoiding
+    # loading huge files (e.g. ACAF at ~58 M intervals) into memory.
+    intervals = []
+    for row in _parse_interval_list(interval_list):
+        intervals.append(row)
+        if len(intervals) > MAX_INLINE_INTERVAL_COUNT:
+            break
+
     if not intervals:
+        return ""
+
+    # Check the cap before contig validation: oversized lists are discarded
+    # without further inspection, matching prior behavior.
+    if len(intervals) > MAX_INLINE_INTERVAL_COUNT:
+        print(f"\n\nTrying to query over the limit of {MAX_INLINE_INTERVAL_COUNT:,} locations; {interval_list} will be discarded, and all locations will be queried.\n\n")
         return ""
 
     unknown_chroms = {chrom for chrom, _, _ in intervals if chrom not in CHROM_MAP}
     if unknown_chroms:
         raise ValueError(f"Interval list contains contigs not recognized by GVS: {sorted(unknown_chroms)}")
-
-    # check to make sure there aren't too many locations to build a SQL query from
-    if len(intervals) > 5000:
-        print(f"\n\nTrying to query over the limit of 5,000 locations; {interval_list} will be discarded, and all locations will be queried.\n\n")
-        return ""
 
     location_clause_list = [f"""(location >= {CHROM_MAP[chrom]}{'0' * (12 - len(str(start)))}{start}
             AND location <= {CHROM_MAP[chrom]}{'0' * (12 - len(str(end)))}{end})"""

--- a/scripts/variantstore/scripts/requirements.txt
+++ b/scripts/variantstore/scripts/requirements.txt
@@ -1,6 +1,7 @@
 google-cloud-bigquery
 ijson
 numpy
+pyarrow==24.0.0
 google-cloud-storage
 terra-notebook-utils
 pybedtools

--- a/scripts/variantstore/scripts/requirements.txt
+++ b/scripts/variantstore/scripts/requirements.txt
@@ -4,5 +4,4 @@ numpy
 pyarrow==24.0.0
 google-cloud-storage
 terra-notebook-utils
-pybedtools
 biopython

--- a/scripts/variantstore/scripts/requirements.txt
+++ b/scripts/variantstore/scripts/requirements.txt
@@ -1,7 +1,6 @@
 google-cloud-bigquery
 ijson
 numpy
-pyarrow==24.0.0
 google-cloud-storage
 terra-notebook-utils
 biopython

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -131,7 +131,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-06-24-alpine-46bd14ddd49d"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-06-24-alpine-bb69725c451a"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-04-08-gatkbase-9434f9e8577f"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -131,7 +131,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-06-23-alpine-435047c9b6e0"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-06-23-alpine-576bb692a66d"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-04-08-gatkbase-9434f9e8577f"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -131,7 +131,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-06-24-alpine-bb69725c451a"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-06-25-alpine-d00fbfb522ea"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-04-08-gatkbase-9434f9e8577f"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -131,7 +131,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-06-15-alpine-7d597aaa4590"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-06-22-alpine-36bf39bb6f0b"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-04-08-gatkbase-9434f9e8577f"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -131,7 +131,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-06-23-alpine-576bb692a66d"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-06-24-alpine-46bd14ddd49d"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-04-08-gatkbase-9434f9e8577f"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -131,7 +131,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-06-22-alpine-36bf39bb6f0b"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-06-23-alpine-435047c9b6e0"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-04-08-gatkbase-9434f9e8577f"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"


### PR DESCRIPTION
Successful integration run [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration%20mcovarr/submission_history/2be255b0-2aeb-4f19-bd7d-ed02ea740ec7).

The main part of the VS-1771 ticket didn't work out (prepares came out slower and more expensive), but there were some improvements made to the Docker image worth keeping:

- Version bumps for `htslib` and `bcftools` to the latest versions
- Dead `pyarrow` dependency and its onerous Apache Arrow source build removed
- Bulky, barely used `pybedtools` dependency removed
- Docker image size reduced ~20%
