### PR TITLE
Fix MANE under-annotation [VS-1970]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -340,7 +340,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1970_fix_mane_under_annotation
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -340,7 +340,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_1963_vat_index
+             - vs_1970_fix_mane_under_annotation
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,19 @@ This is a Google Cloud SDK Alpine-based Docker image to which many useful tools,
 Python packages, and scripts have been added. This can be built on a developer's
 local machine using the `scripts/variantstore/scripts/build_docker.sh` script.
 
+The Python scripts under `scripts/variantstore/scripts/` are baked into this image at `/app/`, and
+WDL tasks that set `docker: variants_docker` invoke them as `python3 /app/<script>.py`. **Editing or
+adding such a script has no effect on a running workflow until the image is rebuilt and the new tag
+is wired in** — a common trap (the WDL keeps using the old image). So whenever you change anything
+baked into the image (a script, an added tool, or a Python package):
+
+1. Run `scripts/variantstore/scripts/build_docker.sh`. It builds the alpine-based image, runs the
+   unit tests, and pushes it to GAR with a tag of the form `<ISO-8601 date>-alpine-<12-char image
+   id>`, e.g. `us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-06-30-alpine-766e78c05289`.
+2. Update the `variants_docker` value in the `GetToolVersions` task of `GvsUtils.wdl` to that new
+   tag. Workflows resolve the image through `GetToolVersions`, so this step is what makes the rebuilt
+   image actually take effect.
+
 ### Nirvana Docker Image
 
 This is an Illumina Nirvana-based Docker image build from

--- a/scripts/variantstore/scripts/check_mane_coverage.py
+++ b/scripts/variantstore/scripts/check_mane_coverage.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+# Validates that the MANE join populated the VAT with the coverage it should (VS-1970).
+#
+# MANE is sparse (~19k transcripts, one MANE Select per gene), so a plain "fraction of rows populated"
+# check is meaningless -- most rows legitimately have no MANE flag. Instead this compares, per
+# MANE_status, the transcripts that SHOULD be flagged (MANE transcripts whose version-stripped base is
+# present in the VAT) against those that ARE flagged (a VAT row with that base has the mane_*_name
+# column set). A correct version-insensitive join flags ~100% of the present transcripts; a regression
+# to exact-version matching (the VS-1970 bug) flags only ~6% and fails this check. The check re-derives
+# the expected set with its own version-stripping, so a matching bug on the WDL side also shows up as a
+# divergence. It cannot catch an error in the shared premise that version-insensitive matching is
+# correct -- but that premise is well established (base ENST accessions are stable).
+import argparse
+import sys
+
+from google.cloud import bigquery
+from google.cloud.bigquery.job import QueryJobConfig
+
+import utils
+
+
+def write_output_files(passed, message, pass_file_output, results_file_output):
+    with open(pass_file_output, 'w') as pass_file, open(results_file_output, 'w') as results_file:
+        pass_file.write('true' if passed else 'false')
+        results_file.write(message)
+
+
+def check_mane_coverage(fq_vat_table, fq_mane_table, query_project, min_coverage,
+                        pass_file_output, results_file_output):
+    query_labels_map = {
+        "id": "check_mane_coverage",
+        "gvs_tool_name": "gvs_validate_mane"
+    }
+    # add labels for DSP Cloud Cost Control Labeling and Reporting
+    query_labels_map.update({'service': 'gvs', 'team': 'variants', 'managedby': 'create_vat'})
+
+    default_config = QueryJobConfig(labels=query_labels_map, priority="INTERACTIVE",
+                                    use_query_cache=True, use_legacy_sql=False)
+    client = bigquery.Client(project=query_project, default_query_job_config=default_config)
+
+    # Per MANE_status: how many MANE transcripts are present in the callset (base match), and how many
+    # of those are actually flagged. The `vat` CTE collapses to one row per base transcript, recording
+    # whether any VAT row with that base carries each mane_*_name.
+    sql = f"""
+        WITH vat AS (
+            SELECT
+                SPLIT(transcript, '.')[OFFSET(0)] AS base,
+                LOGICAL_OR(mane_select_name IS NOT NULL)        AS has_select,
+                LOGICAL_OR(mane_plus_clinical_name IS NOT NULL) AS has_plus_clinical
+            FROM `{fq_vat_table}`
+            WHERE transcript IS NOT NULL
+            GROUP BY base
+        ),
+        mane AS (
+            SELECT DISTINCT MANE_status, SPLIT(Ensembl_nuc, '.')[OFFSET(0)] AS base
+            FROM `{fq_mane_table}`
+            WHERE Ensembl_nuc IS NOT NULL AND Ensembl_nuc != '-'
+              AND MANE_status IN ('MANE Select', 'MANE Plus Clinical')
+        )
+        SELECT
+            m.MANE_status AS mane_status,
+            COUNTIF(v.base IS NOT NULL) AS present_in_callset,
+            COUNTIF(v.base IS NOT NULL AND (
+                (m.MANE_status = 'MANE Select'        AND v.has_select) OR
+                (m.MANE_status = 'MANE Plus Clinical' AND v.has_plus_clinical)
+            )) AS flagged
+        FROM mane m
+        LEFT JOIN vat v ON v.base = m.base
+        GROUP BY m.MANE_status
+        ORDER BY m.MANE_status
+    """
+
+    rows = list(utils.execute_with_retry(client, "validate mane coverage", sql).get('results'))
+
+    lines = []
+    failures = []
+    for row in rows:
+        status = row.get('mane_status')
+        present = row.get('present_in_callset')
+        flagged = row.get('flagged')
+        if present == 0:
+            lines.append(f"{status}: 0 present in callset (skipped)")
+            continue
+        coverage = flagged / present
+        lines.append(f"{status}: {flagged}/{present} flagged ({coverage:.1%})")
+        if coverage < min_coverage:
+            failures.append(f"{status} coverage {coverage:.1%} is below the {min_coverage:.0%} floor "
+                            f"({flagged} of {present} present transcripts flagged); the MANE join may "
+                            f"have regressed to exact-version matching")
+
+    if not rows:
+        failures.append("no MANE rows found; the mane_annotations table may be missing or empty")
+
+    passed = not failures
+    prefix = "MANE coverage passed" if passed else "MANE coverage FAILED"
+    message = f"{prefix}. " + "; ".join(lines)
+    if failures:
+        message += " || " + " || ".join(failures)
+
+    print(message)
+    write_output_files(passed, message, pass_file_output, results_file_output)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(allow_abbrev=False,
+                                     description='Validate MANE annotation coverage in the VAT')
+    parser.add_argument('--fq_vat_table', type=str, required=True,
+                        help='fully-qualified VAT table (project.dataset.table)')
+    parser.add_argument('--fq_mane_table', type=str, required=True,
+                        help='fully-qualified MANE annotations table (project.dataset.mane_annotations)')
+    parser.add_argument('--query_project', type=str, required=True,
+                        help='Google project to run the BigQuery queries with')
+    parser.add_argument('--min_coverage', type=float, required=False, default=0.95,
+                        help='minimum fraction of present MANE transcripts that must be flagged')
+    parser.add_argument('--pass_file_output', type=str, required=True,
+                        help='path to write the pass/fail boolean')
+    parser.add_argument('--results_file_output', type=str, required=True,
+                        help='path to write the human-readable result')
+    args = parser.parse_args()
+
+    check_mane_coverage(args.fq_vat_table,
+                        args.fq_mane_table,
+                        args.query_project,
+                        args.min_coverage,
+                        args.pass_file_output,
+                        args.results_file_output)

