### PR TITLE
Add Entrez ID to VAT annotations [VS-1766]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -238,6 +238,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - ng_gvs_entrez_annnotations
          tags:
              - /.*/
    - name: GvsCreateVATFilesFromBigQuery
@@ -258,6 +259,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - ng_gvs_entrez_annnotations
          tags:
              - /.*/
    - name: GvsExtractCohortFromSampleNames
@@ -341,6 +343,7 @@ workflows:
              - master
              - ah_var_store
              - vs_1963_vat_index
+             - ng_gvs_entrez_annnotations
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -238,7 +238,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - ng_gvs_entrez_annnotations
          tags:
              - /.*/
    - name: GvsCreateVATFilesFromBigQuery
@@ -259,7 +258,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - ng_gvs_entrez_annnotations
          tags:
              - /.*/
    - name: GvsExtractCohortFromSampleNames
@@ -343,7 +341,6 @@ workflows:
              - master
              - ah_var_store
              - vs_1963_vat_index
-             - ng_gvs_entrez_annnotations
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/scripts/check_entrez_table.py
+++ b/scripts/variantstore/scripts/check_entrez_table.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+# Validates the loaded Entrez (gene2ensembl) BigQuery table before it is used to annotate the VAT.
+#
+# The Entrez -> VAT join keys on the gene (Ensembl_gene_identifier -> GeneID), so this checks the
+# two columns that join depends on, plus a row-count floor that catches an empty or partially loaded
+# table (which would otherwise pass "table exists" + "0 bad rows" and silently annotate nothing).
+#
+# Note: we intentionally do NOT check Ensembl_rna_identifier for NULLs. gene2ensembl legitimately
+# leaves the transcript columns blank ("-", loaded as NULL) for a large fraction of rows, and the
+# gene-level join does not use them.
+import argparse
+import sys
+
+from google.cloud import bigquery
+from google.cloud.bigquery.job import QueryJobConfig
+
+import utils
+
+
+def check_entrez_table(fq_entrez_table, query_project, min_rows):
+    query_labels_map = {
+        "id": "check_entrez_table",
+        "gvs_tool_name": "gvs_validate_entrez"
+    }
+
+    # add labels for DSP Cloud Cost Control Labeling and Reporting
+    query_labels_map.update({'service': 'gvs', 'team': 'variants', 'managedby': 'create_vat'})
+
+    default_config = QueryJobConfig(labels=query_labels_map, priority="INTERACTIVE", use_query_cache=True, use_legacy_sql=False)
+    client = bigquery.Client(project=query_project,
+                             default_query_job_config=default_config)
+
+    sql = f"""
+        SELECT
+            COUNT(*) AS total_rows,
+            COUNTIF(SAFE_CAST(GeneID AS INT64) IS NULL) AS bad_gene_ids,
+            COUNTIF(Ensembl_gene_identifier IS NULL OR Ensembl_gene_identifier = '-') AS bad_gene_identifiers
+        FROM `{fq_entrez_table}`
+    """
+
+    query_return = utils.execute_with_retry(client, "validate entrez table", sql)
+    row = next(iter(query_return.get('results')))
+    total_rows = row.get('total_rows')
+    bad_gene_ids = row.get('bad_gene_ids')
+    bad_gene_identifiers = row.get('bad_gene_identifiers')
+
+    print(f"Entrez table {fq_entrez_table}: total_rows={total_rows}, bad_gene_ids={bad_gene_ids}, "
+          f"bad_gene_identifiers={bad_gene_identifiers}")
+
+    errors = []
+    if total_rows < min_rows:
+        errors.append(f"{total_rows} rows is below the expected floor of {min_rows} "
+                      f"(table may be empty or only partially loaded)")
+    if bad_gene_ids > 0:
+        errors.append(f"{bad_gene_ids} rows have a NULL or non-numeric GeneID")
+    if bad_gene_identifiers > 0:
+        errors.append(f"{bad_gene_identifiers} rows have a NULL or placeholder ('-') Ensembl_gene_identifier "
+                      f"(the gene-level join key)")
+
+    if errors:
+        print("Entrez table validation FAILED:", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Entrez table validation passed: all GeneIDs numeric, all Ensembl_gene_identifiers populated, "
+          f"{total_rows} rows.")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(allow_abbrev=False,
+                                     description='Validate the loaded Entrez (gene2ensembl) BigQuery table')
+    parser.add_argument('--fq_entrez_table', type=str, required=True,
+                        help='fully-qualified BigQuery Entrez table (project.dataset.table)')
+    parser.add_argument('--query_project', type=str, required=True,
+                        help='Google project to run the BigQuery queries with')
+    parser.add_argument('--min_rows', type=int, required=False, default=50000,
+                        help='minimum expected row count; gene2ensembl_human is ~88k rows')
+
+    args = parser.parse_args()
+
+    check_entrez_table(args.fq_entrez_table,
+                       args.query_project,
+                       args.min_rows)

--- a/scripts/variantstore/scripts/check_entrez_vat_annotations.py
+++ b/scripts/variantstore/scripts/check_entrez_vat_annotations.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+# Post-join validation of the VAT's entrez_gene_id annotation. Runs after the VAT is built.
+#
+# Two checks:
+#   1. Coverage  - of rows that carry a gene_id, at least `min_coverage` fraction receive a non-empty
+#                  entrez_gene_id array. entrez_gene_id is a repeated field, so an unmatched row is an
+#                  empty array [] (ARRAY_LENGTH = 0), not NULL. This guards against a regression back to
+#                  the sparse (~26%) transcript-keyed join, or to 0% if the join silently matches nothing.
+#   2. Consistency - entrez_gene_id is a gene-level attribute, so every row sharing a gene_id must carry
+#                  the same set of GeneIDs. Fails if any gene_id maps to more than one distinct array.
+import argparse
+
+from google.cloud import bigquery
+from google.cloud.bigquery.job import QueryJobConfig
+
+import utils
+
+
+def write_output_files(passed, message, pass_file_output, results_file_output):
+    with open(pass_file_output, 'w') as pass_file, open(results_file_output, 'w') as results_file:
+        pass_file.write('true' if passed else 'false')
+        results_file.write(message)
+
+
+def check_entrez_vat_annotations(fq_vat_table, query_project, min_coverage, pass_file_output, results_file_output):
+    query_labels_map = {
+        "id": "check_entrez_vat_annotations",
+        "gvs_tool_name": "gvs_validate_vat"
+    }
+
+    # add labels for DSP Cloud Cost Control Labeling and Reporting
+    query_labels_map.update({'service': 'gvs', 'team': 'variants', 'managedby': 'create_vat'})
+
+    default_config = QueryJobConfig(labels=query_labels_map, priority="INTERACTIVE", use_query_cache=True, use_legacy_sql=False)
+    client = bigquery.Client(project=query_project,
+                             default_query_job_config=default_config)
+
+    # Coverage: fraction of gene-bearing rows that received at least one Entrez GeneID.
+    coverage_sql = f"""
+        SELECT
+            COUNTIF(gene_id IS NOT NULL) AS gene_rows,
+            COUNTIF(gene_id IS NOT NULL AND ARRAY_LENGTH(entrez_gene_id) > 0) AS annotated_rows
+        FROM `{fq_vat_table}`
+    """
+    coverage_row = next(iter(utils.execute_with_retry(client, "entrez coverage", coverage_sql).get('results')))
+    gene_rows = coverage_row.get('gene_rows')
+    annotated_rows = coverage_row.get('annotated_rows')
+    coverage = (annotated_rows / gene_rows) if gene_rows else 0.0
+
+    # Consistency: each gene_id must map to a single distinct entrez_gene_id array. The array is
+    # collapsed to an order-independent string (sorted, with empty arrays becoming '') so that
+    # arrays with the same members in a different order are treated as equal, while an empty array
+    # is still distinguished from a populated one.
+    consistency_sql = f"""
+        WITH per_gene AS (
+            SELECT
+                gene_id,
+                COUNT(DISTINCT IFNULL(
+                    (SELECT STRING_AGG(CAST(e AS STRING), ',' ORDER BY e) FROM UNNEST(entrez_gene_id) AS e),
+                    '')) AS distinct_arrays
+            FROM `{fq_vat_table}`
+            WHERE gene_id IS NOT NULL
+            GROUP BY gene_id
+        )
+        SELECT COUNTIF(distinct_arrays > 1) AS inconsistent_genes, COUNT(*) AS total_genes FROM per_gene
+    """
+    consistency_row = next(iter(utils.execute_with_retry(client, "entrez consistency", consistency_sql).get('results')))
+    inconsistent_genes = consistency_row.get('inconsistent_genes')
+    total_genes = consistency_row.get('total_genes')
+
+    coverage_ok = coverage >= min_coverage
+    consistency_ok = inconsistent_genes == 0
+    passed = coverage_ok and consistency_ok
+
+    coverage_msg = (f"entrez_gene_id coverage {coverage:.4f} ({annotated_rows}/{gene_rows} gene-bearing rows) "
+                    f"{'>=' if coverage_ok else '<'} threshold {min_coverage}")
+    consistency_msg = (f"{inconsistent_genes} of {total_genes} gene_ids map to more than one distinct "
+                       f"entrez_gene_id array")
+    message = f"{fq_vat_table}: {coverage_msg}; {consistency_msg}."
+
+    write_output_files(passed, message, pass_file_output, results_file_output)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(allow_abbrev=False,
+                                     description='Check VAT entrez_gene_id coverage and gene-consistency')
+    parser.add_argument('--fq_vat_table', type=str, required=True,
+                        help='fully-qualified BigQuery VAT table')
+    parser.add_argument('--query_project', type=str, required=True,
+                        help='Google project to run the BigQuery queries with')
+    parser.add_argument('--min_coverage', type=float, required=False, default=0.85,
+                        help='minimum fraction of gene-bearing rows that must carry an Entrez GeneID')
+    parser.add_argument('--pass_file_output', type=str, required=True,
+                        help='location to write file with pass/fail into')
+    parser.add_argument('--results_file_output', type=str, required=True,
+                        help='location to write query results into')
+
+    args = parser.parse_args()
+
+    check_entrez_vat_annotations(args.fq_vat_table,
+                                 args.query_project,
+                                 args.min_coverage,
+                                 args.pass_file_output,
+                                 args.results_file_output)

