### PR TITLE
Vs 1831

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -285,6 +285,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - VS-1831
          tags:
              - /.*/
    - name: GvsBeta

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -285,7 +285,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - VS-1831
          tags:
              - /.*/
    - name: GvsBeta

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -128,7 +128,7 @@ workflow GvsImportGenomes {
 
   # At least 1, per limits above not more than 20.
   # But if it's a beta customer, use the number computed above
-  Int effective_load_data_batch_size = if (defined(load_data_scatter_width)) then num_samples / select_first([load_data_scatter_width])
+  Int effective_load_data_batch_size = if (defined(load_data_scatter_width)) then num_samples / (if select_first([load_data_scatter_width]) <= num_samples then select_first([load_data_scatter_width]) else num_samples)
                                        else if num_samples < max_scatter_for_user then 1
                                          else if is_wgs then num_samples / max_scatter_for_user
                                            else if num_samples < 5001 then 20

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -126,9 +126,16 @@ workflow GvsImportGenomes {
     }
   }
 
-  # At least 1, per limits above not more than 20.
-  # But if it's a beta customer, use the number computed above
-  Int effective_load_data_batch_size = if (defined(load_data_scatter_width)) then num_samples / (if select_first([load_data_scatter_width]) <= num_samples then select_first([load_data_scatter_width]) else num_samples)
+  # Compute effective scatter width, clamped to not exceed number of samples
+  Int effective_scatter_width = if (defined(load_data_scatter_width)) then
+                                  min(select_first([load_data_scatter_width]), num_samples)
+                                else num_samples
+
+  # Compute batch size using ceiling division to ensure we don't exceed the requested scatter width.
+  # Using (x + y - 1) / y implementation of ceil(x/y)
+  # Example: 10 samples, scatter_width 6 -> batch_size = ceil(10/6) = 2 -> actual tasks = ceil(10/2) ≈ 5 ≤ 6
+  Int effective_load_data_batch_size = if (defined(load_data_scatter_width)) then
+                                         (num_samples + effective_scatter_width - 1) / effective_scatter_width
                                        else if num_samples < max_scatter_for_user then 1
                                          else if is_wgs then num_samples / max_scatter_for_user
                                            else if num_samples < 5001 then 20

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -128,7 +128,7 @@ workflow GvsImportGenomes {
 
   # Compute effective scatter width, clamped to not exceed number of samples
   Int effective_scatter_width = if (defined(load_data_scatter_width)) then
-                                  min(select_first([load_data_scatter_width]), num_samples)
+                                  if select_first([load_data_scatter_width]) < num_samples then select_first([load_data_scatter_width]) else num_samples
                                 else num_samples
 
   # Compute batch size using ceiling division to ensure we don't exceed the requested scatter width.


### PR DESCRIPTION
Fixing a small bug where, if you specify the scatter width and the number of samples are blow that, the pipeline gives an error when it sends along batches with 0 items in them.  It fails in CreateFOFNs with "split: invalid number of lines: '0': Numerical result out of range"

Modified the pipeline to only ever scatter as far as the sample count, if specified.

Run that encountered the error: https://app.terra.bio/#workspaces/gvs-dev/NHGRI_AnVIL_3K_ahatcher/submission_history/e985ca01-3c76-45f4-a980-0483c4ea6c97

Run that has proceeded past that failure point:
https://app.terra.bio/#workspaces/gvs-dev/NHGRI_AnVIL_3K_ahatcher/submission_history/bdc46a54-ef43-46b3-a9b4-f0b17cf8678b/0fcbb2c9-7330-43b6-a737-e91595145c1b

Post-refactor run that passed the failure point:
https://app.terra.bio/#workspaces/gvs-dev/NHGRI_AnVIL_3K_ahatcher/submission_history/bb9396f6-4de9-4b22-9368-78feca499a93