--- a/scripts/variantstore/scripts/check_mane_coverage.py
+++ b/scripts/variantstore/scripts/check_mane_coverage.py
@@ -5,11 +5,19 @@
 # check is meaningless -- most rows legitimately have no MANE flag. Instead this compares, per
 # MANE_status, the transcripts that SHOULD be flagged (MANE transcripts whose version-stripped base is
 # present in the VAT) against those that ARE flagged (a VAT row with that base has the mane_*_name
-# column set). A correct version-insensitive join flags ~100% of the present transcripts; a regression
+# column set). A correct version-insensitive join flags 100% of the present transcripts; a regression
 # to exact-version matching (the VS-1970 bug) flags only ~6% and fails this check. The check re-derives
 # the expected set with its own version-stripping, so a matching bug on the WDL side also shows up as a
 # divergence. It cannot catch an error in the shared premise that version-insensitive matching is
 # correct -- but that premise is well established (base ENST accessions are stable).
+#
+# A second, coarser metric is also reported: catalog utilization, the fraction of the entire MANE
+# catalog (per status) that ended up annotated in the VAT. Unlike coverage, this depends on the
+# callset's genomic breadth, not on join correctness: a whole-genome callset exercises nearly the whole
+# MANE catalog even with a few samples (~94% for MANE Select, ~88% for the tiny Plus Clinical set),
+# whereas an interval-restricted callset (e.g. the chr20/X/Y quickstart) legitimately uses only a
+# fraction. It is therefore gated only when the caller says the callset is genome-wide, and then only
+# against a loose floor -- a gross-failure tripwire, not a tight assertion.
 import argparse
 import sys
 