--- a/scripts/variantstore/scripts/variant_annotation_table/schema/variant_transcript_schema.json
+++ b/scripts/variantstore/scripts/variant_annotation_table/schema/variant_transcript_schema.json
@@ -432,6 +432,12 @@
     "mode": "Nullable"
   },
   {
+    "description": "NCBI Entrez Gene ID",
+    "name": "entrez_gene_id",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
     "description": "HGNC (HUGO Gene Nomenclature Committee) Symbol",
     "name": "hgnc_symbol",
     "type": "String",

--- a/scripts/variantstore/scripts/variant_annotation_table/schema/variant_transcript_schema.json
+++ b/scripts/variantstore/scripts/variant_annotation_table/schema/variant_transcript_schema.json
@@ -432,10 +432,10 @@
     "mode": "Nullable"
   },
   {
-    "description": "NCBI Entrez Gene ID",
+    "description": "NCBI Entrez Gene ID(s). Repeated because a single Ensembl gene can map to more than one NCBI GeneID.",
     "name": "entrez_gene_id",
     "type": "Integer",
-    "mode": "Nullable"
+    "mode": "Repeated"
   },
   {
     "description": "HGNC (HUGO Gene Nomenclature Committee) Symbol",

--- a/scripts/variantstore/scripts/variant_annotation_table/schema/vat_schema.json
+++ b/scripts/variantstore/scripts/variant_annotation_table/schema/vat_schema.json
@@ -432,6 +432,12 @@
     "mode": "Nullable"
   },
   {
+    "description": "NCBI Entrez Gene ID",
+    "name": "entrez_gene_id",
+    "type": "Integer",
+    "mode": "Nullable"
+  },
+  {
     "description": "HGNC (HUGO Gene Nomenclature Committee) Symbol",
     "name": "hgnc_symbol",
     "type": "String",

--- a/scripts/variantstore/scripts/variant_annotation_table/schema/vat_schema.json
+++ b/scripts/variantstore/scripts/variant_annotation_table/schema/vat_schema.json
@@ -432,10 +432,10 @@
     "mode": "Nullable"
   },
   {
-    "description": "NCBI Entrez Gene ID",
+    "description": "NCBI Entrez Gene ID(s). Repeated because a single Ensembl gene can map to more than one NCBI GeneID.",
     "name": "entrez_gene_id",
     "type": "Integer",
-    "mode": "Nullable"
+    "mode": "Repeated"
   },
   {
     "description": "HGNC (HUGO Gene Nomenclature Committee) Symbol",

--- a/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
@@ -81,6 +81,9 @@ workflow GvsCreateVATfromVDS {
 
     String region = "us-central1"
     File mane_annotation_file = "gs://gvs_quickstart_storage/MANE/MANE_human/release_1.4/MANE.GRCh38.v1.4.summary.txt"
+
+    # gene2ensembl_human.tsv is extracted and filtered for humans from https://ftp.ncbi.nlm.nih.gov/gene/DATA/gene2ensembl.gz
+    # There is also a more comprehensive and very large https://ftp.ncbi.nlm.nih.gov/gene/DATA/gene_info.gz to use if necessary.
     File entrez_annotation_file = "gs://gvs_quickstart_storage/Entrez/gene2ensembl_human.tsv"
 
     # Always call `GetToolVersions` to get the git hash for this run as this is a top-level-only WDL (i.e. there are

--- a/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
@@ -1486,8 +1486,10 @@ task LoadEntrezDataIntoBigQuery {
         PS4='\D{+%F %T} \w $ '
         set -o errexit -o nounset -o pipefail -o xtrace
 
-        # Remove the leading comment character on the first line so BigQuery will name the columns all nice.
-        sed -i 's/^\#tax_id/tax_id/' ~{entrez_data_file}
+        # Fix the header line: remove the leading comment character, and replace dots with underscores in
+        # column names (BigQuery V1 character map does not support dots in field names).
+        # Write to a temp file rather than modifying in-place, as the localized input file may be read-only.
+        sed '1{s/^\#tax_id/tax_id/; s/\./_/g}' ~{entrez_data_file} > entrez_data_processed.tsv
 
         echo "project_id = ~{project_id}" > ~/.bigqueryrc
 
@@ -1498,7 +1500,7 @@ task LoadEntrezDataIntoBigQuery {
 
         if [ $BQ_SHOW_RC -ne 0 ]; then
             echo "Loading Entrez annotations into table ~{dataset_name}.~{entrez_table_name}"
-            bq --apilog=false load --project_id=~{project_id} --source_format=CSV --field_delimiter='\t' --skip_leading_rows=1 --autodetect ~{dataset_name}.~{entrez_table_name} ~{entrez_data_file}
+            bq --apilog=false load --project_id=~{project_id} --source_format=CSV --field_delimiter='\t' --skip_leading_rows=1 --autodetect ~{dataset_name}.~{entrez_table_name} entrez_data_processed.tsv
         else
             echo "Found existing Entrez annotations table ~{dataset_name}.~{entrez_table_name}. Using it"
         fi

--- a/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
@@ -81,6 +81,7 @@ workflow GvsCreateVATfromVDS {
 
     String region = "us-central1"
     File mane_annotation_file = "gs://gvs_quickstart_storage/MANE/MANE_human/release_1.4/MANE.GRCh38.v1.4.summary.txt"
+    File entrez_annotation_file = "gs://gvs-internal/Entrez/gene2ensembl_human.tsv"
 
     # Always call `GetToolVersions` to get the git hash for this run as this is a top-level-only WDL (i.e. there are
     # no calling WDLs that might supply `git_hash`).
@@ -181,6 +182,15 @@ workflow GvsCreateVATfromVDS {
                 dataset_name = dataset_name,
                 mane_table_name = "mane_annotations",
                 mane_data_file = mane_annotation_file,
+                cloud_sdk_docker = effective_cloud_sdk_docker,
+        }
+
+        call LoadEntrezDataIntoBigQuery {
+            input:
+                project_id = project_id,
+                dataset_name = dataset_name,
+                entrez_table_name = "entrez_annotations",
+                entrez_data_file = entrez_annotation_file,
                 cloud_sdk_docker = effective_cloud_sdk_docker,
         }
 
@@ -371,6 +381,7 @@ workflow GvsCreateVATfromVDS {
                 variant_transcript_schema = MakeSubpopulationFilesAndReadSchemaFiles.variant_transcript_schema_json_file,
                 genes_schema = MakeSubpopulationFilesAndReadSchemaFiles.genes_schema_json_file,
                 mane_table_name = LoadManeDataIntoBigQuery.mane_table,
+                entrez_table_name = LoadEntrezDataIntoBigQuery.entrez_table,
                 vep_loftee_cooked_table_name = BigQueryCookVepAndLofteeRawAnnotations.cooked_table_name,
                 run_vep_loftee_update = generate_vep_and_loftee_annotations,
                 project_id = project_id,
@@ -1454,6 +1465,59 @@ task LoadManeDataIntoBigQuery {
     }
 }
 
+task LoadEntrezDataIntoBigQuery {
+    meta {
+        # volatile: true so that call caching does not prevent this task from loading Entrez data
+        # into the current dataset. Without this, a cache hit would return the correct output
+        # string ("entrez_annotations") but skip the actual bq load, leaving the table absent.
+        volatile: true
+    }
+
+    input {
+        String project_id
+        String dataset_name
+        String entrez_table_name
+        File entrez_data_file
+        String cloud_sdk_docker
+    }
+
+    command <<<
+        # Prepend date, time and pwd to xtrace log entries.
+        PS4='\D{+%F %T} \w $ '
+        set -o errexit -o nounset -o pipefail -o xtrace
+
+        # Remove the leading comment character on the first line so BigQuery will name the columns all nice.
+        sed -i 's/^\#tax_id/tax_id/' ~{entrez_data_file}
+
+        echo "project_id = ~{project_id}" > ~/.bigqueryrc
+
+        set +o errexit
+        bq --apilog=false show --project_id=~{project_id} ~{dataset_name}.~{entrez_table_name} > /dev/null
+        BQ_SHOW_RC=$?
+        set -o errexit
+
+        if [ $BQ_SHOW_RC -ne 0 ]; then
+            echo "Loading Entrez annotations into table ~{dataset_name}.~{entrez_table_name}"
+            bq --apilog=false load --project_id=~{project_id} --source_format=CSV --field_delimiter='\t' --skip_leading_rows=1 --autodetect ~{dataset_name}.~{entrez_table_name} ~{entrez_data_file}
+        else
+            echo "Found existing Entrez annotations table ~{dataset_name}.~{entrez_table_name}. Using it"
+        fi
+    >>>
+
+    runtime {
+        docker: cloud_sdk_docker
+        memory: "3 GB"
+        preemptible: 3
+        cpu: 1
+        disks: "local-disk 100 HDD"
+    }
+
+    output {
+        String entrez_table = entrez_table_name
+        Boolean done = true
+    }
+}
+
 task BigQueryLoadJson {
     meta {
         # since the WDL will not see the updated data (its getting put in a gcp bucket)
@@ -1466,6 +1530,7 @@ task BigQueryLoadJson {
         File variant_transcript_schema
         File genes_schema
         String mane_table_name
+        String entrez_table_name
         String? vep_loftee_cooked_table_name
         Boolean run_vep_loftee_update
         String project_id
@@ -1526,6 +1591,10 @@ task BigQueryLoadJson {
         echo "Adding the Mane Plus Clinical annotation data to the pre-vat table ~{dataset_name}.~{variant_transcript_table}"
         bq --apilog=false --project_id=~{project_id} query --format=csv --use_legacy_sql=false ~{bq_labels} \
         'UPDATE `~{dataset_name}.~{variant_transcript_table}` vtt SET vtt.mane_plus_clinical_name = mane.name FROM `~{dataset_name}.~{mane_table_name}` mane WHERE vtt.transcript = mane.Ensembl_nuc AND mane.MANE_status = "MANE Plus Clinical" AND vtt.transcript is not null;'
+
+        echo "Adding Entrez gene ID data to the pre-vat table ~{dataset_name}.~{variant_transcript_table}"
+        bq --apilog=false --project_id=~{project_id} query --format=csv --use_legacy_sql=false ~{bq_labels} \
+        'UPDATE `~{dataset_name}.~{variant_transcript_table}` vtt SET vtt.entrez_gene_id = CAST(entrez.GeneID AS INT64) FROM `~{dataset_name}.~{entrez_table_name}` entrez WHERE vtt.transcript = entrez.Ensembl_RNA_identifier AND entrez.tax_id = 9606 AND vtt.transcript is not null;'
 
         if [[ "~{run_vep_loftee_update}" == "true" ]]; then
         echo "Adding VEP + LOFTEE annotation data to the pre-vat table ~{dataset_name}.~{variant_transcript_table}"
@@ -1650,7 +1719,7 @@ task BigQueryLoadJson {
             # v.hgvsc AS splice_distance
             v.dbsnp_rsid,
             v.gene_id,
-            # v.entrez_gene_id,
+            v.entrez_gene_id,
             # g.hgnc_gene_id,
             g.gene_omim_id,
             CASE WHEN ( v.transcript is not null and v.is_canonical_transcript is not True)

--- a/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
@@ -1489,8 +1489,14 @@ task LoadEntrezDataIntoBigQuery {
         PS4='\D{+%F %T} \w $ '
         set -o errexit -o nounset -o pipefail -o xtrace
 
-        # Fix the header line: remove the leading comment character, and replace dots with underscores in
-        # column names (BigQuery V1 character map does not support dots in field names).
+        # Fix the header line: remove the leading comment character (#tax_id -> tax_id), and replace dots
+        # with underscores in column names (BigQuery V1 character map does not support dots in field names).
+        # Affected columns: RNA_nucleotide_accession.version -> RNA_nucleotide_accession_version,
+        #                   protein_accession.version -> protein_accession_version.
+        # Ensembl_rna_identifier has no dots and is unchanged — this is the column used in the UPDATE join.
+        # Column order in NCBI gene2ensembl: tax_id, GeneID, Ensembl_gene_identifier,
+        #   RNA_nucleotide_accession_version, Ensembl_rna_identifier, protein_accession_version,
+        #   Ensembl_protein_identifier — schema below must match this order exactly.
         # Write to a temp file rather than modifying in-place, as the localized input file may be read-only.
         sed '1{s/^\#tax_id/tax_id/; s/\./_/g}' ~{entrez_data_file} > entrez_data_processed.tsv
 
@@ -1503,10 +1509,43 @@ task LoadEntrezDataIntoBigQuery {
 
         if [ $BQ_SHOW_RC -ne 0 ]; then
             echo "Loading Entrez annotations into table ~{dataset_name}.~{entrez_table_name}"
-            bq --apilog=false load --project_id=~{project_id} --source_format=CSV --field_delimiter='\t' --skip_leading_rows=1 --autodetect ~{dataset_name}.~{entrez_table_name} entrez_data_processed.tsv
+            # Explicit schema ensures GeneID loads as INTEGER (not STRING), making the CAST in the UPDATE
+            # a safe no-op rather than depending on autodetect inference. Column order must match file exactly.
+            bq --apilog=false load --project_id=~{project_id} --source_format=CSV --field_delimiter='\t' --skip_leading_rows=1 \
+                --schema='tax_id:INTEGER,GeneID:INTEGER,Ensembl_gene_identifier:STRING,RNA_nucleotide_accession_version:STRING,Ensembl_rna_identifier:STRING,protein_accession_version:STRING,Ensembl_protein_identifier:STRING' \
+                ~{dataset_name}.~{entrez_table_name} entrez_data_processed.tsv
         else
             echo "Found existing Entrez annotations table ~{dataset_name}.~{entrez_table_name}. Using it"
         fi
+
+        # Emit the loaded table schema in prettyjson so maintainers can confirm column types in logs.
+        bq --apilog=false --project_id=~{project_id} show --format=prettyjson ~{project_id}:~{dataset_name}.~{entrez_table_name}
+
+        # Validate the table regardless of whether it was just loaded or already existed,
+        # so a malformed preexisting table is caught before the UPDATE join runs.
+        echo "Validating Entrez table ~{dataset_name}.~{entrez_table_name}"
+        bq --apilog=false --project_id=~{project_id} query --format=csv --use_legacy_sql=false \
+            'SELECT COUNTIF(SAFE_CAST(GeneID AS INT64) IS NULL) as bad_gene_ids, COUNTIF(Ensembl_rna_identifier IS NULL) as null_transcripts FROM `~{project_id}.~{dataset_name}.~{entrez_table_name}`' > validation.csv
+        python3 -c "
+import csv, subprocess, sys
+with open('validation.csv') as f:
+    reader = csv.DictReader(f)
+    try:
+        row = next(reader)
+    except StopIteration:
+        sys.exit('ERROR: validation query returned no rows — bq output may be malformed')
+    bad_ids = int(row['bad_gene_ids'])
+    null_tx = int(row['null_transcripts'])
+    if bad_ids > 0 or null_tx > 0:
+        print(f'ERROR: {bad_ids} rows have NULL or non-numeric GeneID, {null_tx} rows have NULL Ensembl_rna_identifier', flush=True)
+        print('===== Entrez bad rows (limit 50) =====', flush=True)
+        subprocess.run([
+            'bq', '--apilog=false', '--project_id=~{project_id}', 'query', '--format=csv', '--use_legacy_sql=false',
+            'SELECT GeneID, Ensembl_rna_identifier FROM \`~{project_id}.~{dataset_name}.~{entrez_table_name}\` WHERE SAFE_CAST(GeneID AS INT64) IS NULL OR Ensembl_rna_identifier IS NULL LIMIT 50'
+        ], check=True)
+        sys.exit('Entrez table validation failed — see bad rows above')
+    print(f'Entrez table validation passed: all GeneIDs are numeric, no null transcript identifiers')
+"
     >>>
 
     runtime {
@@ -1599,7 +1638,7 @@ task BigQueryLoadJson {
 
         echo "Adding Entrez gene ID data to the pre-vat table ~{dataset_name}.~{variant_transcript_table}"
         bq --apilog=false --project_id=~{project_id} query --format=csv --use_legacy_sql=false ~{bq_labels} \
-        'UPDATE `~{dataset_name}.~{variant_transcript_table}` vtt SET vtt.entrez_gene_id = CAST(entrez.GeneID AS INT64) FROM `~{dataset_name}.~{entrez_table_name}` entrez WHERE vtt.transcript = entrez.Ensembl_RNA_identifier AND entrez.tax_id = 9606 AND vtt.transcript is not null;'
+        'UPDATE `~{dataset_name}.~{variant_transcript_table}` vtt SET vtt.entrez_gene_id = CAST(entrez.GeneID AS INT64) FROM `~{dataset_name}.~{entrez_table_name}` entrez WHERE vtt.transcript = entrez.Ensembl_rna_identifier AND entrez.tax_id = 9606 AND vtt.transcript is not null;'
 
         if [[ "~{run_vep_loftee_update}" == "true" ]]; then
         echo "Adding VEP + LOFTEE annotation data to the pre-vat table ~{dataset_name}.~{variant_transcript_table}"

--- a/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
@@ -82,12 +82,16 @@ workflow GvsCreateVATfromVDS {
     String region = "us-central1"
     File mane_annotation_file = "gs://gvs_quickstart_storage/MANE/MANE_human/release_1.4/MANE.GRCh38.v1.4.summary.txt"
 
-    # gene2ensembl_human.tsv is extracted and filtered for humans from https://ftp.ncbi.nlm.nih.gov/gene/DATA/gene2ensembl.gz
-    # gene2ensembl provides Entrez-to-Ensembl transcript mappings, which is all that is needed for the VAT join.
+    # gene2ensembl_human.tsv is extracted and filtered for humans (tax_id 9606) from
+    # https://ftp.ncbi.nlm.nih.gov/gene/DATA/gene2ensembl.gz (NCBI snapshot 2026-07-10). gene2ensembl provides
+    # Entrez-to-Ensembl mappings at both the gene (Ensembl_gene_identifier -> GeneID) and transcript level; the VAT
+    # join keys on the gene, so Ensembl_gene_identifier and GeneID are the columns that matter.
     # gene_info.gz (https://ftp.ncbi.nlm.nih.gov/gene/DATA/gene_info.gz) is a larger alternative that includes gene
     # descriptions, synonyms, and other metadata, but is significantly larger and slower to load. Prefer gene2ensembl
     # unless additional gene-level annotations beyond the Entrez ID are required.
-    File entrez_annotation_file = "gs://gvs_quickstart_storage/Entrez/gene2ensembl_human.tsv"
+    # The path is pinned to a dated, immutable copy for reproducibility: the upstream NCBI file is a rolling file that
+    # is overwritten continuously, so an undated path could silently change the Entrez annotations between runs.
+    File entrez_annotation_file = "gs://gvs_quickstart_storage/Entrez/gene2ensembl_human_2026-07-10.tsv"
 
     # Always call `GetToolVersions` to get the git hash for this run as this is a top-level-only WDL (i.e. there are
     # no calling WDLs that might supply `git_hash`).
@@ -198,6 +202,15 @@ workflow GvsCreateVATfromVDS {
                 entrez_table_name = "entrez_annotations",
                 entrez_data_file = entrez_annotation_file,
                 cloud_sdk_docker = effective_cloud_sdk_docker,
+        }
+
+        call ValidateEntrezTable {
+            input:
+                project_id = project_id,
+                dataset_name = dataset_name,
+                entrez_table_name = LoadEntrezDataIntoBigQuery.entrez_table,
+                load_done = LoadEntrezDataIntoBigQuery.done,
+                variants_docker = effective_variants_docker,
         }
 
         call MakeSubpopulationFilesAndReadSchemaFiles {
@@ -395,7 +408,7 @@ workflow GvsCreateVATfromVDS {
                 variant_transcripts_path = variant_transcripts_output_path,
                 genes_path = genes_output_path,
                 base_vat_table_name = effective_vat_table_name,
-                go = flatten([PrepVtAnnotationJson.done, PrepGenesAnnotationJson.done]),
+                go = flatten([PrepVtAnnotationJson.done, PrepGenesAnnotationJson.done, [ValidateEntrezTable.done]]),
                 cloud_sdk_docker = effective_cloud_sdk_docker,
         }
 
@@ -1496,7 +1509,8 @@ task LoadEntrezDataIntoBigQuery {
         # with underscores in column names (BigQuery V1 character map does not support dots in field names).
         # Affected columns: RNA_nucleotide_accession.version -> RNA_nucleotide_accession_version,
         #                   protein_accession.version -> protein_accession_version.
-        # Ensembl_rna_identifier has no dots and is unchanged — this is the column used in the UPDATE join.
+        # Ensembl_gene_identifier and GeneID have no dots and are unchanged — these are the columns used in the
+        # gene-level UPDATE join that populates entrez_gene_id.
         # Column order in NCBI gene2ensembl: tax_id, GeneID, Ensembl_gene_identifier,
         #   RNA_nucleotide_accession_version, Ensembl_rna_identifier, protein_accession_version,
         #   Ensembl_protein_identifier — schema below must match this order exactly.
@@ -1505,50 +1519,44 @@ task LoadEntrezDataIntoBigQuery {
 
         echo "project_id = ~{project_id}" > ~/.bigqueryrc
 
+        # Row-aware guard: (re)load unless the table already exists AND has rows. An existing-but-empty table
+        # (e.g. left behind by a preempted or partial prior attempt) would otherwise be trusted as "already
+        # loaded" and silently annotate nothing, so we treat 0 rows as needing a reload.
+        NEEDS_LOAD=1
         set +o errexit
-        bq --apilog=false show --project_id=~{project_id} ~{dataset_name}.~{entrez_table_name} > /dev/null
+        bq --apilog=false show --project_id=~{project_id} ~{dataset_name}.~{entrez_table_name} > /dev/null 2>&1
         BQ_SHOW_RC=$?
         set -o errexit
 
-        if [ $BQ_SHOW_RC -ne 0 ]; then
+        if [ $BQ_SHOW_RC -eq 0 ]; then
+            ROW_COUNT=$(bq --apilog=false --project_id=~{project_id} query --format=csv --use_legacy_sql=false \
+                'SELECT COUNT(*) FROM `~{project_id}.~{dataset_name}.~{entrez_table_name}`' | tail -n1 | tr -d '\r')
+            if [[ "$ROW_COUNT" =~ ^[0-9]+$ && "$ROW_COUNT" -gt 0 ]]; then
+                NEEDS_LOAD=0
+                echo "Found existing non-empty Entrez annotations table ~{dataset_name}.~{entrez_table_name} ($ROW_COUNT rows). Using it"
+            else
+                echo "Existing Entrez annotations table ~{dataset_name}.~{entrez_table_name} is empty ($ROW_COUNT rows); reloading"
+            fi
+        fi
+
+        if [ $NEEDS_LOAD -eq 1 ]; then
             echo "Loading Entrez annotations into table ~{dataset_name}.~{entrez_table_name}"
             # Explicit schema ensures GeneID loads as INTEGER (not STRING), making the CAST in the UPDATE
             # a safe no-op rather than depending on autodetect inference. Column order must match file exactly.
+            # --null_marker='-' matches the VEP+LOFTEE load: gene2ensembl uses the literal '-' as its missing-value
+            # placeholder, so this stores those as NULL rather than literal '-' strings. No INTEGER column
+            # (tax_id, GeneID) ever contains '-', so nothing is nulled unintentionally.
+            # --replace so a reload of a partially-loaded table starts clean rather than appending duplicates.
             bq --apilog=false load --project_id=~{project_id} --source_format=CSV --field_delimiter='\t' --skip_leading_rows=1 \
+                --null_marker='-' --replace \
                 --schema='tax_id:INTEGER,GeneID:INTEGER,Ensembl_gene_identifier:STRING,RNA_nucleotide_accession_version:STRING,Ensembl_rna_identifier:STRING,protein_accession_version:STRING,Ensembl_protein_identifier:STRING' \
                 ~{dataset_name}.~{entrez_table_name} entrez_data_processed.tsv
-        else
-            echo "Found existing Entrez annotations table ~{dataset_name}.~{entrez_table_name}. Using it"
         fi
 
         # Emit the loaded table schema in prettyjson so maintainers can confirm column types in logs.
+        # Content validation (row-count floor, GeneID/Ensembl_gene_identifier integrity) is done in the
+        # downstream ValidateEntrezTable task via check_entrez_table.py.
         bq --apilog=false --project_id=~{project_id} show --format=prettyjson ~{project_id}:~{dataset_name}.~{entrez_table_name}
-
-        # Validate the table regardless of whether it was just loaded or already existed,
-        # so a malformed preexisting table is caught before the UPDATE join runs.
-        echo "Validating Entrez table ~{dataset_name}.~{entrez_table_name}"
-        bq --apilog=false --project_id=~{project_id} query --format=csv --use_legacy_sql=false \
-            'SELECT COUNTIF(SAFE_CAST(GeneID AS INT64) IS NULL) as bad_gene_ids, COUNTIF(Ensembl_rna_identifier IS NULL) as null_transcripts FROM `~{project_id}.~{dataset_name}.~{entrez_table_name}`' > validation.csv
-        python3 -c "
-import csv, subprocess, sys
-with open('validation.csv') as f:
-    reader = csv.DictReader(f)
-    try:
-        row = next(reader)
-    except StopIteration:
-        sys.exit('ERROR: validation query returned no rows — bq output may be malformed')
-    bad_ids = int(row['bad_gene_ids'])
-    null_tx = int(row['null_transcripts'])
-    if bad_ids > 0 or null_tx > 0:
-        print(f'ERROR: {bad_ids} rows have NULL or non-numeric GeneID, {null_tx} rows have NULL Ensembl_rna_identifier', flush=True)
-        print('===== Entrez bad rows (limit 50) =====', flush=True)
-        subprocess.run([
-            'bq', '--apilog=false', '--project_id=~{project_id}', 'query', '--format=csv', '--use_legacy_sql=false',
-            'SELECT GeneID, Ensembl_rna_identifier FROM \`~{project_id}.~{dataset_name}.~{entrez_table_name}\` WHERE SAFE_CAST(GeneID AS INT64) IS NULL OR Ensembl_rna_identifier IS NULL LIMIT 50'
-        ], check=True)
-        sys.exit('Entrez table validation failed — see bad rows above')
-    print(f'Entrez table validation passed: all GeneIDs are numeric, no null transcript identifiers')
-"
     >>>
 
     runtime {
@@ -1561,6 +1569,48 @@ with open('validation.csv') as f:
 
     output {
         String entrez_table = entrez_table_name
+        Boolean done = true
+    }
+}
+
+task ValidateEntrezTable {
+    meta {
+        # volatile: true so this content validation always runs against the current table rather than
+        # returning a cached "pass" from a previous run.
+        volatile: true
+    }
+
+    input {
+        String project_id
+        String dataset_name
+        String entrez_table_name
+        # Intentionally unused: passed solely to enforce ordering after LoadEntrezDataIntoBigQuery.
+        #@ except: UnusedInput
+        Boolean load_done
+        String variants_docker
+    }
+
+    command <<<
+        # Prepend date, time and pwd to xtrace log entries.
+        PS4='\D{+%F %T} \w $ '
+        set -o errexit -o nounset -o pipefail -o xtrace
+
+        # check_entrez_table.py exits non-zero (failing this task) if the table is empty/undersized or has
+        # NULL/non-numeric GeneIDs or missing Ensembl_gene_identifiers (the gene-level join key).
+        python3 /app/check_entrez_table.py \
+            --fq_entrez_table ~{project_id}.~{dataset_name}.~{entrez_table_name} \
+            --query_project ~{project_id}
+    >>>
+
+    runtime {
+        docker: variants_docker
+        memory: "3 GB"
+        preemptible: 3
+        cpu: 1
+        disks: "local-disk 100 HDD"
+    }
+
+    output {
         Boolean done = true
     }
 }
@@ -1640,11 +1690,33 @@ task BigQueryLoadJson {
         'UPDATE `~{dataset_name}.~{variant_transcript_table}` vtt SET vtt.mane_plus_clinical_name = mane.name FROM `~{dataset_name}.~{mane_table_name}` mane WHERE vtt.transcript = mane.Ensembl_nuc AND mane.MANE_status = "MANE Plus Clinical" AND vtt.transcript is not null;'
 
         echo "Adding Entrez gene ID data to the pre-vat table ~{dataset_name}.~{variant_transcript_table}"
+        # entrez_gene_id is a gene-level attribute, so we map by Ensembl gene (vtt.gene_id -> entrez.Ensembl_gene_identifier)
+        # rather than by transcript. Ensembl gene IDs are unversioned and always present on both sides, whereas the
+        # transcript columns are versioned and only cover a curated subset, so a transcript-keyed join populated only
+        # ~26% of eligible rows vs. ~92% for the gene-keyed join. Ensembl gene IDs are compared version-stripped for
+        # safety even though they are normally unversioned.
+        # An Ensembl gene can legitimately map to more than one NCBI GeneID (~0.7% of genes; Ensembl and NCBI are
+        # independent authorities that sometimes draw gene boundaries differently), so we ARRAY_AGG all GeneIDs into the
+        # repeated entrez_gene_id field. The GROUP BY collapses the source to exactly one row per gene, which the UPDATE
+        # requires. An unmatched row is left as an empty array [] (not NULL).
         # tax_id = 9606 filters for Homo sapiens. GVS exclusively processes human data, so this is intentionally
         # hardcoded rather than parameterized. The filter also acts as a safeguard in case an unfiltered
         # gene2ensembl file (covering all species) is passed instead of the human-only extract.
-        bq --apilog=false --project_id=~{project_id} query --format=csv --use_legacy_sql=false ~{bq_labels} \
-        'UPDATE `~{dataset_name}.~{variant_transcript_table}` vtt SET vtt.entrez_gene_id = CAST(entrez.GeneID AS INT64) FROM `~{dataset_name}.~{entrez_table_name}` entrez WHERE vtt.transcript = entrez.Ensembl_rna_identifier AND entrez.tax_id = 9606 AND vtt.transcript is not null;'
+        bq --apilog=false --project_id=~{project_id} query --format=csv --use_legacy_sql=false ~{bq_labels} '
+        UPDATE `~{dataset_name}.~{variant_transcript_table}` vtt
+        SET vtt.entrez_gene_id = gene_map.gene_ids
+        FROM (
+            SELECT
+                SPLIT(Ensembl_gene_identifier, ".")[OFFSET(0)] AS ensembl_gene_base,
+                ARRAY_AGG(DISTINCT CAST(GeneID AS INT64) IGNORE NULLS) AS gene_ids
+            FROM `~{dataset_name}.~{entrez_table_name}`
+            WHERE Ensembl_gene_identifier IS NOT NULL
+              AND Ensembl_gene_identifier != "-"
+              AND tax_id = 9606
+            GROUP BY ensembl_gene_base
+        ) gene_map
+        WHERE vtt.gene_id IS NOT NULL
+          AND SPLIT(vtt.gene_id, ".")[OFFSET(0)] = gene_map.ensembl_gene_base;'
 
         if [[ "~{run_vep_loftee_update}" == "true" ]]; then
         echo "Adding VEP + LOFTEE annotation data to the pre-vat table ~{dataset_name}.~{variant_transcript_table}"

--- a/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
@@ -83,7 +83,10 @@ workflow GvsCreateVATfromVDS {
     File mane_annotation_file = "gs://gvs_quickstart_storage/MANE/MANE_human/release_1.4/MANE.GRCh38.v1.4.summary.txt"
 
     # gene2ensembl_human.tsv is extracted and filtered for humans from https://ftp.ncbi.nlm.nih.gov/gene/DATA/gene2ensembl.gz
-    # There is also a more comprehensive and very large https://ftp.ncbi.nlm.nih.gov/gene/DATA/gene_info.gz to use if necessary.
+    # gene2ensembl provides Entrez-to-Ensembl transcript mappings, which is all that is needed for the VAT join.
+    # gene_info.gz (https://ftp.ncbi.nlm.nih.gov/gene/DATA/gene_info.gz) is a larger alternative that includes gene
+    # descriptions, synonyms, and other metadata, but is significantly larger and slower to load. Prefer gene2ensembl
+    # unless additional gene-level annotations beyond the Entrez ID are required.
     File entrez_annotation_file = "gs://gvs_quickstart_storage/Entrez/gene2ensembl_human.tsv"
 
     # Always call `GetToolVersions` to get the git hash for this run as this is a top-level-only WDL (i.e. there are
@@ -1637,6 +1640,9 @@ task BigQueryLoadJson {
         'UPDATE `~{dataset_name}.~{variant_transcript_table}` vtt SET vtt.mane_plus_clinical_name = mane.name FROM `~{dataset_name}.~{mane_table_name}` mane WHERE vtt.transcript = mane.Ensembl_nuc AND mane.MANE_status = "MANE Plus Clinical" AND vtt.transcript is not null;'
 
         echo "Adding Entrez gene ID data to the pre-vat table ~{dataset_name}.~{variant_transcript_table}"
+        # tax_id = 9606 filters for Homo sapiens. GVS exclusively processes human data, so this is intentionally
+        # hardcoded rather than parameterized. The filter also acts as a safeguard in case an unfiltered
+        # gene2ensembl file (covering all species) is passed instead of the human-only extract.
         bq --apilog=false --project_id=~{project_id} query --format=csv --use_legacy_sql=false ~{bq_labels} \
         'UPDATE `~{dataset_name}.~{variant_transcript_table}` vtt SET vtt.entrez_gene_id = CAST(entrez.GeneID AS INT64) FROM `~{dataset_name}.~{entrez_table_name}` entrez WHERE vtt.transcript = entrez.Ensembl_rna_identifier AND entrez.tax_id = 9606 AND vtt.transcript is not null;'
 

--- a/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
@@ -81,7 +81,7 @@ workflow GvsCreateVATfromVDS {
 
     String region = "us-central1"
     File mane_annotation_file = "gs://gvs_quickstart_storage/MANE/MANE_human/release_1.4/MANE.GRCh38.v1.4.summary.txt"
-    File entrez_annotation_file = "gs://gvs-internal/Entrez/gene2ensembl_human.tsv"
+    File entrez_annotation_file = "gs://gvs_quickstart_storage/Entrez/gene2ensembl_human.tsv"
 
     # Always call `GetToolVersions` to get the git hash for this run as this is a top-level-only WDL (i.e. there are
     # no calling WDLs that might supply `git_hash`).

--- a/scripts/variantstore/variant-annotations-table/GvsValidateVAT.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsValidateVAT.wdl
@@ -172,6 +172,16 @@ workflow GvsValidateVat {
             cloud_sdk_docker = effective_cloud_sdk_docker,
     }
 
+    # Runs for both large and small callsets (unlike CheckForNullColumns, which is large-only): entrez_gene_id
+    # is populated for every callset, and the quickstart (small) is where coverage is most easily regressed.
+    call CheckEntrezGeneIdCoverage {
+        input:
+            project_id = project_id,
+            fq_vat_table = fq_vat_table,
+            last_modified_timestamp = VatDateTime.last_modified_timestamp,
+            variants_docker = effective_variants_docker,
+    }
+
     # Check if the input boolean `is_small_callset` is defined,
     # if not use the `GetNumSamples` task to find the number of samples in the callset and set the flag if it's < 10000
     Boolean callset_is_small = select_first([is_small_callset, select_first([GetNumSamplesLoaded.num_samples, 1]) < 10000])
@@ -220,7 +230,8 @@ workflow GvsValidateVat {
                            SpotCheckForManeSelectTranscript.pass,
                            SpotCheckForEntrezGeneId.pass,
                            SpotCheckForAAChangeAndExonNumberConsistency.pass,
-                           CheckForNullColumns.pass
+                           CheckForNullColumns.pass,
+                           CheckEntrezGeneIdCoverage.pass
                            ],
                 validation_names = [
                                    EnsureVatTableHasVariants.name,
@@ -240,7 +251,8 @@ workflow GvsValidateVat {
                                    SpotCheckForManeSelectTranscript.name,
                                    SpotCheckForEntrezGeneId.name,
                                    SpotCheckForAAChangeAndExonNumberConsistency.name,
-                                   CheckForNullColumns.name
+                                   CheckForNullColumns.name,
+                                   CheckEntrezGeneIdCoverage.name
                                    ],
                 validation_results = [
                                      EnsureVatTableHasVariants.result,
@@ -260,7 +272,8 @@ workflow GvsValidateVat {
                                      SpotCheckForManeSelectTranscript.result,
                                      SpotCheckForEntrezGeneId.result,
                                      SpotCheckForAAChangeAndExonNumberConsistency.result,
-                                     CheckForNullColumns.result
+                                     CheckForNullColumns.result,
+                                     CheckEntrezGeneIdCoverage.result
                                      ],
                 cloud_sdk_docker = effective_cloud_sdk_docker,
         }
@@ -285,6 +298,7 @@ workflow GvsValidateVat {
                            SchemaAAChangeAndExonNumberConsistent.pass,
                            SpotCheckForManeSelectTranscript.pass,
                            SpotCheckForEntrezGeneId.pass,
+                           CheckEntrezGeneIdCoverage.pass,
                            ],
                 validation_names = [
                                    EnsureVatTableHasVariants.name,
@@ -302,6 +316,7 @@ workflow GvsValidateVat {
                                    SchemaAAChangeAndExonNumberConsistent.name,
                                    SpotCheckForManeSelectTranscript.name,
                                    SpotCheckForEntrezGeneId.name,
+                                   CheckEntrezGeneIdCoverage.name,
                                    ],
                 validation_results = [
                                      EnsureVatTableHasVariants.result,
@@ -319,6 +334,7 @@ workflow GvsValidateVat {
                                      SchemaAAChangeAndExonNumberConsistent.result,
                                      SpotCheckForManeSelectTranscript.result,
                                      SpotCheckForEntrezGeneId.result,
+                                     CheckEntrezGeneIdCoverage.result,
                                      ],
                 cloud_sdk_docker = effective_cloud_sdk_docker,
         }
@@ -1505,17 +1521,19 @@ task SpotCheckForEntrezGeneId {
 
         echo "project_id = ~{project_id}" > ~/.bigqueryrc
 
+        # entrez_gene_id is a repeated field, so membership is tested with `<id> IN UNNEST(entrez_gene_id)`
+        # rather than an equality comparison.
         # bq query --max_rows check: ok single row
         bq --apilog=false query --nouse_legacy_sql --project_id=~{project_id} --format=csv 'SELECT
-        COUNT (DISTINCT entrez_gene_id) FROM
+        COUNT (DISTINCT gene) FROM
         (
-            SELECT entrez_gene_id
+            SELECT 25980 AS gene
             FROM `~{fq_vat_table}`
-            WHERE entrez_gene_id = 25980
+            WHERE 25980 IN UNNEST(entrez_gene_id)
         UNION ALL
-            SELECT entrez_gene_id
+            SELECT 22 AS gene
             FROM `~{fq_vat_table}`
-            WHERE entrez_gene_id = 22
+            WHERE 22 IN UNNEST(entrez_gene_id)
         )' > output.csv
 
         NUMVARS=$(tail -n +2 output.csv | head -n1 | tr -d '\r')
@@ -1584,6 +1602,43 @@ task CheckForNullColumns {
     output {
         Boolean pass = read_boolean(pf_file)
         String name = "CheckForNullColumns"
+        String result = read_string(results_file)
+    }
+}
+
+task CheckEntrezGeneIdCoverage {
+    input {
+        String project_id
+        String fq_vat_table
+        # Intentionally unused: passed solely to bust WDL call-caching when the referenced BigQuery table has been modified.
+        #@ except: UnusedInput
+        String last_modified_timestamp
+        String variants_docker
+    }
+    String pf_file = "pf.txt"
+    String results_file = "results.txt"
+
+    command <<<
+        # check_entrez_vat_annotations.py fails if entrez_gene_id coverage over gene-bearing rows falls below
+        # the threshold (guards against regressing to the sparse transcript-keyed join) or if any gene_id maps
+        # to more than one distinct entrez_gene_id array (entrez_gene_id is a gene-level attribute).
+        python3 /app/check_entrez_vat_annotations.py --fq_vat_table ~{fq_vat_table} \
+            --query_project ~{project_id} \
+            --pass_file_output ~{pf_file} \
+            --results_file_output ~{results_file}
+    >>>
+
+    runtime {
+        docker: variants_docker
+        memory: "3 GB"
+        disks: "local-disk 10 HDD"
+        preemptible: 3
+        cpu: 1
+    }
+
+    output {
+        Boolean pass = read_boolean(pf_file)
+        String name = "CheckEntrezGeneIdCoverage"
         String result = read_string(results_file)
     }
 }

--- a/scripts/variantstore/variant-annotations-table/GvsValidateVAT.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsValidateVAT.wdl
@@ -1493,8 +1493,8 @@ task SpotCheckForEntrezGeneId {
     String results_file = "results.txt"
 
     # This test runs a spot check on the VAT table to verify that known Entrez Gene IDs are present.
-    # TP53 (GeneID=7157) and BRCA1 (GeneID=672) are used as reference genes.
-    # Update these GeneIDs if the callset does not contain variants in these genes.
+    # AAR2 (GeneID=25980, chr20) and ABCB7 (GeneID=22, chrX) are used as reference genes,
+    # as both are present in quickstart and full callsets.
 
     command <<<
         # Prepend date, time and pwd to xtrace log entries.
@@ -1509,11 +1509,11 @@ task SpotCheckForEntrezGeneId {
         (
             SELECT entrez_gene_id
             FROM `~{fq_vat_table}`
-            WHERE entrez_gene_id = 7157
+            WHERE entrez_gene_id = 25980
         UNION ALL
             SELECT entrez_gene_id
             FROM `~{fq_vat_table}`
-            WHERE entrez_gene_id = 672
+            WHERE entrez_gene_id = 22
         )' > output.csv
 
         NUMVARS=$(python3 -c "csvObj=open('output.csv','r');csvContents=csvObj.read();print(csvContents.split('\n')[1]);")

--- a/scripts/variantstore/variant-annotations-table/GvsValidateVAT.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsValidateVAT.wdl
@@ -164,6 +164,14 @@ workflow GvsValidateVat {
             cloud_sdk_docker = effective_cloud_sdk_docker,
     }
 
+    call SpotCheckForEntrezGeneId {
+        input:
+            project_id = project_id,
+            fq_vat_table = fq_vat_table,
+            last_modified_timestamp = VatDateTime.last_modified_timestamp,
+            cloud_sdk_docker = effective_cloud_sdk_docker,
+    }
+
     # Check if the input boolean `is_small_callset` is defined,
     # if not use the `GetNumSamples` task to find the number of samples in the callset and set the flag if it's < 10000
     Boolean callset_is_small = select_first([is_small_callset, select_first([GetNumSamplesLoaded.num_samples, 1]) < 10000])
@@ -210,6 +218,7 @@ workflow GvsValidateVat {
                            ClinvarSignificance.pass,
                            SchemaAAChangeAndExonNumberConsistent.pass,
                            SpotCheckForManeSelectTranscript.pass,
+                           SpotCheckForEntrezGeneId.pass,
                            SpotCheckForAAChangeAndExonNumberConsistency.pass,
                            CheckForNullColumns.pass
                            ],
@@ -229,6 +238,7 @@ workflow GvsValidateVat {
                                    ClinvarSignificance.name,
                                    SchemaAAChangeAndExonNumberConsistent.name,
                                    SpotCheckForManeSelectTranscript.name,
+                                   SpotCheckForEntrezGeneId.name,
                                    SpotCheckForAAChangeAndExonNumberConsistency.name,
                                    CheckForNullColumns.name
                                    ],
@@ -248,6 +258,7 @@ workflow GvsValidateVat {
                                      ClinvarSignificance.result,
                                      SchemaAAChangeAndExonNumberConsistent.result,
                                      SpotCheckForManeSelectTranscript.result,
+                                     SpotCheckForEntrezGeneId.result,
                                      SpotCheckForAAChangeAndExonNumberConsistency.result,
                                      CheckForNullColumns.result
                                      ],
@@ -273,6 +284,7 @@ workflow GvsValidateVat {
                            DuplicateAnnotations.pass,
                            SchemaAAChangeAndExonNumberConsistent.pass,
                            SpotCheckForManeSelectTranscript.pass,
+                           SpotCheckForEntrezGeneId.pass,
                            ],
                 validation_names = [
                                    EnsureVatTableHasVariants.name,
@@ -289,6 +301,7 @@ workflow GvsValidateVat {
                                    DuplicateAnnotations.name,
                                    SchemaAAChangeAndExonNumberConsistent.name,
                                    SpotCheckForManeSelectTranscript.name,
+                                   SpotCheckForEntrezGeneId.name,
                                    ],
                 validation_results = [
                                      EnsureVatTableHasVariants.result,
@@ -305,6 +318,7 @@ workflow GvsValidateVat {
                                      DuplicateAnnotations.result,
                                      SchemaAAChangeAndExonNumberConsistent.result,
                                      SpotCheckForManeSelectTranscript.result,
+                                     SpotCheckForEntrezGeneId.result,
                                      ],
                 cloud_sdk_docker = effective_cloud_sdk_docker,
         }
@@ -1461,6 +1475,78 @@ task SpotCheckForManeSelectTranscript {
     output {
         Boolean pass = read_boolean(pf_file)
         String name = "SpotCheckForManeSelectTranscript"
+        String result = read_string(results_file)
+    }
+}
+
+task SpotCheckForEntrezGeneId {
+    input {
+        String project_id
+        String fq_vat_table
+        # Intentionally unused: passed solely to bust WDL call-caching when the referenced BigQuery table has been modified.
+        #@ except: UnusedInput
+        String last_modified_timestamp
+        String cloud_sdk_docker
+    }
+
+    String pf_file = "pf.txt"
+    String results_file = "results.txt"
+
+    # This test runs a spot check on the VAT table to verify that known Entrez Gene IDs are present.
+    # TP53 (GeneID=7157) and BRCA1 (GeneID=672) are used as reference genes.
+    # Update these GeneIDs if the callset does not contain variants in these genes.
+
+    command <<<
+        # Prepend date, time and pwd to xtrace log entries.
+        PS4='\D{+%F %T} \w $ '
+        set -o errexit -o nounset -o pipefail -o xtrace
+
+        echo "project_id = ~{project_id}" > ~/.bigqueryrc
+
+        # bq query --max_rows check: ok single row
+        bq --apilog=false query --nouse_legacy_sql --project_id=~{project_id} --format=csv 'SELECT
+        COUNT (DISTINCT entrez_gene_id) FROM
+        (
+            SELECT entrez_gene_id
+            FROM `~{fq_vat_table}`
+            WHERE entrez_gene_id = 7157
+        UNION ALL
+            SELECT entrez_gene_id
+            FROM `~{fq_vat_table}`
+            WHERE entrez_gene_id = 672
+        )' > output.csv
+
+        NUMVARS=$(python3 -c "csvObj=open('output.csv','r');csvContents=csvObj.read();print(csvContents.split('\n')[1]);")
+
+        echo "false" > ~{pf_file}
+        # if the result of the bq call and the csv parsing is a series of digits, then check that it isn't 0
+        if [[ $NUMVARS =~ ^[0-9]+$ ]]; then
+            if [[ $NUMVARS -eq 2 ]]; then
+                echo "true" > ~{pf_file}
+                echo "The VAT table ~{fq_vat_table} has been successfully spot checked for known Entrez Gene IDs." > ~{results_file}
+            else
+                echo "The VAT table ~{fq_vat_table} has failed the spot check for known Entrez Gene IDs." > ~{results_file}
+            fi
+        # otherwise, something is off, so return the output from the bq query call
+        else
+            echo "Something went wrong. The attempt to count the spot checked entries returned: " $(cat output.csv) >&2
+            exit 1
+        fi
+    >>>
+
+    # ------------------------------------------------
+    # Runtime settings:
+    runtime {
+        docker: cloud_sdk_docker
+        memory: "1 GB"
+        preemptible: 3
+        cpu: 1
+        disks: "local-disk 100 HDD"
+    }
+
+    output {
+        Boolean pass = read_boolean(pf_file)
+        String name = "SpotCheckForEntrezGeneId"
         String result = read_string(results_file)
     }
 }

--- a/scripts/variantstore/variant-annotations-table/GvsValidateVAT.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsValidateVAT.wdl
@@ -1516,7 +1516,7 @@ task SpotCheckForEntrezGeneId {
             WHERE entrez_gene_id = 22
         )' > output.csv
 
-        NUMVARS=$(python3 -c "csvObj=open('output.csv','r');csvContents=csvObj.read();print(csvContents.split('\n')[1]);")
+        NUMVARS=$(tail -n +2 output.csv | head -n1 | tr -d '\r')
 
         echo "false" > ~{pf_file}
         # if the result of the bq call and the csv parsing is a series of digits, then check that it isn't 0

--- a/scripts/variantstore/variant-annotations-table/GvsValidateVAT.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsValidateVAT.wdl
@@ -1493,8 +1493,10 @@ task SpotCheckForEntrezGeneId {
     String results_file = "results.txt"
 
     # This test runs a spot check on the VAT table to verify that known Entrez Gene IDs are present.
-    # AAR2 (GeneID=25980, chr20) and ABCB7 (GeneID=22, chrX) are used as reference genes,
-    # as both are present in quickstart and full callsets.
+    # AAR2 (GeneID=25980, chr20) and ABCB7 (GeneID=22, chrX) are used as reference genes because both
+    # are present in the quickstart callset (chr20 and chrX only) as well as full callsets.
+    # If the quickstart data is refreshed and these genes are no longer covered, update the GeneIDs here
+    # to genes confirmed present in the new quickstart dataset.
 
     command <<<
         # Prepend date, time and pwd to xtrace log entries.

--- a/scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
+++ b/scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
@@ -39,7 +39,7 @@ workflow GvsQuickstartIntegration {
     }
 
     String expected_subdir = if (!chr20_X_Y_only) then "all_chrs/"  else ""
-    File expected_output_prefix = "gs://gvs-internal-quickstart/integration/2026-03-12/" + expected_subdir
+    File expected_output_prefix = "gs://gvs-internal-quickstart/integration/2026-07-09/" + expected_subdir
     File truth_data_prefix = "gs://gvs-internal-quickstart/integration/test_data/2025-12-05/" + expected_subdir
 
     # WDL 1.0 trick to set a variable ('none') to be undefined.


### PR DESCRIPTION
## Summary

This PR adds **Entrez Gene ID** annotation support to the GATK Variant Annotation Table (VAT). Here are the high-level changes:

### **Schema Changes (2 files)**
- Added a new nullable Integer field `entrez_gene_id` to both:
  - `variant_transcript_schema.json`
  - `vat_schema.json`

### **WDL Workflow Updates**

**GvsCreateVATfromVDS.wdl** 
- Adds a new task `LoadEntrezDataIntoBigQuery` that loads Entrez gene annotation data from a TSV file into BigQuery
- Passes an `entrez_table_name` parameter to downstream tasks
- Updates the `BigQueryLoadJson` task to perform a SQL UPDATE that matches Entrez Gene IDs to transcripts using Ensembl RNA identifiers and taxonomy ID 9606 (human)

**GvsValidateVat.wdl**:
- Adds a new validation task `SpotCheckForEntrezGeneId` that spot-checks the VAT table by verifying known Entrez Gene IDs (AAR2:25980 and ABCB7:22) are present in the data
- Integrates this validation check into the workflow's validation reporting

### **CI Configuration**
- Added the new branch `ng_gvs_entrez_annnotations` to the Dockstore workflow configuration in `.dockstore.yml`