@@ -26,7 +34,7 @@ def write_output_files(passed, message, pass_file_output, results_file_output):
 
 
 def check_mane_coverage(fq_vat_table, fq_mane_table, query_project, min_coverage,
-                        pass_file_output, results_file_output):
+                        min_catalog_utilization, pass_file_output, results_file_output):
     query_labels_map = {
         "id": "check_mane_coverage",
         "gvs_tool_name": "gvs_validate_mane"
@@ -59,6 +67,7 @@ def check_mane_coverage(fq_vat_table, fq_mane_table, query_project, min_coverage
         )
         SELECT
             m.MANE_status AS mane_status,
+            COUNT(*) AS total_in_catalog,
             COUNTIF(v.base IS NOT NULL) AS present_in_callset,
             COUNTIF(v.base IS NOT NULL AND (
                 (m.MANE_status = 'MANE Select'        AND v.has_select) OR
@@ -76,17 +85,25 @@ def check_mane_coverage(fq_vat_table, fq_mane_table, query_project, min_coverage
     failures = []
     for row in rows:
         status = row.get('mane_status')
+        total = row.get('total_in_catalog')
         present = row.get('present_in_callset')
         flagged = row.get('flagged')
         if present == 0:
             lines.append(f"{status}: 0 present in callset (skipped)")
             continue
         coverage = flagged / present
-        lines.append(f"{status}: {flagged}/{present} flagged ({coverage:.1%})")
+        utilization = flagged / total if total else 0.0
+        lines.append(f"{status}: {flagged}/{present} present transcripts flagged ({coverage:.1%}); "
+                     f"{flagged}/{total} of catalog used ({utilization:.1%})")
         if coverage < min_coverage:
             failures.append(f"{status} coverage {coverage:.1%} is below the {min_coverage:.0%} floor "
                             f"({flagged} of {present} present transcripts flagged); the MANE join may "
                             f"have regressed to exact-version matching")
+        if min_catalog_utilization > 0 and utilization < min_catalog_utilization:
+            failures.append(f"{status} catalog utilization {utilization:.1%} is below the "
+                            f"{min_catalog_utilization:.0%} floor ({flagged} of {total} MANE transcripts "
+                            f"used); on a genome-wide callset nearly the entire MANE catalog should be "
+                            f"annotated, so this points to a gross MANE-annotation failure upstream")
 
     if not rows:
         failures.append("no MANE rows found; the mane_annotations table may be missing or empty")
@@ -110,8 +127,13 @@ if __name__ == '__main__':
                         help='fully-qualified MANE annotations table (project.dataset.mane_annotations)')
     parser.add_argument('--query_project', type=str, required=True,
                         help='Google project to run the BigQuery queries with')
-    parser.add_argument('--min_coverage', type=float, required=False, default=0.95,
-                        help='minimum fraction of present MANE transcripts that must be flagged')
+    parser.add_argument('--min_coverage', type=float, required=False, default=1.0,
+                        help='minimum fraction of present MANE transcripts that must be flagged '
+                             '(a correct version-insensitive join flags all of them)')
+    parser.add_argument('--min_catalog_utilization', type=float, required=False, default=0.0,
+                        help='minimum fraction of the whole MANE catalog (per status) that must be '
+                             'annotated; callset-breadth dependent, so 0 (the default) disables it. '
+                             'Set > 0 only for genome-wide callsets, as a gross-failure tripwire.')
     parser.add_argument('--pass_file_output', type=str, required=True,
                         help='path to write the pass/fail boolean')
     parser.add_argument('--results_file_output', type=str, required=True,
@@ -122,5 +144,6 @@ if __name__ == '__main__':
                         args.fq_mane_table,
                         args.query_project,
                         args.min_coverage,
+                        args.min_catalog_utilization,
                         args.pass_file_output,
                         args.results_file_output)

--- a/scripts/variantstore/scripts/check_mane_table.py
+++ b/scripts/variantstore/scripts/check_mane_table.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+# Validates the loaded MANE (MANE.GRCh38.summary) BigQuery table before it is used to annotate the VAT.
+#
+# The MANE -> VAT join keys on the transcript (Ensembl_nuc, version-insensitive) and filters on
+# MANE_status, so this checks a row-count floor (which catches an empty or partially loaded table --
+# it would otherwise pass "table exists" and silently annotate nothing) plus the two columns the join
+# depends on: Ensembl_nuc must be a populated Ensembl transcript id, and MANE_status must be one of the
+# two expected values.
+import argparse
+import sys
+
+from google.cloud import bigquery
+from google.cloud.bigquery.job import QueryJobConfig
+
+import utils
+
+
+def check_mane_table(fq_mane_table, query_project, min_rows):
+    query_labels_map = {
+        "id": "check_mane_table",
+        "gvs_tool_name": "gvs_validate_mane"
+    }
+    # add labels for DSP Cloud Cost Control Labeling and Reporting
+    query_labels_map.update({'service': 'gvs', 'team': 'variants', 'managedby': 'create_vat'})
+
+    default_config = QueryJobConfig(labels=query_labels_map, priority="INTERACTIVE", use_query_cache=True, use_legacy_sql=False)
+    client = bigquery.Client(project=query_project,
+                             default_query_job_config=default_config)
+
+    sql = f"""
+        SELECT
+            COUNT(*) AS total_rows,
+            COUNTIF(Ensembl_nuc IS NULL OR NOT STARTS_WITH(Ensembl_nuc, 'ENST')) AS bad_transcripts,
+            COUNTIF(MANE_status NOT IN ('MANE Select', 'MANE Plus Clinical')) AS bad_statuses
+        FROM `{fq_mane_table}`
+    """
+
+    query_return = utils.execute_with_retry(client, "validate mane table", sql)
+    row = next(iter(query_return.get('results')))
+    total_rows = row.get('total_rows')
+    bad_transcripts = row.get('bad_transcripts')
+    bad_statuses = row.get('bad_statuses')
+
+    print(f"MANE table {fq_mane_table}: total_rows={total_rows}, bad_transcripts={bad_transcripts}, "
+          f"bad_statuses={bad_statuses}")
+
+    errors = []
+    if total_rows < min_rows:
+        errors.append(f"{total_rows} rows is below the expected floor of {min_rows} "
+                      f"(table may be empty or only partially loaded)")
+    if bad_transcripts > 0:
+        errors.append(f"{bad_transcripts} rows have a NULL or non-Ensembl (not ENST...) Ensembl_nuc "
+                      f"(the transcript join key)")
+    if bad_statuses > 0:
+        errors.append(f"{bad_statuses} rows have an unexpected MANE_status "
+                      f"(expected 'MANE Select' or 'MANE Plus Clinical')")
+
+    if errors:
+        print("MANE table validation FAILED:", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"MANE table validation passed: {total_rows} rows, all Ensembl_nuc are ENST, all MANE_status valid.")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(allow_abbrev=False,
+                                     description='Validate the loaded MANE (MANE.GRCh38.summary) BigQuery table')
+    parser.add_argument('--fq_mane_table', type=str, required=True,
+                        help='fully-qualified BigQuery MANE table (project.dataset.table)')
+    parser.add_argument('--query_project', type=str, required=True,
+                        help='Google project to run the BigQuery queries with')
+    parser.add_argument('--min_rows', type=int, required=False, default=15000,
+                        help='minimum expected row count; MANE 1.4 is ~19.4k rows')
+
+    args = parser.parse_args()
+
+    check_mane_table(args.fq_mane_table,
+                     args.query_project,
+                     args.min_rows)

--- a/scripts/variantstore/scripts/check_mane_table.py
+++ b/scripts/variantstore/scripts/check_mane_table.py
@@ -31,7 +31,7 @@ def check_mane_table(fq_mane_table, query_project, min_rows):
         SELECT
             COUNT(*) AS total_rows,
             COUNTIF(Ensembl_nuc IS NULL OR NOT STARTS_WITH(Ensembl_nuc, 'ENST')) AS bad_transcripts,
-            COUNTIF(MANE_status NOT IN ('MANE Select', 'MANE Plus Clinical')) AS bad_statuses
+            COUNTIF(MANE_status IS NULL OR MANE_status NOT IN ('MANE Select', 'MANE Plus Clinical')) AS bad_statuses
         FROM `{fq_mane_table}`
     """
 

--- a/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
@@ -1681,13 +1681,18 @@ task BigQueryLoadJson {
         echo ~{variant_transcripts_wildcarded_path}
         bq --apilog=false load --project_id=~{project_id} --source_format=NEWLINE_DELIMITED_JSON ~{dataset_name}.~{variant_transcript_table} ~{variant_transcripts_wildcarded_path}
 
+        # Match transcripts WITHOUT version suffixes (VS-1970): MANE's transcript versions run ahead of
+        # the Nirvana cache that produced vtt.transcript, so an exact match on vtt.transcript =
+        # mane.Ensembl_nuc silently dropped ~94% of MANE annotations. Strip versions, mirroring the
+        # version-insensitive VEP+LOFTEE join below. (No multi-match: each gene has one MANE Select
+        # transcript, so a base transcript is unique within a MANE_status.)
         echo "Adding the Mane SELECT annotation data to the pre-vat table ~{dataset_name}.~{variant_transcript_table}"
         bq --apilog=false --project_id=~{project_id} query --format=csv --use_legacy_sql=false ~{bq_labels} \
-        'UPDATE `~{dataset_name}.~{variant_transcript_table}` vtt SET vtt.mane_select_name = mane.name FROM `~{dataset_name}.~{mane_table_name}` mane WHERE vtt.transcript = mane.Ensembl_nuc AND mane.MANE_status = "MANE Select" AND vtt.transcript is not null;'
+        'UPDATE `~{dataset_name}.~{variant_transcript_table}` vtt SET vtt.mane_select_name = mane.name FROM `~{dataset_name}.~{mane_table_name}` mane WHERE SPLIT(vtt.transcript, ".")[OFFSET(0)] = SPLIT(mane.Ensembl_nuc, ".")[OFFSET(0)] AND mane.MANE_status = "MANE Select" AND vtt.transcript is not null;'
 
         echo "Adding the Mane Plus Clinical annotation data to the pre-vat table ~{dataset_name}.~{variant_transcript_table}"
         bq --apilog=false --project_id=~{project_id} query --format=csv --use_legacy_sql=false ~{bq_labels} \
-        'UPDATE `~{dataset_name}.~{variant_transcript_table}` vtt SET vtt.mane_plus_clinical_name = mane.name FROM `~{dataset_name}.~{mane_table_name}` mane WHERE vtt.transcript = mane.Ensembl_nuc AND mane.MANE_status = "MANE Plus Clinical" AND vtt.transcript is not null;'
+        'UPDATE `~{dataset_name}.~{variant_transcript_table}` vtt SET vtt.mane_plus_clinical_name = mane.name FROM `~{dataset_name}.~{mane_table_name}` mane WHERE SPLIT(vtt.transcript, ".")[OFFSET(0)] = SPLIT(mane.Ensembl_nuc, ".")[OFFSET(0)] AND mane.MANE_status = "MANE Plus Clinical" AND vtt.transcript is not null;'
 
         echo "Adding Entrez gene ID data to the pre-vat table ~{dataset_name}.~{variant_transcript_table}"
         # entrez_gene_id is a gene-level attribute, so we map by Ensembl gene (vtt.gene_id -> entrez.Ensembl_gene_identifier)

--- a/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsCreateVATfromVDS.wdl
@@ -213,6 +213,15 @@ workflow GvsCreateVATfromVDS {
                 variants_docker = effective_variants_docker,
         }
 
+        call ValidateManeTable {
+            input:
+                project_id = project_id,
+                dataset_name = dataset_name,
+                mane_table_name = LoadManeDataIntoBigQuery.mane_table,
+                load_done = LoadManeDataIntoBigQuery.done,
+                variants_docker = effective_variants_docker,
+        }
+
         call MakeSubpopulationFilesAndReadSchemaFiles {
             input:
                 input_ancestry_file = ancestry_file,
@@ -408,7 +417,7 @@ workflow GvsCreateVATfromVDS {
                 variant_transcripts_path = variant_transcripts_output_path,
                 genes_path = genes_output_path,
                 base_vat_table_name = effective_vat_table_name,
-                go = flatten([PrepVtAnnotationJson.done, PrepGenesAnnotationJson.done, [ValidateEntrezTable.done]]),
+                go = flatten([PrepVtAnnotationJson.done, PrepGenesAnnotationJson.done, [ValidateEntrezTable.done], [ValidateManeTable.done]]),
                 cloud_sdk_docker = effective_cloud_sdk_docker,
         }
 
@@ -1452,22 +1461,48 @@ task LoadManeDataIntoBigQuery {
         PS4='\D{+%F %T} \w $ '
         set -o errexit -o nounset -o pipefail -o xtrace
 
-        # Remove the leading comment character on the first line so BigQuery will name the columns all nice.
-        sed -i 's/^\#NCBI_GeneID/NCBI_GeneID/' ~{mane_data_file}
+        # Remove the leading comment character on the header (#NCBI_GeneID -> NCBI_GeneID) so BigQuery names
+        # the columns cleanly. Write to a temp file rather than editing in place, as the localized input file
+        # may be read-only (mirrors the Entrez load).
+        sed '1s/^\#NCBI_GeneID/NCBI_GeneID/' ~{mane_data_file} > mane_data_processed.tsv
 
         echo "project_id = ~{project_id}" > ~/.bigqueryrc
 
+        # Row-aware guard (mirrors the Entrez load): (re)load unless the table already exists AND has rows, so an
+        # existing-but-empty table left by a preempted or partial prior attempt is not silently trusted.
+        NEEDS_LOAD=1
         set +o errexit
-        bq --apilog=false show --project_id=~{project_id} ~{dataset_name}.~{mane_table_name} > /dev/null
+        bq --apilog=false show --project_id=~{project_id} ~{dataset_name}.~{mane_table_name} > /dev/null 2>&1
         BQ_SHOW_RC=$?
         set -o errexit
 
-        if [ $BQ_SHOW_RC -ne 0 ]; then
-            echo "Loading MANE annotations into table ~{dataset_name}.~{mane_table_name}"
-            bq --apilog=false load --project_id=~{project_id} --source_format=CSV --field_delimiter='\t' --skip_leading_rows=1 --autodetect ~{dataset_name}.~{mane_table_name} ~{mane_data_file}
-        else
-            echo "Found existing MANE annotations table ~{dataset_name}.~{mane_table_name}. Using it"
+        if [ $BQ_SHOW_RC -eq 0 ]; then
+            ROW_COUNT=$(bq --apilog=false --project_id=~{project_id} query --format=csv --use_legacy_sql=false \
+                'SELECT COUNT(*) FROM `~{project_id}.~{dataset_name}.~{mane_table_name}`' | tail -n1 | tr -d '\r')
+            if [[ "$ROW_COUNT" =~ ^[0-9]+$ && "$ROW_COUNT" -gt 0 ]]; then
+                NEEDS_LOAD=0
+                echo "Found existing non-empty MANE annotations table ~{dataset_name}.~{mane_table_name} ($ROW_COUNT rows). Using it"
+            else
+                echo "Existing MANE annotations table ~{dataset_name}.~{mane_table_name} is empty ($ROW_COUNT rows); reloading"
+            fi
         fi
+
+        if [ $NEEDS_LOAD -eq 1 ]; then
+            echo "Loading MANE annotations into table ~{dataset_name}.~{mane_table_name}"
+            # Explicit schema instead of --autodetect so the columns the joins depend on (Ensembl_nuc, name,
+            # MANE_status) get stable, known types rather than relying on inference. Types match what autodetect
+            # produced for this file (NCBI_GeneID stays STRING; only chr_start/chr_end are integers), so the load
+            # cannot fail on an unexpected value. Column order must match the MANE summary file exactly.
+            # --replace so a reload of a partially-loaded table starts clean rather than appending duplicates.
+            bq --apilog=false load --project_id=~{project_id} --source_format=CSV --field_delimiter='\t' --skip_leading_rows=1 \
+                --replace \
+                --schema='NCBI_GeneID:STRING,Ensembl_Gene:STRING,HGNC_ID:STRING,symbol:STRING,name:STRING,RefSeq_nuc:STRING,RefSeq_prot:STRING,Ensembl_nuc:STRING,Ensembl_prot:STRING,MANE_status:STRING,GRCh38_chr:STRING,chr_start:INTEGER,chr_end:INTEGER,chr_strand:STRING' \
+                ~{dataset_name}.~{mane_table_name} mane_data_processed.tsv
+        fi
+
+        # Emit the loaded schema for the logs; content validation (row-count floor, Ensembl_nuc / MANE_status
+        # integrity) is done downstream in ValidateManeTable via check_mane_table.py.
+        bq --apilog=false --project_id=~{project_id} show --format=prettyjson ~{project_id}:~{dataset_name}.~{mane_table_name}
     >>>
 
     runtime {
@@ -1599,6 +1634,41 @@ task ValidateEntrezTable {
         # NULL/non-numeric GeneIDs or missing Ensembl_gene_identifiers (the gene-level join key).
         python3 /app/check_entrez_table.py \
             --fq_entrez_table ~{project_id}.~{dataset_name}.~{entrez_table_name} \
+            --query_project ~{project_id}
+    >>>
+
+    runtime {
+        docker: variants_docker
+        memory: "3 GB"
+        preemptible: 3
+        cpu: 1
+        disks: "local-disk 100 HDD"
+    }
+
+    output {
+        Boolean done = true
+    }
+}
+task ValidateManeTable {
+    input {
+        String project_id
+        String dataset_name
+        String mane_table_name
+        # Intentionally unused: passed solely to order this task after LoadManeDataIntoBigQuery.
+        #@ except: UnusedInput
+        Boolean load_done
+        String variants_docker
+    }
+
+    command <<<
+        # Prepend date, time and pwd to xtrace log entries.
+        PS4='\D{+%F %T} \w $ '
+        set -o errexit -o nounset -o pipefail -o xtrace
+
+        echo "project_id = ~{project_id}" > ~/.bigqueryrc
+
+        # Fails on an empty/partial table or a bad Ensembl_nuc / MANE_status; see check_mane_table.py.
+        python3 /app/check_mane_table.py --fq_mane_table ~{project_id}.~{dataset_name}.~{mane_table_name} \
             --query_project ~{project_id}
     >>>
 

--- a/scripts/variantstore/variant-annotations-table/GvsValidateVAT.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsValidateVAT.wdl
@@ -1476,7 +1476,7 @@ task SpotCheckForManeSelectTranscript {
             where mane_plus_clinical_name = "GNAS complex locus"
         )' > output.csv
 
-        NUMVARS=$(python3 -c "csvObj=open('output.csv','r');csvContents=csvObj.read();print(csvContents.split('\n')[1]);")
+        NUMVARS=$(tail -n +2 output.csv | head -n1 | tr -d '\r')
 
         echo "false" > ~{pf_file}
         # if the result of the bq call and the csv parsing is a series of digits, then check that it isn't 0

--- a/scripts/variantstore/variant-annotations-table/GvsValidateVAT.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsValidateVAT.wdl
@@ -9,6 +9,14 @@ workflow GvsValidateVat {
         String dataset_name
         String vat_table_name
         Boolean? is_small_callset
+        # Whether the callset spans the whole genome (the default, e.g. AoU) vs. is restricted to a few
+        # contigs (e.g. the chr20/X/Y quickstart). Only genome-wide callsets exercise ~all of MANE, so
+        # the MANE catalog-utilization floor is enforced only when this is true.
+        Boolean is_genome_wide = true
+        # Loose gross-failure floor for MANE catalog utilization on genome-wide callsets. Legitimate
+        # values are ~94% (MANE Select) / ~88% (the tiny Plus Clinical set); the VS-1970 regression sits
+        # at ~6%, so 0.5 is a decisive tripwire with margin on both sides.
+        Float min_mane_catalog_utilization = 0.5
         String? cloud_sdk_docker
         String? variants_docker
     }
@@ -16,6 +24,10 @@ workflow GvsValidateVat {
     String fq_vat_table = "~{project_id}.~{dataset_name}.~{vat_table_name}"
     String fq_mane_table = "~{project_id}.~{dataset_name}.mane_annotations"
     String fq_sample_table = "~{project_id}.~{dataset_name}.sample_info"
+
+    # Catalog utilization is callset-breadth dependent, so only gate it for genome-wide callsets; a
+    # floor of 0 disables the gate (the number is still reported) for interval-restricted callsets.
+    Float effective_mane_catalog_floor = if is_genome_wide then min_mane_catalog_utilization else 0.0
 
     # Always call `GetToolVersions` to get the git hash for this run as this is a top-level-only WDL (i.e. there are
     # no calling WDLs that might supply `git_hash`).
@@ -188,6 +200,7 @@ workflow GvsValidateVat {
             project_id = project_id,
             fq_vat_table = fq_vat_table,
             fq_mane_table = fq_mane_table,
+            min_catalog_utilization = effective_mane_catalog_floor,
             last_modified_timestamp = VatDateTime.last_modified_timestamp,
             variants_docker = effective_variants_docker,
     }
@@ -1664,6 +1677,8 @@ task CheckManeCoverage {
         String project_id
         String fq_vat_table
         String fq_mane_table
+        # 0 disables the catalog-utilization floor (still reported); > 0 enforces it (genome-wide only).
+        Float min_catalog_utilization = 0.0
         # Intentionally unused: passed solely to bust WDL call-caching when the referenced BigQuery table has been modified.
         #@ except: UnusedInput
         String last_modified_timestamp
@@ -1675,10 +1690,12 @@ task CheckManeCoverage {
     command <<<
         # check_mane_coverage.py fails if MANE Select / Plus Clinical coverage over the transcripts present in
         # the callset falls below the threshold -- guards against regressing to the exact-version transcript
-        # join (VS-1970), which flagged only ~6% of the MANE transcripts it should have.
+        # join (VS-1970), which flagged only ~6% of the MANE transcripts it should have. On genome-wide
+        # callsets it also enforces a loose catalog-utilization floor (min_catalog_utilization > 0).
         python3 /app/check_mane_coverage.py --fq_vat_table ~{fq_vat_table} \
             --fq_mane_table ~{fq_mane_table} \
             --query_project ~{project_id} \
+            --min_catalog_utilization ~{min_catalog_utilization} \
             --pass_file_output ~{pf_file} \
             --results_file_output ~{results_file}
     >>>

--- a/scripts/variantstore/variant-annotations-table/GvsValidateVAT.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsValidateVAT.wdl
@@ -14,6 +14,7 @@ workflow GvsValidateVat {
     }
 
     String fq_vat_table = "~{project_id}.~{dataset_name}.~{vat_table_name}"
+    String fq_mane_table = "~{project_id}.~{dataset_name}.mane_annotations"
     String fq_sample_table = "~{project_id}.~{dataset_name}.sample_info"
 
     # Always call `GetToolVersions` to get the git hash for this run as this is a top-level-only WDL (i.e. there are
@@ -182,6 +183,15 @@ workflow GvsValidateVat {
             variants_docker = effective_variants_docker,
     }
 
+    call CheckManeCoverage {
+        input:
+            project_id = project_id,
+            fq_vat_table = fq_vat_table,
+            fq_mane_table = fq_mane_table,
+            last_modified_timestamp = VatDateTime.last_modified_timestamp,
+            variants_docker = effective_variants_docker,
+    }
+
     # Check if the input boolean `is_small_callset` is defined,
     # if not use the `GetNumSamples` task to find the number of samples in the callset and set the flag if it's < 10000
     Boolean callset_is_small = select_first([is_small_callset, select_first([GetNumSamplesLoaded.num_samples, 1]) < 10000])
@@ -231,7 +241,8 @@ workflow GvsValidateVat {
                            SpotCheckForEntrezGeneId.pass,
                            SpotCheckForAAChangeAndExonNumberConsistency.pass,
                            CheckForNullColumns.pass,
-                           CheckEntrezGeneIdCoverage.pass
+                           CheckEntrezGeneIdCoverage.pass,
+                           CheckManeCoverage.pass
                            ],
                 validation_names = [
                                    EnsureVatTableHasVariants.name,
@@ -252,7 +263,8 @@ workflow GvsValidateVat {
                                    SpotCheckForEntrezGeneId.name,
                                    SpotCheckForAAChangeAndExonNumberConsistency.name,
                                    CheckForNullColumns.name,
-                                   CheckEntrezGeneIdCoverage.name
+                                   CheckEntrezGeneIdCoverage.name,
+                                   CheckManeCoverage.name
                                    ],
                 validation_results = [
                                      EnsureVatTableHasVariants.result,
@@ -273,7 +285,8 @@ workflow GvsValidateVat {
                                      SpotCheckForEntrezGeneId.result,
                                      SpotCheckForAAChangeAndExonNumberConsistency.result,
                                      CheckForNullColumns.result,
-                                     CheckEntrezGeneIdCoverage.result
+                                     CheckEntrezGeneIdCoverage.result,
+                                     CheckManeCoverage.result
                                      ],
                 cloud_sdk_docker = effective_cloud_sdk_docker,
         }
@@ -299,6 +312,7 @@ workflow GvsValidateVat {
                            SpotCheckForManeSelectTranscript.pass,
                            SpotCheckForEntrezGeneId.pass,
                            CheckEntrezGeneIdCoverage.pass,
+                           CheckManeCoverage.pass,
                            ],
                 validation_names = [
                                    EnsureVatTableHasVariants.name,
@@ -317,6 +331,7 @@ workflow GvsValidateVat {
                                    SpotCheckForManeSelectTranscript.name,
                                    SpotCheckForEntrezGeneId.name,
                                    CheckEntrezGeneIdCoverage.name,
+                                   CheckManeCoverage.name,
                                    ],
                 validation_results = [
                                      EnsureVatTableHasVariants.result,
@@ -335,6 +350,7 @@ workflow GvsValidateVat {
                                      SpotCheckForManeSelectTranscript.result,
                                      SpotCheckForEntrezGeneId.result,
                                      CheckEntrezGeneIdCoverage.result,
+                                     CheckManeCoverage.result,
                                      ],
                 cloud_sdk_docker = effective_cloud_sdk_docker,
         }
@@ -1639,6 +1655,45 @@ task CheckEntrezGeneIdCoverage {
     output {
         Boolean pass = read_boolean(pf_file)
         String name = "CheckEntrezGeneIdCoverage"
+        String result = read_string(results_file)
+    }
+}
+
+task CheckManeCoverage {
+    input {
+        String project_id
+        String fq_vat_table
+        String fq_mane_table
+        # Intentionally unused: passed solely to bust WDL call-caching when the referenced BigQuery table has been modified.
+        #@ except: UnusedInput
+        String last_modified_timestamp
+        String variants_docker
+    }
+    String pf_file = "pf.txt"
+    String results_file = "results.txt"
+
+    command <<<
+        # check_mane_coverage.py fails if MANE Select / Plus Clinical coverage over the transcripts present in
+        # the callset falls below the threshold -- guards against regressing to the exact-version transcript
+        # join (VS-1970), which flagged only ~6% of the MANE transcripts it should have.
+        python3 /app/check_mane_coverage.py --fq_vat_table ~{fq_vat_table} \
+            --fq_mane_table ~{fq_mane_table} \
+            --query_project ~{project_id} \
+            --pass_file_output ~{pf_file} \
+            --results_file_output ~{results_file}
+    >>>
+
+    runtime {
+        docker: variants_docker
+        memory: "3 GB"
+        disks: "local-disk 10 HDD"
+        preemptible: 3
+        cpu: 1
+    }
+
+    output {
+        Boolean pass = read_boolean(pf_file)
+        String name = "CheckManeCoverage"
         String result = read_string(results_file)
     }
 }

--- a/scripts/variantstore/variant-annotations-table/GvsValidateVAT.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsValidateVAT.wdl
@@ -1691,7 +1691,7 @@ task CheckManeCoverage {
         # check_mane_coverage.py fails if MANE Select / Plus Clinical coverage over the transcripts present in
         # the callset falls below the threshold -- guards against regressing to the exact-version transcript
         # join (VS-1970), which flagged only ~6% of the MANE transcripts it should have. On genome-wide
-        # callsets it also enforces a loose catalog-utilization floor (min_catalog_utilization > 0).
+        # callsets it also enforces a MANE catalog-utilization floor.
         python3 /app/check_mane_coverage.py --fq_vat_table ~{fq_vat_table} \
             --fq_mane_table ~{fq_mane_table} \
             --query_project ~{project_id} \

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -131,7 +131,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-07-21-alpine-de069eb976a9"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-07-21-alpine-44609d757141"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-04-08-gatkbase-9434f9e8577f"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -131,7 +131,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-07-21-alpine-44609d757141"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-07-22-alpine-498efb2860b5"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-04-08-gatkbase-9434f9e8577f"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -131,7 +131,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-07-22-alpine-498efb2860b5"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-07-23-alpine-48448f6c15c9"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-04-08-gatkbase-9434f9e8577f"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -131,7 +131,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-06-30-alpine-766e78c05289"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-07-21-alpine-de069eb976a9"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-04-08-gatkbase-9434f9e8577f"
     String real_time_genomics_docker = "docker.io/realtimegenomics/rtg-tools:latest"

--- a/scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
+++ b/scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
@@ -368,6 +368,7 @@ workflow GvsQuickstartIntegration {
                 dataset_suffix = "vat",
                 output_path = extract_vat_output_gcs_dir,
                 use_vds_as_input = run_vat_integration_test_from_vds,
+                chr20_X_Y_only = chr20_X_Y_only,
                 basic_docker = effective_basic_docker,
                 cloud_sdk_docker = effective_cloud_sdk_docker,
                 cloud_sdk_slim_docker = effective_cloud_sdk_slim_docker,

--- a/scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
+++ b/scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
@@ -39,7 +39,7 @@ workflow GvsQuickstartIntegration {
     }
 
     String expected_subdir = if (!chr20_X_Y_only) then "all_chrs/"  else ""
-    File expected_output_prefix = "gs://gvs-internal-quickstart/integration/2026-07-09/" + expected_subdir
+    File expected_output_prefix = "gs://gvs-internal-quickstart/integration/2026-07-22/" + expected_subdir
     File truth_data_prefix = "gs://gvs-internal-quickstart/integration/test_data/2025-12-05/" + expected_subdir
 
     # WDL 1.0 trick to set a variable ('none') to be undefined.

--- a/scripts/variantstore/wdl/test/GvsQuickstartVATIntegration.wdl
+++ b/scripts/variantstore/wdl/test/GvsQuickstartVATIntegration.wdl
@@ -14,6 +14,9 @@ workflow GvsQuickstartVATIntegration {
         String expected_output_prefix
         String dataset_suffix
         Boolean use_vds_as_input = true      # If true, use a VDS, otherwise use a sites only VCF.
+        # Mirrors GvsQuickstartIntegration.chr20_X_Y_only: when true the callset is restricted to a few
+        # contigs, so the genome-wide-only MANE catalog-utilization floor must not be enforced.
+        Boolean chr20_X_Y_only = false
         String output_path
         Int split_intervals_scatter_count = 10
         String? basic_docker
@@ -92,6 +95,7 @@ workflow GvsQuickstartVATIntegration {
             dataset_name = CreateDatasetForTest.dataset_name,
             vat_table_name = CreateVATFromVDS.vat_table_name,
             is_small_callset = true,
+            is_genome_wide = !chr20_X_Y_only,
             cloud_sdk_docker = effective_cloud_sdk_docker,
             variants_docker = effective_variants_docker,
     }


### PR DESCRIPTION
Fixes the MANE under-annotation caused by inappropriate version-sensitive transcript matching and adds several robustness enhancments:

- MANE coverage check that specifically confirms unversioned transcripts match as expected
- Generalized MANE transcript-agnostic catalog usage check for whole genome callsets
- Lots of robustness improvements inspired by the recent Entrez work in #9397.
- Added an additional MANE catalog table validation

20/X/Y VAT run [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration%20mcovarr/submission_history/a395859e-cccf-467f-949b-c837426a5557), all chromosomes run [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration%20mcovarr/submission_history/0a6bcd65-d250-4dc9-8c9a-07a0f46620e1).