### PR TITLE
Support parquet header loading [VS-1803]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -218,6 +218,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - ng_vs_1803_parquet_headers_impl
        tags:
          - /.*/
    - name: GvsPrepareRangesCallset

--- a/scripts/variantstore/docs/parquet/header_loading_design.md
+++ b/scripts/variantstore/docs/parquet/header_loading_design.md
@@ -557,17 +557,37 @@ Callsets are ingested in batches, so it matters which header tables persist:
 
 ---
 
-## 8. AC2 — consistency queries
+## 8. AC2 — header-analysis queries WIP based on VS-1215
 
-Consistency queries to be supplied by Aaron Hatcher. They will presumably assert
-equivalence between a BQ-loaded and a Parquet-loaded dataset. Expected checks:
-- row counts and distinct-hash counts in `vcf_header_lines` match across paths;
-- `sample_vcf_header` (sample_id, hash) set is identical across paths;
-- every `sample_vcf_header.vcf_header_lines_hash` resolves to a row in `vcf_header_lines`
-  (referential integrity; no orphan hashes);
-- reconstructed per-sample header text is byte-identical across paths.
+The consistency checks are captured in **VS-1215** (*Create WDL to analyze VCF headers and
+create a small report*). Those queries — from the manual analysis of the first Echo header
+ingest — read the final `vcf_header_lines` / `sample_vcf_header` / `sample_info` tables and
+fall into three groups. Because those tables are identical across load paths (§3), the queries
+are **path-agnostic** and validate a Parquet-loaded dataset the same as a BQ-loaded one.
 
-*(Placeholder — fill in once queries are provided.)*
+**1. Integrity invariants** (should hold for any correct header load):
+- distinct `sample_id` in `sample_vcf_header` == the loaded (non-control) sample count in
+  `sample_info` — i.e. every sample has header data. *(Echo: 414,830 ✓.)*
+- every sample has ≥1 `is_expected_unique = true` chunk (its per-sample processing info is
+  present). *(Echo: 414,830 ✓.)*
+- referential integrity: every `sample_vcf_header.vcf_header_lines_hash` resolves to a row in
+  `vcf_header_lines` (no orphan hashes).
+
+**2. Shared-blob distribution** — the distinct `is_expected_unique = false` blobs and how many
+samples carry each. Ideally one; more than one indicates distinct delivery batches
+(informational, not necessarily an error). *(Echo: 6 distinct shared blobs.)*
+
+**3. DRAGEN-version report (the "useful info")** — group samples by the DRAGEN software-version
+string in their `is_expected_unique = true` chunk (`DRAGENCommandLine=<ID=dragen,Version="SW: …"`).
+The final VS-1215 query joins `vcf_header_lines` × `sample_vcf_header` × `sample_info` against a
+small `dragen_versions` CTE and counts samples per version. *(This is exactly how Echo's mixed
+processing was found: four versions — `05/07.021.408.3.4.12` and `05/07.021.604.3.7.8`.)*
+
+**Relation to this spike:** these are the concrete form of the §1.5 input-gVCF sanity check,
+and they double as the Parquet consistency check — run them on a Parquet-loaded dataset and
+confirm the invariants hold and the version breakdown matches expectations. If an explicit
+A/B check against a BQ-loaded dataset is wanted, the same tables can be compared directly
+(distinct-hash sets, the (sample_id, hash) set, and reconstructed per-sample text).
 
 ---
 

--- a/scripts/variantstore/docs/parquet/header_loading_design.md
+++ b/scripts/variantstore/docs/parquet/header_loading_design.md
@@ -97,6 +97,12 @@ task.
    design must avoid re-inserting a hash already present in `vcf_header_lines` from a prior
    batch.
 5. **The current BQ dedup is itself expensive** — see §5.
+6. **Header loading must be idempotent** (explicit design goal). Re-running the load —
+   whether from a WDL task retry (`LoadParquetFilesToBQ` runs `preemptible: 5`,
+   `maxRetries: 3`), a Cromwell workflow resume, or a re-ingest of the same batch — must
+   converge to the same final tables, with no duplicate rows in `vcf_header_lines` or
+   `sample_vcf_header`. Today this holds only *by accident* (see §7); the Parquet design
+   should make it structural. Full treatment in §7.
 
 ---
 
@@ -174,11 +180,17 @@ Options 1 and 3 share the same writer-schema and WDL wiring work; only dedup dif
 
 ### 4.3 Python — merge
 - `process_sample_vcf_headers.py:21` — change the `vcf_header_lines` INSERT to a
-  **MERGE**/dedup on `vcf_header_lines_hash` (dedups the naive-loaded scratch rows *and*
-  makes it idempotent across incremental batches). The `sample_vcf_header` INSERT
-  (`:24`) stays as-is (naturally unique per sample+hash).
-- `load_parquet_to_bq.py` — no change needed for Option 1 (raw load into scratch);
-  Option 2/3 would need a content-addressed loader.
+  **MERGE** on `vcf_header_lines_hash` (`WHEN NOT MATCHED THEN INSERT`). This dedups the
+  naive-loaded scratch rows *and* makes the step idempotent across retries and incremental
+  batches (satisfies constraints #4 and #6).
+- `process_sample_vcf_headers.py:24` — the `sample_vcf_header` INSERT **also** needs to
+  become a **MERGE** on (`sample_id`, `vcf_header_lines_hash`). *(Correction: this is not
+  idempotent as a blind INSERT — a task retry or re-ingest would duplicate the
+  (sample_id, hash) associations. See §7.)*
+- `load_parquet_to_bq.py` — no change needed for Option 1 (raw load into scratch), but the
+  scratch loads rely on deterministic BQ load job IDs for retry-idempotency
+  (`load_parquet_to_bq.py:166`, `_make_job_id`) — see §7.
+- Option 2/3 would need a content-addressed loader.
 
 ### 4.4 Table schema
 - No schema change to the three tables. `vcf_header_lines_scratch` stays as the load
@@ -324,7 +336,80 @@ by N:
 
 ---
 
-## 7. AC2 — consistency queries
+## 7. Idempotency
+
+**Goal:** re-running header loading converges to the same final tables — no duplicate rows,
+no partial corruption — under three triggers: (a) a WDL **task retry** (preemption /
+`maxRetries`), (b) a Cromwell **workflow resume / re-run**, and (c) a deliberate
+**re-ingest** of the same batch.
+
+### 7.1 How idempotent is the pipeline today?
+
+Only *by accident*. The BQ path has three separate, fragile mechanisms:
+
+- **Per-sample skip:** `CreateVariantIngestFiles` checks `doScratchRowsExistFor` /
+  `doNonScratchRowsExistFor` per sample and skips header writes if rows already exist
+  (`CreateVariantIngestFiles.java:340-347`). Idempotent-ish, but per-`sample_id` and not
+  atomic — a partially-written prior run can leave inconsistent state.
+- **Blind-INSERT merge:** `process_sample_vcf_headers.py:21,24` are plain INSERTs. Running
+  the merge **twice would duplicate** rows in both `vcf_header_lines` and
+  `sample_vcf_header`.
+- **Scratch delete as the only guard:** `clean_up_scratch_table`
+  (`process_sample_vcf_headers.py:28-31`) empties scratch after the merge, so a *second*
+  merge finds nothing to insert. Idempotency thus depends on the DELETE having succeeded —
+  if the merge commits but the delete fails (or the step is retried before it), the next
+  run double-inserts.
+
+So the current design is not structurally idempotent; it relies on ordering and a cleanup
+step. The Parquet redesign should not inherit that fragility.
+
+### 7.2 Where idempotency must be enforced per layer
+
+The Parquet path deliberately moves dedup/idempotency *off* the ingest write (no BQ
+round-trips there) and onto the load + merge. Each layer needs a keyed, re-runnable
+operation:
+
+| Layer | Non-idempotent form | Idempotent form |
+|---|---|---|
+| Parquet write (offline, per sample) | (already safe — writes local files only; re-run overwrites) | deterministic file contents |
+| GCS upload of header parquet | `cp` (overwrite — safe, identical bytes) | idempotent by nature; Opt 2/3 blob uses `ifGenerationMatch=0` |
+| BQ load scratch ← parquet | `WRITE_APPEND` retried → double-load | **deterministic load job ID** (`load_parquet_to_bq.py:166`) so BQ dedups the retried job |
+| Merge scratch → `vcf_header_lines` | blind INSERT | **MERGE** on `vcf_header_lines_hash` |
+| Merge scratch → `sample_vcf_header` | blind INSERT | **MERGE** on (`sample_id`, `vcf_header_lines_hash`) |
+| Scratch cleanup | — | DELETE is naturally idempotent (re-delete = no-op) |
+
+Key point: with both final-table populations as **MERGEs keyed on their natural keys**, the
+whole chain becomes idempotent *independently* of the scratch-delete step — removing the
+fragile dependency in §7.1.
+
+### 7.3 Idempotency by option
+
+- **Option 1 (naive + MERGE):** idempotent once both merges are keyed (§7.2) and scratch
+  loads use deterministic job IDs. Note scratch can accumulate rows across retries; the
+  MERGE absorbs that harmlessly (dedup by key), which is exactly why MERGE (not
+  `INSERT ... SELECT DISTINCT`) is the right primitive here.
+- **Option 2 / 3 (content-addressed):** strongest form — the expensive header **text** is
+  idempotent at the *storage* layer (path = hash, identical bytes, `ifGenerationMatch=0`
+  skips re-writes), so re-runs are no-ops for the blob. The BQ association / `vcf_header_lines`
+  loads still need keyed MERGE/skip-existing, same as Option 1.
+- **Option 4 (consolidation):** the consolidation output must be deterministic (stable
+  file naming by hash) for the downstream load to be idempotent; otherwise re-runs produce
+  new files that re-load.
+
+### 7.4 Recommendation
+
+Make idempotency structural, not incidental:
+1. Both final-table populations become **MERGE** statements keyed on natural keys.
+2. Rely on **deterministic BQ load job IDs** for scratch-load retry safety.
+3. Keep the scratch DELETE as cleanup, but the design must be correct **without** depending
+   on it having run.
+
+This is small extra work on top of Option 1 (one of the two merges was already going to
+change for dedup) and it satisfies constraint #6 for every option.
+
+---
+
+## 8. AC2 — consistency queries
 
 Consistency queries to be supplied by Aaron Hatcher. They will presumably assert
 equivalence between a BQ-loaded and a Parquet-loaded dataset. Expected checks:
@@ -338,7 +423,7 @@ equivalence between a BQ-loaded and a Parquet-loaded dataset. Expected checks:
 
 ---
 
-## 8. Open questions / risks
+## 9. Open questions / risks
 
 - **Small-object cost (Option 2/3):** how many distinct `is_expected_unique = true` chunks
   arise at AoU scale? Determines whether content-addressing the unique lines is viable.
@@ -351,7 +436,7 @@ equivalence between a BQ-loaded and a Parquet-loaded dataset. Expected checks:
 
 ---
 
-## 9. File / line reference index
+## 10. File / line reference index
 
 | Area | Location |
 |---|---|

--- a/scripts/variantstore/docs/parquet/header_loading_design.md
+++ b/scripts/variantstore/docs/parquet/header_loading_design.md
@@ -1,6 +1,10 @@
 # Loading VCF Headers in the Parquet Code Path
 
-**Tickets:** VS-1968 — *[Spike] How to load headers in Parquet code path*
+**Tickets:**
+- **VS-1968** — *[Spike] How to load headers in Parquet code path* — deliverables are this
+  design doc and the consistency checks (§8).
+- **VS-1803** — *Header loading not supported on Parquet branch* — the **implementation** (the
+  Java/Python/WDL changes and the `is_loaded` view fix described here belong to this ticket).
 
 **Motivation:** To support GVS on TSPS and the next All of Us callset. Today VCF header
 loading works only on the legacy BigQuery Write API ingest path; the Parquet ingest
@@ -72,14 +76,87 @@ shared blob.
 - A gate placeholder is left at `GvsImportGenomes.wdl:252`
   ("*add a gate for Parquet header loading here once that's implemented*").
 
-### 1.4 TODO in Parquet
+### 1.4 Header extraction: single invocation vs. the gated model
 
-The Parquet-generating task already localizes each VCF once
-(`GvsImportGenomes.wdl:551-553`) and runs a **single** `CreateVariantIngestFiles` call
-(`GvsImportGenomes.wdl:560`) that already passes `--enable-vcf-headers`
-(`GvsImportGenomes.wdl:575`). Header extraction piggybacks on the existing VCF read —
-**no second localization is required**. The work is finishing the plumbing, not adding a
-task.
+`CreateVariantIngestFiles` already localizes each VCF once (`GvsImportGenomes.wdl:551-553`)
+and runs a **single** call (`GvsImportGenomes.wdl:560`) that already accepts
+`--enable-vcf-headers` (`GvsImportGenomes.wdl:575`), so header extraction *can* piggyback on
+the existing VCF read with no extra localization. **However**, the operational model (§1.5)
+deliberately loads headers as a *separate, gated* phase before vet/ref/ploidy, which is in
+tension with folding everything into one pass. The Parquet architecture reconciles this
+because generation and BQ loading are already decoupled — see §1.5. Either way the remaining
+work is finishing the plumbing, not adding an ingest tool.
+
+### 1.5 Operational model: phased, gated loading
+
+**Purpose of the header phase.** The header-only ingest is not a check that header *loading*
+worked — it is an early **sanity check of the input gVCFs themselves**. Loading just the
+headers is a cheap way to inspect each input's metadata (reference version, contig list,
+sample names, expected INFO/FORMAT/FILTER definitions, pipeline provenance) and confirm the
+cohort is well-formed and mutually consistent *before* committing to the expensive vet/ref
+ingest. This purpose must be preserved in the Parquet path.
+
+**AoU today (BQ path).** Header loading is run as its **own** ingest first
+(`load_vcf_headers = true`, `load_vet_and_ref_ranges = false`), the loaded headers are then
+**manually inspected** to sanity-check the input gVCFs, and **only if that passes** is a
+second ingest run for vet / ref_ranges / sample_chromosome_ploidy. Three phases: *load
+headers → sanity check inputs → load everything else*. On the BQ path this localizes the VCFs
+**twice** (once per ingest run).
+
+**TSPS (assumption — undecided).** Likely the same three phases, but **automated** (the
+manual sanity check becomes an automated gate).
+
+**How this maps onto Parquet.** In the Parquet path, *generation* (localize VCF → write
+parquet to GCS) is already decoupled from *loading* (`DiscoverParquetFiles` →
+`LoadParquetFilesToBQ`). That opens two ways to honor the gate:
+
+- **(A) Generate-all-once, phased load.** One `CreateVariantIngestFiles` pass writes *all*
+  parquet (headers + vet + ref + ploidy) with a single localization; then load **only** the
+  header parquet, gate on the sanity check, and load the rest afterward from the parquet
+  already in GCS. Single localization *and* a real gate.
+  *Cost:* vet/ref/ploidy parquet is **generated before** the gate, so a failed header check
+  wastes that generation compute (and transient GCS storage).
+- **(B) Phase-separated generation.** A headers-only generation+load first (cheap), gate,
+  then a second generation+load for the rest — **re-localizing** the VCFs (as AoU does today
+  on the BQ path). *Cost:* pays localization + generation twice, but spends **no** vet/ref
+  compute until the gate passes.
+
+**Trade-off — sharpened by the purpose.** Because the gate exists specifically to *avoid
+expensive work on bad inputs*, approach (A) partly defeats it: (A) generates the vet/ref/ploidy
+parquet **before** the gate, so a caught bad input still pays the full generation cost — only
+the vet/ref *BQ load* is saved. In fact the "avoid re-localizing in a second task" wish
+(from VS-1803, not this spike) and the header phase's purpose are **fundamentally in
+conflict**: validating inputs
+before doing expensive variant work requires *either* re-localizing (B) *or* doing that
+expensive work first (A). We can have at most one.
+
+Concretely, per-sample the costs are: **localize** (copy the gVCF; needed for headers *and*
+variants), cheap **header parse**, and expensive **vet/ref parse**.
+- **(A)** localizes once but always does the vet/ref parse up front → wastes vet/ref parse on
+  a gate failure.
+- **(B)** localizes twice on success but does the vet/ref parse only after the gate → wastes
+  almost nothing on failure.
+
+So (A) wins only when localization dominates *and* input failures are rare; the stated
+purpose (the phase exists because bad inputs are a real risk) leans toward **(B)**, or toward
+(A) only if TSPS confirms failures are rare and localization is the dominant cost.
+**Recommendation:** leave open until TSPS fixes its model, but note the conflict above rather
+than assuming the re-localization can simply be optimized away.
+
+**Implication either way:**
+- The header load must complete and be validated as a *distinct, gated step* before the
+  vet/ref/ploidy load (see the WDL gate in §4.2); for approach (A) the parquet cleanup
+  (`DeleteParquetFiles`, which runs by default right after loading — plus the off-by-default
+  14-day GCS lifecycle rule as a backstop) must **not** remove the vet/ref parquet before the
+  post-gate load.
+- The sanity check reads header **content**, so the Parquet header load must persist the
+  **full header text**, not just hashes. Storing it *deduplicated* does not hurt inspection:
+  the check reconstructs any sample's header by joining `sample_vcf_header` (sample → hash) to
+  `vcf_header_lines` (hash → text). Every design in §3 ends with those same two tables, so all
+  of them keep the header lines (contigs, reference, INFO/FORMAT) fully inspectable — the only
+  way to lose that is an *incomplete* implementation that persists hashes without ever loading
+  the text into `vcf_header_lines` (see the caveat on the current content-addressing scaffold
+  in §3 / §7.3).
 
 ---
 
@@ -87,8 +164,12 @@ task.
 
 1. **The merge does not dedup** (§1.2). Naive Parquet writing requires a dedup step to be
    added.
-2. **`is_expected_unique` is an unused lever.** It cleanly separates the one shared blob
-   (dedup-worthy) from per-sample command lines (not dedup-worthy). Designs can route on it.
+2. **`is_expected_unique` distinguishes the shared blob from per-sample command lines** —
+   `false` for the joined non-command-line blob (shared, dedup-worthy), `true` for the
+   command-line chunks (expected to differ per sample). This flag is **already used** by the
+   AoU header sanity check: its query filters `is_expected_unique = TRUE` to isolate the
+   per-sample command lines and extract the DRAGEN version for validation
+   (`AOU_DELIVERABLES.md`). Dedup designs can *additionally* route storage on it (Option 3).
 3. **Per-sample invocations are isolated.** Each `CreateVariantIngestFiles` run sees one
    gVCF and cannot see other samples' chunks without a shared store — so cross-sample
    write-time dedup (as the BQ path does via BQ queries) is not naturally available offline.
@@ -97,24 +178,36 @@ task.
    design must avoid re-inserting a hash already present in `vcf_header_lines` from a prior
    batch.
 5. **The current BQ dedup is itself expensive** — see §5.
-6. **Header loading must be idempotent** (explicit design goal). Re-running the load —
-   whether from a WDL task retry (`LoadParquetFilesToBQ` runs `preemptible: 5`,
-   `maxRetries: 3`), a Cromwell workflow resume, or a re-ingest of the same batch — must
-   converge to the same final tables, with no duplicate rows in `vcf_header_lines` or
-   `sample_vcf_header`. Today this holds only *by accident* (see §7); the Parquet design
-   should make it structural. Full treatment in §7.
+6. **Header loading must be idempotent** (explicit design goal — and largely already
+   realized). Re-running the load — WDL task retry (`LoadParquetFilesToBQ` runs
+   `preemptible: 5`, `maxRetries: 3`), Cromwell resume, or re-ingest of a batch — must
+   converge to the same final tables, with no duplicate rows. The **BQ path already
+   implements this deliberately** via the per-sample `HEADERS_LOADED` status in
+   `sample_load_status` (§7.1); it is not accidental. The gap the Parquet work must close is
+   narrower: the Parquet path bypasses that per-sample status check and the promotion step's
+   blind INSERT does not dedup — both addressed by the anti-join INSERT (§7).
+7. **Loading is phased and gated — as an input-gVCF sanity check** (§1.5). The header-only
+   phase exists to validate the *input gVCFs* (reference, contigs, samples, expected fields)
+   before the expensive vet/ref ingest, so it must remain a distinct, gated phase in the
+   Parquet path too. Consequences: (a) the header load must stand alone and gate the data
+   load; (b) it must persist **full header text** so the check can inspect content (a hard
+   requirement on Option 3's content-addressing); (c) for approach (A) the parquet cleanup
+   must be phase-aware so vet/ref parquet survives until its post-gate load; (d) this gated
+   re-run pattern makes constraint #6 (idempotency) more pressing, not less.
 
 ---
 
 ## 3. Design options
 
-### Option 1 — Naive write, dedup in the merge SQL (low risk)
+### Option 1 — Naive write, dedup in the load SQL (low risk)
 - Writer: emit full text + `is_expected_unique` for every chunk, every sample; drop the
   existence queries.
-- Merge: change `process_sample_vcf_headers.py:21` from a blind INSERT to a **MERGE** into
-  `vcf_header_lines` on `vcf_header_lines_hash` (or `SELECT ... GROUP BY hash`), so it
-  dedups *and* is idempotent across batches (satisfies constraint #4).
-- **Cost:** max (transient) scratch bloat; one large dedup/MERGE query scanning the text
+- Load: change `process_sample_vcf_headers.py:21` from a blind INSERT to an **anti-join
+  INSERT** (`INSERT ... SELECT ... LEFT JOIN <target> USING(key) WHERE <target>.key IS NULL`,
+  with `GROUP BY`/`DISTINCT` on the source), so it dedups *and* is idempotent across batches
+  (satisfies constraint #4). Anti-join INSERT rather than `MERGE` to match GVS convention
+  (GVS uses `MERGE` nowhere) and avoid mutating-DML concerns.
+- **Cost:** max (transient) scratch bloat; one large dedup query scanning the text
   column; zero per-sample BQ round-trips during ingest.
 - **Pros:** simplest; keeps existing scratch + load machinery; ingest stays fully offline
   and parallel (the point of the Parquet path).
@@ -133,11 +226,18 @@ task.
   grouping in `DiscoverParquetFiles`).
 
 ### Option 3 — Hybrid, routed by `is_expected_unique` (probably optimal for implementation)
-- `false` (shared blob): content-address it (Option 2) → stored once. The big win.
+- `false` (shared blob): content-address it (Option 2) → stored once, then **loaded
+  (deduplicated) into `vcf_header_lines`** — the same final table as Option 1, so the header
+  text remains fully inspectable by the sanity check.
 - `true` (command lines): write naively inline with associations → no small-object
   explosion, no dedup benefit lost (they were never going to dedup).
 - **Pros:** cost-optimal; uses the schema flag as intended.
 - **Cons:** two code paths in the writer.
+- **Scaffold caveat:** the current `HYBRID` code (`VcfHeaderLineScratchCreator`, dormant behind
+  the hardcoded strategy switch) is a *stub* — it writes the blob's association only and drops
+  the text with a TODO. A complete Option 3 must actually store the blob and load its text into
+  `vcf_header_lines`; until then `HYBRID` is not functional and would leave the shared header
+  lines uninspectable. Only Option 1 is fully implemented.
 
 ### Option 4 — Pre-load local consolidation
 - Dedup header Parquet by hash in a consolidation step before load (git precedent:
@@ -146,7 +246,7 @@ task.
 
 **Recommendation:** implement **Option 1 first** (low risk, unblocks TSPS/AoU, benchmarks
 the "naive" cost for AC1), then evaluate **Option 3** if the naive cost is unacceptable.
-Options 1 and 3 share the same writer-schema and WDL wiring work; only dedup differs.
+Options 1 and 3 share the same writer-schema and WDL wiring work; only the dedup locus differs.
 
 ---
 
@@ -164,29 +264,49 @@ Options 1 and 3 share the same writer-schema and WDL wiring work; only dedup dif
 - Reference template: commits `e852dcf27` / `2d48b4a84` (ref & ploidy Parquet writers) and
   `gvs_ingest_refactoring.md` (note VS-1803 is called out there as the pending header work).
 
-### 4.2 WDL — `GvsImportGenomes.wdl`
-- Remove the block at `:97-100` (`CannotLoadHeadersWithParquetIngest`).
-- Upload the header Parquet in the generate task: extend the glob/copy block
-  (`:586-596`) to pick up `header_file.parquet` and copy it to a new
-  `.../vcf_header_lines_scratch/` GCS dir (before the `rm *.parquet` at `:599`).
-- `DiscoverParquetFiles` (`:273`, prefixes at `:278-279`): add `vcf_header_lines_scratch`
-  as a `regular_table_prefixes` entry so the FOFN grouping (`parse_and_group_files.py`)
-  picks it up. The loader derives the table name from the FOFN filename
-  (`load_parquet_to_bq.py:46-52`), so a `vcf_header_lines_scratch.fofn` loads into the
-  scratch table with no loader change.
-- Gate: wire `ProcessVCFHeaders` (`:249`, gate at `:252`) to also depend on
-  `LoadParquetFilesToBQ.done` when `use_parquet_ingest` (currently only
-  `LoadDataViaBigQueryWriteAPI.done`).
+### 4.2 WDL — `GvsImportGenomes.wdl` (implemented)
+- Removed the `CannotLoadHeadersWithParquetIngest` guard.
+- **Header parquet naming:** the Java writer now names the file
+  `vcf_header_lines_scratch_<sampleId>.parquet` (was `header_file.parquet`) so it matches the
+  regular-table discovery regex in `parse_and_group_files.py`
+  (`/(prefix)_([0-9]+)...`). Without this the file would never be discovered.
+- **Upload:** the generate task's per-sample upload block now guards the vet/ref/ploidy
+  copies behind `load_vet_and_ref_ranges` and adds a `load_vcf_headers`-guarded copy of the
+  header parquet to `.../vcf_header_lines_scratch/`. (`rm *.parquet` → `rm -f`.)
+- **One combined discover/load/verify** now runs when
+  `use_parquet_ingest && (load_vet_and_ref_ranges || load_vcf_headers)` — pulled out of the
+  old `load_vet_and_ref_ranges`-only block so a **headers-only** run also loads. Prefixes:
+  `regular = load_vcf_headers ? [sample_chromosome_ploidy, vcf_header_lines_scratch] :
+  [sample_chromosome_ploidy]`, `superpartitioned = [vet, ref_ranges]` (always non-empty to
+  avoid empty-array / argparse issues; extra prefixes are harmless — no files match). The
+  loader/verifier need no changes beyond receiving these prefixes.
+- **VerifyParquetLoading** now takes and forwards `--regular-table-prefixes` /
+  `--superpartitioned-table-prefixes` (previously defaulted, which would flag header files as
+  unverified).
+- **Gate:** `ProcessVCFHeaders` now gates on
+  `flatten([select_all([VerifyParquetLoading.done]), select_all(LoadDataViaBigQueryWriteAPI.done)])`
+  — i.e. the Parquet header load for parquet runs, or the BQ Write API for BQ runs.
+  `SetIsLoadedColumn` stays under `load_vet_and_ref_ranges` (headers-only runs don't mark
+  samples loaded).
+- **Phasing (per §1.5):** the AoU-style gate is achieved by running the workflow **twice**
+  (headers-only, sanity-check, then data-only). The single-run intra-workflow gate
+  (approach A with a split scatter) and phase-aware parquet deletion are **not** implemented —
+  in a combined run headers and data load together.
+- Validated with `womtool validate`. End-to-end coverage is the Terra `quickstart*` tests.
 
-### 4.3 Python — merge
-- `process_sample_vcf_headers.py:21` — change the `vcf_header_lines` INSERT to a
-  **MERGE** on `vcf_header_lines_hash` (`WHEN NOT MATCHED THEN INSERT`). This dedups the
-  naive-loaded scratch rows *and* makes the step idempotent across retries and incremental
-  batches (satisfies constraints #4 and #6).
-- `process_sample_vcf_headers.py:24` — the `sample_vcf_header` INSERT **also** needs to
-  become a **MERGE** on (`sample_id`, `vcf_header_lines_hash`). *(Correction: this is not
-  idempotent as a blind INSERT — a task retry or re-ingest would duplicate the
+### 4.3 Python — scratch → final load
+- `process_sample_vcf_headers.py:21` — change the `vcf_header_lines` INSERT to an **anti-join
+  INSERT**: `INSERT ... SELECT s.hash, ANY_VALUE(s.text), ANY_VALUE(s.is_expected_unique)
+  FROM scratch s LEFT JOIN vcf_header_lines t USING(vcf_header_lines_hash) WHERE s.text IS
+  NOT NULL AND t.vcf_header_lines_hash IS NULL GROUP BY s.hash`. This dedups the naive-loaded
+  scratch rows *and* makes the step idempotent across retries and incremental batches
+  (satisfies constraints #4 and #6).
+- `process_sample_vcf_headers.py:24` — the `sample_vcf_header` INSERT **also** needs the same
+  anti-join treatment, keyed on (`sample_id`, `vcf_header_lines_hash`). *(Correction: this is
+  not idempotent as a blind INSERT — a task retry or re-ingest would duplicate the
   (sample_id, hash) associations. See §7.)*
+- Anti-join INSERT is used rather than `MERGE` to match GVS convention (GVS uses `MERGE`
+  nowhere) and sidestep mutating-DML concerns; `INSERT` also never touches a streaming buffer.
 - `load_parquet_to_bq.py` — no change needed for Option 1 (raw load into scratch), but the
   scratch loads rely on deterministic BQ load job IDs for retry-idempotency
   (`load_parquet_to_bq.py:166`, `_make_job_id`) — see §7.
@@ -205,7 +325,7 @@ Options 1 and 3 share the same writer-schema and WDL wiring work; only dedup dif
 **Option 1 (Parquet) cost components:**
 - transient scratch storage ≈ N samples × (blob + command-line text) bytes;
 - the BQ Parquet load-job bytes;
-- the dedup/MERGE query bytes scanned (dominated by the large text column).
+- the dedup (anti-join INSERT) query bytes scanned (dominated by the large text column).
 
 **Current BQ Write API path baseline (for comparison):**
 - `doRowsExistFor` runs a `SELECT COUNT(*)` per lookup (`BigQueryUtils.java:455`), called
@@ -248,7 +368,8 @@ Cost dimensions (the BQ/GCS pricing levers):
 
 1. **Ingest-time BQ queries** — query jobs fired *inside* each `CreateVariantIngestFiles` run.
 2. **GCS write ops + bytes** uploaded.
-3. **GCS transient storage** — held until the 14-day lifecycle delete.
+3. **GCS transient storage** — held until `DeleteParquetFiles` removes it after loading (the
+   14-day GCS lifecycle rule is only an off-by-default backstop).
 4. **GCS object count** — drives discovery `ls` cost and BQ small-file load overhead.
 5. **BQ load jobs** — free in dollars, but subject to quota + small-file overhead.
 6. **BQ query bytes scanned for dedup** — the on-demand dollar driver.
@@ -260,7 +381,7 @@ batch **load jobs are free**.
 
 ### 6.2 Comparison table (dominant term per cell)
 
-| Dimension | Current BQ Write API | Opt 1 Naive+MERGE | Opt 2 Content-addr (all) | Opt 3 Hybrid | Opt 4 Pre-load consolidate |
+| Dimension | Current BQ Write API | Opt 1 Naive+anti-join INSERT | Opt 2 Content-addr (all) | Opt 3 Hybrid | Opt 4 Pre-load consolidate |
 |---|---|---|---|---|---|
 | Ingest BQ queries | **~2(k+1)·N ≈ 1.6M** | 0 | 0 | 0 | 0 |
 | GCS bytes written | 0 | **N·B** | d_B·B + d_C·C | N·k·C + d_B·B | **N·B** |
@@ -283,15 +404,15 @@ of magnitude below an `N·B` term.
   `BigQueryUtils.java:455`). This is the fragility the Parquet path exists to escape, not a
   dollar problem.
 - **Option 1 (naive)** — the only nontrivial costs are transient GCS storage of **N·B**
-  (every sample's copy of the blob) for up to 14 days, plus one dedup MERGE that scans
-  **N·B** once. Both are ~N·B — cheap in absolute dollars (§6.4) but the largest
+  (every sample's copy of the blob) for up to 14 days, plus one dedup (anti-join INSERT) scan
+  of **N·B** once. Both are ~N·B — cheap in absolute dollars (§6.4) but the largest
   storage/scan footprint of the Parquet options. Zero ingest queries; lowest complexity.
 - **Option 2 (content-addressed, all chunks)** — eliminates N·B: the blob is stored once,
-  dedup is free via the object namespace, no MERGE scan. But `is_expected_unique = true`
+  dedup is free via the object namespace, no dedup scan. But `is_expected_unique = true`
   lines can explode to **~N tiny objects**, which hits (a) `ls` discovery cost/time, (b) BQ
   small-file load overhead, and (c) GCS Class-A op counts from N precondition writes.
   Lowest bytes, worst object-count profile, highest complexity (bespoke loader).
-- **Option 3 (hybrid)** — keeps the blob content-addressed (stored once, no MERGE scan for
+- **Option 3 (hybrid)** — keeps the blob content-addressed (stored once, no dedup scan for
   it) while writing the small command-line/association data the naive way. Object count ≈ N
   (same as naive) but each object is tiny (no B), so transient storage and any residual
   dedup scan drop from **N·B** to **N·k·C** — orders of magnitude smaller. Best
@@ -312,12 +433,13 @@ N = 400,000; B = 50 KB; k = 1; C = 200 B; d_B = 1; d_C ≈ 400,000.
 | BQ dedup scan | ~20 GB → ~$0.13 | 0 | ~80 MB → <$0.01 |
 
 **Takeaway:** every Parquet option is dollar-trivial. The decision is *operational*, not
-financial: Option 1's downside is a ~20 GB transient footprint (already auto-cleaned by the
-14-day lifecycle rule) and one ~20 GB scan; Options 2/3 shrink that to ~80 MB at the price
-of complexity (Opt 2 also trades it for an ~N-tiny-object problem). This argues for
-**Option 1 first** (cheapest to build, only real cost is transient storage the lifecycle
-already handles) and **Option 3** only if the transient footprint or object count becomes a
-problem at full AoU scale.
+financial: Option 1's downside is a ~20 GB transient footprint (auto-cleaned by
+`DeleteParquetFiles` after loading, with the 14-day lifecycle rule as an off-by-default
+backstop) and one ~20 GB scan; Options 2/3 shrink that to ~80 MB at the price of complexity
+(Opt 2 also trades it for an ~N-tiny-object problem). This argues for **Option 1 first**
+(cheapest to build, only real cost is transient storage that cleanup already handles) and
+**Option 3** only if the transient footprint or object count becomes a problem at full AoU
+scale.
 
 ### 6.5 How to measure each (extends the AC1 harness)
 
@@ -327,8 +449,8 @@ by N:
 - **Ingest queries:** count BQ jobs per ingest step (`cost_observability` / INFORMATION_SCHEMA.JOBS);
   confirm 0 for all Parquet options vs ~2(k+1)·N for the BQ path.
 - **GCS bytes/objects:** `gcloud storage du` and object counts on the parquet output dir
-  *before* the lifecycle delete.
-- **Dedup scan:** `totalBytesProcessed` / `totalSlotMs` from the MERGE job.
+  *before* `DeleteParquetFiles` runs.
+- **Dedup scan:** `totalBytesProcessed` / `totalSlotMs` from the anti-join INSERT job.
 - **Load:** job count + per-job duration from `load_parquet_to_bq.py` `stats.json`.
 - **Empirically measure the drivers** from one real gVCF header: **B** and **k** (they
   dominate every formula), and **d_B** via
@@ -343,30 +465,37 @@ no partial corruption — under three triggers: (a) a WDL **task retry** (preemp
 `maxRetries`), (b) a Cromwell **workflow resume / re-run**, and (c) a deliberate
 **re-ingest** of the same batch.
 
-### 7.1 How idempotent is the pipeline today?
+### 7.1 Existing idempotency, and the gap the Parquet path leaves
 
-Only *by accident*. The BQ path has three separate, fragile mechanisms:
+The system **was designed with idempotency in mind — this is not accidental.** The BQ ingest
+path tracks a per-sample `HEADERS_LOADED` status in `sample_load_status` (`LoadStatus.java`):
+`CreateVariantIngestFiles` checks it and **skips** header writes for a sample whose headers are
+already loaded, then writes the status on success (`CreateVariantIngestFiles.java:338-354`,
+`:466-468`). Re-ingesting an already-loaded sample is a deliberate no-op. The BQ path also
+dedups header *text* at write time by hash (`VcfHeaderLineScratchCreator`), so the
+scratch→final blind INSERT sees one non-null-text row per hash.
 
-- **Per-sample skip:** `CreateVariantIngestFiles` checks `doScratchRowsExistFor` /
-  `doNonScratchRowsExistFor` per sample and skips header writes if rows already exist
-  (`CreateVariantIngestFiles.java:340-347`). Idempotent-ish, but per-`sample_id` and not
-  atomic — a partially-written prior run can leave inconsistent state.
-- **Blind-INSERT merge:** `process_sample_vcf_headers.py:21,24` are plain INSERTs. Running
-  the merge **twice would duplicate** rows in both `vcf_header_lines` and
-  `sample_vcf_header`.
-- **Scratch delete as the only guard:** `clean_up_scratch_table`
-  (`process_sample_vcf_headers.py:28-31`) empties scratch after the merge, so a *second*
-  merge finds nothing to insert. Idempotency thus depends on the DELETE having succeeded —
-  if the merge commits but the delete fails (or the step is retried before it), the next
-  run double-inserts.
+Two narrower gaps remain, both specific to the **Parquet** path:
 
-So the current design is not structurally idempotent; it relies on ordering and a cleanup
-step. The Parquet redesign should not inherit that fragility.
+- **It bypasses the per-sample status logic.** `CreateVariantIngestFiles.java:356-361`
+  short-circuits the existence checks for `PARQUET` ("operate as though they don't exist"), and
+  `HEADERS_LOADED` is never written on the Parquet path (`shouldWriteVCFHeadersLoadedStatusRow`
+  is set only on the BQ branch, `:353`). So Parquet generation does not skip already-loaded
+  samples. *(Aside: the Parquet path not writing `HEADERS_LOADED` at all is a separate gap —
+  see §9.)*
+- **The promotion step is not self-contained.** The original scratch→final blind INSERT relied
+  on the scratch DELETE having run to avoid re-inserting; and because the Parquet path does no
+  write-time hash dedup, its scratch holds full text for *every* (sample, hash), which a blind
+  INSERT would duplicate in `vcf_header_lines`.
+
+The anti-join INSERT (§7.2) closes both: it dedups by key and refuses to re-insert rows already
+in the target, so the promotion is deduplicating and idempotent regardless of the scratch
+DELETE or the (absent) Parquet per-sample skip.
 
 ### 7.2 Where idempotency must be enforced per layer
 
 The Parquet path deliberately moves dedup/idempotency *off* the ingest write (no BQ
-round-trips there) and onto the load + merge. Each layer needs a keyed, re-runnable
+round-trips there) and onto the scratch → final load. Each layer needs a keyed, re-runnable
 operation:
 
 | Layer | Non-idempotent form | Idempotent form |
@@ -374,24 +503,26 @@ operation:
 | Parquet write (offline, per sample) | (already safe — writes local files only; re-run overwrites) | deterministic file contents |
 | GCS upload of header parquet | `cp` (overwrite — safe, identical bytes) | idempotent by nature; Opt 2/3 blob uses `ifGenerationMatch=0` |
 | BQ load scratch ← parquet | `WRITE_APPEND` retried → double-load | **deterministic load job ID** (`load_parquet_to_bq.py:166`) so BQ dedups the retried job |
-| Merge scratch → `vcf_header_lines` | blind INSERT | **MERGE** on `vcf_header_lines_hash` |
-| Merge scratch → `sample_vcf_header` | blind INSERT | **MERGE** on (`sample_id`, `vcf_header_lines_hash`) |
+| Load scratch → `vcf_header_lines` | blind INSERT | **anti-join INSERT** on `vcf_header_lines_hash` |
+| Load scratch → `sample_vcf_header` | blind INSERT | **anti-join INSERT** on (`sample_id`, `vcf_header_lines_hash`) |
 | Scratch cleanup | — | DELETE is naturally idempotent (re-delete = no-op) |
 
-Key point: with both final-table populations as **MERGEs keyed on their natural keys**, the
-whole chain becomes idempotent *independently* of the scratch-delete step — removing the
-fragile dependency in §7.1.
+Key point: with both final-table populations as **anti-join INSERTs keyed on their natural
+keys**, the whole chain becomes idempotent *independently* of the scratch-delete step —
+removing the fragile dependency in §7.1.
 
 ### 7.3 Idempotency by option
 
-- **Option 1 (naive + MERGE):** idempotent once both merges are keyed (§7.2) and scratch
-  loads use deterministic job IDs. Note scratch can accumulate rows across retries; the
-  MERGE absorbs that harmlessly (dedup by key), which is exactly why MERGE (not
-  `INSERT ... SELECT DISTINCT`) is the right primitive here.
+- **Option 1 (naive + anti-join INSERT):** idempotent once both loads are anti-joined (§7.2)
+  and scratch loads use deterministic job IDs. Note scratch can accumulate rows across
+  retries; the anti-join skips keys already in the target (and `GROUP BY`/`DISTINCT` collapses
+  within-batch dups), which is exactly why an anti-join INSERT — not a blind
+  `INSERT ... SELECT DISTINCT`, which would still re-insert rows already loaded — is the right
+  primitive here.
 - **Option 2 / 3 (content-addressed):** strongest form — the expensive header **text** is
   idempotent at the *storage* layer (path = hash, identical bytes, `ifGenerationMatch=0`
   skips re-writes), so re-runs are no-ops for the blob. The BQ association / `vcf_header_lines`
-  loads still need keyed MERGE/skip-existing, same as Option 1.
+  loads still need the keyed anti-join INSERT / skip-existing, same as Option 1.
 - **Option 4 (consolidation):** the consolidation output must be deterministic (stable
   file naming by hash) for the downstream load to be idempotent; otherwise re-runs produce
   new files that re-load.
@@ -399,13 +530,30 @@ fragile dependency in §7.1.
 ### 7.4 Recommendation
 
 Make idempotency structural, not incidental:
-1. Both final-table populations become **MERGE** statements keyed on natural keys.
+1. Both final-table populations become **anti-join INSERT** statements keyed on natural keys.
 2. Rely on **deterministic BQ load job IDs** for scratch-load retry safety.
 3. Keep the scratch DELETE as cleanup, but the design must be correct **without** depending
    on it having run.
 
 This is small extra work on top of Option 1 (one of the two merges was already going to
 change for dedup) and it satisfies constraint #6 for every option.
+
+### 7.5 Table persistence & incremental ingest
+
+Callsets are ingested in batches, so it matters which header tables persist:
+
+- **`vcf_header_lines` + `sample_vcf_header` are the incremental accumulator.** Each batch
+  merges its headers into them and they grow across batches. They must persist for the
+  callset's life.
+- **`vcf_header_lines_scratch` is throwaway.** `clean_up_scratch_table` empties it after every
+  merge, so it holds no long-term data; deleting its *rows* is normal. Dropping the *table*
+  breaks the next run only until it is recreated (`DiscoverParquetFiles` queries it).
+- **Subtlety:** header "skip already-loaded" detection in `DiscoverParquetFiles` reads the
+  *transient scratch* table (regular prefix `vcf_header_lines_scratch`), unlike vet/ref/ploidy
+  which check their persistent data tables. So cross-batch skip is effectively a no-op for
+  headers — harmless only because each batch generates parquet for its new samples and old
+  parquet is deleted after loading. Incremental **correctness rests on the anti-join INSERT +
+  the persistent tables**, not on skip-detection.
 
 ---
 
@@ -425,14 +573,36 @@ equivalence between a BQ-loaded and a Parquet-loaded dataset. Expected checks:
 
 ## 9. Open questions / risks
 
+- **`is_loaded` would not be set for Parquet callsets that load headers** (found by static
+  tracing during the VS-1968 spike; fix applied under the VS-1803 implementation — no
+  dedicated bug ticket yet — but **not** yet verified end-to-end, see `quickstart*` note). The
+  Parquet path writes no `sample_load_status` rows: all `shouldWrite*StatusRow` flags are set
+  only on the BQ branch (`CreateVariantIngestFiles.java:318/334/353`) and the Parquet branch
+  bypasses them (`:356-361`). Separately, `sample_info.is_loaded` is set post-load in bulk by
+  `SetIsLoadedColumn` from the `samples_with_all_data` view, which JOINs `samples_with_header_data`
+  when headers are in play. That header view read the **transient** `vcf_header_lines_scratch`
+  table (emptied by `ProcessVCFHeaders`) UNION the `HEADERS_LOADED` status — **neither of which
+  survives for Parquet**, so the view went empty and `is_loaded` was never set.
+  - **Fix applied:** point `samples_with_header_data` at the durable
+    `sample_vcf_header` table instead of transient scratch (`GvsImportGenomes.wdl`). This is
+    path-agnostic and removes the reliance on `HEADERS_LOADED` (aligns with the code's note
+    that `sample_load_status` "may no longer be needed").
+  - **Safe for the BQ path:** the view is a shared BQ/Parquet artifact, but the change doesn't
+    regress BQ — the `HEADERS_LOADED` status clause (still UNION'd in) covers the during-ingest
+    window before the scratch→final merge, and post-merge `sample_vcf_header` is populated for
+    BQ too, so no BQ samples drop out of the view.
+  - *Alternative (not chosen):* have the Parquet path write `HEADERS_LOADED` — but only at a
+    post-merge step (writing it during generation would mark "loaded" before the data is in
+    BigQuery). Left as an option if per-sample header status is wanted for parity.
+  - **Verify in the Terra `quickstart*` run** (traced statically; not executed here).
 - **Small-object cost (Option 2/3):** how many distinct `is_expected_unique = true` chunks
   arise at AoU scale? Determines whether content-addressing the unique lines is viable.
-- **MERGE cost at scale (Option 1):** the dedup MERGE scans the text column; confirm this
-  is cheaper than the query storm it replaces.
+- **Dedup-scan cost at scale (Option 1):** the anti-join INSERT scans the text column;
+  confirm this is cheaper than the query storm it replaces.
 - **`billing_project_id` not threaded to the loader** (`GvsImportGenomes.wdl:1248`,
   VS-1955) — verify header loads don't need it.
 - **Scratch retention:** Option 1 keeps scratch; confirm `clean_up_scratch_table`
-  (`process_sample_vcf_headers.py:28-31`) still applies cleanly after a MERGE.
+  (`process_sample_vcf_headers.py:28-31`) still applies cleanly after the anti-join INSERT.
 
 ---
 

--- a/scripts/variantstore/docs/parquet/header_loading_design.md
+++ b/scripts/variantstore/docs/parquet/header_loading_design.md
@@ -1,8 +1,8 @@
-# Loading VCF Headers on the Parquet Ingest Branch — Spike & Implementation Plan
+# Loading VCF Headers on the Parquet Ingest Branch
 
-**Tickets:** VS-1803 / VS-1951 / VS-1968 — *[Spike] How to load headers in Parquet branch*
+**Tickets:** VS-1968 — *[Spike] How to load headers in Parquet branch*
 
-**Motivation:** Supports GVS on TSPS and the next All of Us callset. Today VCF header
+**Motivation:** To support GVS on TSPS and the next All of Us callset. Today VCF header
 loading works only on the legacy BigQuery Write API ingest path; the Parquet ingest
 path (now the default for bulk/AoU) cannot load headers and actively blocks the attempt.
 
@@ -30,7 +30,7 @@ A sample's header is split into **chunks** by
 
 Each chunk is MD5-hashed; the hash is the dedup key.
 
-### 1.2 Where dedup actually happens today (important correction)
+### 1.2 Where dedup actually happens today
 
 Dedup is done **entirely at write time** in `VcfHeaderLineScratchCreator.java:93-108`
 (BQ path): for each chunk it runs existence checks against both the scratch and the
@@ -72,7 +72,7 @@ shared blob.
 - A gate placeholder is left at `GvsImportGenomes.wdl:252`
   ("*add a gate for Parquet header loading here once that's implemented*").
 
-### 1.4 The good news for the "same invocation" requirement
+### 1.4 TODO in Parquet
 
 The Parquet-generating task already localizes each VCF once
 (`GvsImportGenomes.wdl:551-553`) and runs a **single** `CreateVariantIngestFiles` call
@@ -126,7 +126,7 @@ task.
   object-count/listing cost); needs a bespoke loader (doesn't fit the superpartition FOFN
   grouping in `DiscoverParquetFiles`).
 
-### Option 3 — Hybrid, routed by `is_expected_unique` (recommended)
+### Option 3 — Hybrid, routed by `is_expected_unique` (probably optimal for implementation)
 - `false` (shared blob): content-address it (Option 2) → stored once. The big win.
 - `true` (command lines): write naively inline with associations → no small-object
   explosion, no dedup benefit lost (they were never going to dedup).
@@ -140,8 +140,7 @@ task.
 
 **Recommendation:** implement **Option 1 first** (low risk, unblocks TSPS/AoU, benchmarks
 the "naive" cost for AC1), then evaluate **Option 3** if the naive cost is unacceptable.
-Options 1 and 3 share the same writer-schema and WDL wiring work; only the dedup locus
-differs.
+Options 1 and 3 share the same writer-schema and WDL wiring work; only dedup differs.
 
 ---
 

--- a/scripts/variantstore/docs/parquet/header_loading_design.md
+++ b/scripts/variantstore/docs/parquet/header_loading_design.md
@@ -1,6 +1,6 @@
 # Loading VCF Headers on the Parquet Ingest Branch
 
-**Tickets:** VS-1968 — *[Spike] How to load headers in Parquet branch*
+**Tickets:** VS-1968 — *[Spike] How to load headers in Parquet code path*
 
 **Motivation:** To support GVS on TSPS and the next All of Us callset. Today VCF header
 loading works only on the legacy BigQuery Write API ingest path; the Parquet ingest

--- a/scripts/variantstore/docs/parquet/header_loading_design.md
+++ b/scripts/variantstore/docs/parquet/header_loading_design.md
@@ -571,13 +571,16 @@ is not a Parquet-specific regression.
 
 The race would only appear if **two ingest runs promoted into the same dataset concurrently**.
 The WDL guarantees only the *within-run* single-task promotion above; whether two
-`GvsImportGenomes` runs can overlap on one dataset is an **orchestration-layer assumption** this
-design has NOT verified — it depends on how bulk-ingest / AoU schedules runs. **Open item:**
-confirm with the AoU/bulk-ingest owners that concurrent promotions into one dataset cannot
-happen. If they can, the anti-join alone is insufficient and the promotion must be serialized
-(a dataset-level lock / mutex step) or followed by a dedup pass; Option 3's content-addressed
-blob dedup (§3) sidesteps this entirely for the expensive shared blob.
-*(Raised in review by mcovarr on the VS-1968 doc.)*
+`GvsImportGenomes` runs can overlap on one dataset is an **orchestration-layer question** the
+WDL itself cannot answer. **Resolved:** the bulk-ingest / AoU owner (mcovarr) has confirmed this
+must never happen going forward — the rest of the ingest system is not designed for that
+concurrency and would almost certainly enter a bad state if two runs shared a dataset. So the
+anti-join's *sequential* idempotency is sufficient for the supported operational model, and no
+dataset-level lock is required. (Were that invariant ever relaxed, the anti-join alone would be
+insufficient and the promotion would need serializing or a dedup pass; Option 3's
+content-addressed blob dedup (§3) sidesteps the concern entirely for the expensive shared blob
+regardless.)
+*(Raised in review by mcovarr on the VS-1968 doc; concurrency invariant confirmed by mcovarr.)*
 
 ---
 
@@ -653,9 +656,11 @@ A/B check against a BQ-loaded dataset is wanted, the same tables can be compared
   VS-1955) — verify header loads don't need it.
 - **Scratch retention:** Option 1 keeps scratch; confirm `clean_up_scratch_table`
   (`process_sample_vcf_headers.py:28-31`) still applies cleanly after the anti-join INSERT.
-- **Concurrent promotions into one dataset (§7.6):** the anti-join is only *sequentially*
-  idempotent. Confirm that two `GvsImportGenomes` in AoU/bulk-ingest runs cannot
-  overlap on the same dataset; if they can, serialize the promotion or move to Option 3's
+- **Concurrent promotions into one dataset (§7.6): resolved.** The anti-join is only
+  *sequentially* idempotent, which is sufficient because the bulk-ingest / AoU owner (mcovarr)
+  has confirmed two `GvsImportGenomes` runs must never overlap on the same dataset going forward
+  (the ingest system is not designed for that concurrency). No dataset-level lock is required; if
+  that invariant were ever relaxed, serialize the promotion or move to Option 3's
   content-addressed blob dedup.
 
 ---

--- a/scripts/variantstore/docs/parquet/header_loading_design.md
+++ b/scripts/variantstore/docs/parquet/header_loading_design.md
@@ -76,87 +76,52 @@ shared blob.
 - A gate placeholder is left at `GvsImportGenomes.wdl:252`
   ("*add a gate for Parquet header loading here once that's implemented*").
 
-### 1.4 Header extraction: single invocation vs. the gated model
+### 1.4 Header extraction reuses the existing single VCF read
 
 `CreateVariantIngestFiles` already localizes each VCF once (`GvsImportGenomes.wdl:551-553`)
 and runs a **single** call (`GvsImportGenomes.wdl:560`) that already accepts
-`--enable-vcf-headers` (`GvsImportGenomes.wdl:575`), so header extraction *can* piggyback on
-the existing VCF read with no extra localization. **However**, the operational model (§1.5)
-deliberately loads headers as a *separate, gated* phase before vet/ref/ploidy, which is in
-tension with folding everything into one pass. The Parquet architecture reconciles this
-because generation and BQ loading are already decoupled — see §1.5. Either way the remaining
-work is finishing the plumbing, not adding an ingest tool.
+`--enable-vcf-headers` (`GvsImportGenomes.wdl:575`), so header extraction piggybacks on the
+existing VCF read with no extra ingest tool — the remaining work is finishing the plumbing
+(upload → discover → load), not adding an extraction tool. Note that the operational model
+(§1.5) runs header loading as a **separate ingest** from vet/ref, so in practice each phase
+localizes its VCFs independently (twice overall) rather than folding everything into one pass.
 
-### 1.5 Operational model: phased, gated loading
+### 1.5 Operational model: phased header-then-data loading (AoU style)
 
-**Purpose of the header phase.** The header-only ingest is not a check that header *loading*
-worked — it is an early **sanity check of the input gVCFs themselves**. Loading just the
-headers is a cheap way to inspect each input's metadata (reference version, contig list,
-sample names, expected INFO/FORMAT/FILTER definitions, pipeline provenance) and confirm the
+**Purpose of the header phase.** The header-only ingest is an early **sanity check of the input gVCFs themselves**. Loading just the
+headers is one way to inspect each input's metadata (reference version, contig list,
+sample names, expected INFO/FORMAT/FILTER definitions, pipeline provenance, DRAGEN versions) and confirm the
 cohort is well-formed and mutually consistent *before* committing to the expensive vet/ref
 ingest. This purpose must be preserved in the Parquet path.
 
-**AoU today (BQ path).** Header loading is run as its **own** ingest first
-(`load_vcf_headers = true`, `load_vet_and_ref_ranges = false`), the loaded headers are then
-**manually inspected** to sanity-check the input gVCFs, and **only if that passes** is a
-second ingest run for vet / ref_ranges / sample_chromosome_ploidy. Three phases: *load
-headers → sanity check inputs → load everything else*. On the BQ path this localizes the VCFs
-**twice** (once per ingest run).
+**The supported model.** Header loading runs as its **own** ingest first
+(`load_vcf_headers = true`, `load_vet_and_ref_ranges = false`); the loaded headers are then
+**manually inspected** with BQ queries to sanity-check the input gVCFs; and **only if that passes** is a
+second ingest run for vet / ref_ranges / sample_chromosome_ploidy (`load_vcf_headers = false`,
+`load_vet_and_ref_ranges = true`). Three phases: *load headers → manually inspect inputs →
+load everything else*. This is the same operational model AoU already uses on the BQ path, and
+it is the **only** model supported on the Parquet path. It localizes the VCFs **twice** (once
+per ingest run) — an accepted cost, because the header phase exists precisely to catch bad
+inputs before paying for the expensive vet/ref ingest.
 
-**TSPS (assumption — undecided).** Likely the same three phases, but **automated** (the
-manual sanity check becomes an automated gate).
+The "avoid re-localizing the VCFs in a second task" idea (from VS-1803) is therefore **not**
+pursued: the phased model re-localizes by design. Validating inputs before doing expensive
+variant work fundamentally requires either re-localizing or doing that expensive work first,
+and this model chooses to re-localize so that **no** vet/ref compute is spent until the manual
+gate passes.
 
-**How this maps onto Parquet.** In the Parquet path, *generation* (localize VCF → write
-parquet to GCS) is already decoupled from *loading* (`DiscoverParquetFiles` →
-`LoadParquetFilesToBQ`). That opens two ways to honor the gate:
-
-- **(A) Generate-all-once, phased load.** One `CreateVariantIngestFiles` pass writes *all*
-  parquet (headers + vet + ref + ploidy) with a single localization; then load **only** the
-  header parquet, gate on the sanity check, and load the rest afterward from the parquet
-  already in GCS. Single localization *and* a real gate.
-  *Cost:* vet/ref/ploidy parquet is **generated before** the gate, so a failed header check
-  wastes that generation compute (and transient GCS storage).
-- **(B) Phase-separated generation.** A headers-only generation+load first (cheap), gate,
-  then a second generation+load for the rest — **re-localizing** the VCFs (as AoU does today
-  on the BQ path). *Cost:* pays localization + generation twice, but spends **no** vet/ref
-  compute until the gate passes.
-
-**Trade-off — sharpened by the purpose.** Because the gate exists specifically to *avoid
-expensive work on bad inputs*, approach (A) partly defeats it: (A) generates the vet/ref/ploidy
-parquet **before** the gate, so a caught bad input still pays the full generation cost — only
-the vet/ref *BQ load* is saved. In fact the "avoid re-localizing in a second task" wish
-(from VS-1803, not this spike) and the header phase's purpose are **fundamentally in
-conflict**: validating inputs
-before doing expensive variant work requires *either* re-localizing (B) *or* doing that
-expensive work first (A). We can have at most one.
-
-Concretely, per-sample the costs are: **localize** (copy the gVCF; needed for headers *and*
-variants), cheap **header parse**, and expensive **vet/ref parse**.
-- **(A)** localizes once but always does the vet/ref parse up front → wastes vet/ref parse on
-  a gate failure.
-- **(B)** localizes twice on success but does the vet/ref parse only after the gate → wastes
-  almost nothing on failure.
-
-So (A) wins only when localization dominates *and* input failures are rare; the stated
-purpose (the phase exists because bad inputs are a real risk) leans toward **(B)**, or toward
-(A) only if TSPS confirms failures are rare and localization is the dominant cost.
-**Recommendation:** leave open until TSPS fixes its model, but note the conflict above rather
-than assuming the re-localization can simply be optimized away.
-
-**Implication either way:**
-- The header load must complete and be validated as a *distinct, gated step* before the
-  vet/ref/ploidy load (see the WDL gate in §4.2); for approach (A) the parquet cleanup
-  (`DeleteParquetFiles`, which runs by default right after loading — plus the off-by-default
-  14-day GCS lifecycle rule as a backstop) must **not** remove the vet/ref parquet before the
-  post-gate load.
+**Implication:**
+- The header load must complete and be **manually validated** before the vet/ref/ploidy
+  ingest is started. Because these are separate workflow runs, the gate is enforced naturally
+  by the operator between runs (see the WDL wiring in §4.2).
 - The sanity check reads header **content**, so the Parquet header load must persist the
   **full header text**, not just hashes. Storing it *deduplicated* does not hurt inspection:
   the check reconstructs any sample's header by joining `sample_vcf_header` (sample → hash) to
   `vcf_header_lines` (hash → text). Every design in §3 ends with those same two tables, so all
   of them keep the header lines (contigs, reference, INFO/FORMAT) fully inspectable — the only
   way to lose that is an *incomplete* implementation that persists hashes without ever loading
-  the text into `vcf_header_lines` (see the caveat on the current content-addressing scaffold
-  in §3 / §7.3).
+  the text into `vcf_header_lines` (see the caveat on the content-addressing scaffold in
+  §3 / §7.3).
 
 ---
 
@@ -189,11 +154,11 @@ than assuming the re-localization can simply be optimized away.
 7. **Loading is phased and gated — as an input-gVCF sanity check** (§1.5). The header-only
    phase exists to validate the *input gVCFs* (reference, contigs, samples, expected fields)
    before the expensive vet/ref ingest, so it must remain a distinct, gated phase in the
-   Parquet path too. Consequences: (a) the header load must stand alone and gate the data
-   load; (b) it must persist **full header text** so the check can inspect content (a hard
-   requirement on Option 3's content-addressing); (c) for approach (A) the parquet cleanup
-   must be phase-aware so vet/ref parquet survives until its post-gate load; (d) this gated
-   re-run pattern makes constraint #6 (idempotency) more pressing, not less.
+   Parquet path too — run as a **separate ingest** from the data load. Consequences: (a) the
+   header load must stand alone and be manually validated before the data load is started;
+   (b) it must persist **full header text** so the check can inspect content (a hard
+   requirement on Option 3's content-addressing); (c) this separate-run pattern makes
+   constraint #6 (idempotency) more pressing, not less.
 
 ---
 
@@ -288,10 +253,12 @@ Options 1 and 3 share the same writer-schema and WDL wiring work; only the dedup
   — i.e. the Parquet header load for parquet runs, or the BQ Write API for BQ runs.
   `SetIsLoadedColumn` stays under `load_vet_and_ref_ranges` (headers-only runs don't mark
   samples loaded).
-- **Phasing (per §1.5):** the AoU-style gate is achieved by running the workflow **twice**
-  (headers-only, sanity-check, then data-only). The single-run intra-workflow gate
-  (approach A with a split scatter) and phase-aware parquet deletion are **not** implemented —
-  in a combined run headers and data load together.
+- **Phasing (per §1.5):** the supported operational model runs the workflow **twice** — a
+  headers-only ingest (`load_vcf_headers = true`, `load_vet_and_ref_ranges = false`), manual
+  inspection, then a data-only ingest. Each run localizes its own VCFs and cleans up its own
+  parquet after loading, so no intra-run phase-aware deletion is needed. (Setting both
+  booleans true in one run would load headers and data together and is technically possible,
+  but it bypasses the manual gate and is **not** the supported model.)
 - Validated with `womtool validate`. End-to-end coverage is the Terra `quickstart*` tests.
 
 ### 4.3 Python — scratch → final load

--- a/scripts/variantstore/docs/parquet/header_loading_design.md
+++ b/scripts/variantstore/docs/parquet/header_loading_design.md
@@ -1,0 +1,257 @@
+# Loading VCF Headers on the Parquet Ingest Branch — Spike & Implementation Plan
+
+**Tickets:** VS-1803 / VS-1951 / VS-1968 — *[Spike] How to load headers in Parquet branch*
+
+**Motivation:** Supports GVS on TSPS and the next All of Us callset. Today VCF header
+loading works only on the legacy BigQuery Write API ingest path; the Parquet ingest
+path (now the default for bulk/AoU) cannot load headers and actively blocks the attempt.
+
+---
+
+## 1. Current state
+
+### 1.1 The header data model (unchanged, works on the BQ path)
+
+Three tables, all created *conditionally* on `load_vcf_headers` in
+`GvsAssignIds.wdl:96-129` (schemas at `GvsAssignIds.wdl:30-32`):
+
+| Table | Columns | Role |
+|---|---|---|
+| `vcf_header_lines_scratch` | `sample_id`, `vcf_header_lines` (NULLABLE), `vcf_header_lines_hash`, `is_expected_unique` | Transient staging during ingest |
+| `vcf_header_lines` | `vcf_header_lines_hash`, `vcf_header_lines`, `is_expected_unique` | Deduplicated header text, one row per distinct hash |
+| `sample_vcf_header` | `sample_id`, `vcf_header_lines_hash` | Many-to-many map: which chunks each sample has |
+
+A sample's header is split into **chunks** by
+`CreateVariantIngestFiles.buildAllVcfLineHeaders()` (`CreateVariantIngestFiles.java:524-537`):
+
+- each `CommandLine` header line individually → `is_expected_unique = true` (varies per sample);
+- all remaining header lines joined into one blob → `is_expected_unique = false`
+  (near-identical across *all* samples — this blob is the entire dedup cost story).
+
+Each chunk is MD5-hashed; the hash is the dedup key.
+
+### 1.2 Where dedup actually happens today (important correction)
+
+Dedup is done **entirely at write time** in `VcfHeaderLineScratchCreator.java:93-108`
+(BQ path): for each chunk it runs existence checks against both the scratch and the
+already-loaded tables (`VcfHeaderLineScratchCreator.java:43-52`, backed by
+`BigQueryUtils.doRowsExistFor` at `BigQueryUtils.java:455`). If the hash already exists,
+it writes a row with **NULL** text (association only); otherwise it writes the full text.
+
+The scratch→final merge in `process_sample_vcf_headers.py` does **NOT** deduplicate:
+
+```sql
+-- process_sample_vcf_headers.py:21  (no DISTINCT / GROUP BY)
+INSERT INTO ...vcf_header_lines (vcf_header_lines_hash, vcf_header_lines, is_expected_unique)
+SELECT vcf_header_lines_hash, vcf_header_lines, is_expected_unique
+FROM ...vcf_header_lines_scratch
+WHERE vcf_header_lines IS NOT NULL;   -- relies on write-time NULLing for uniqueness
+```
+
+**Consequence for Parquet:** any design that drops the write-time existence checks
+*must* add deduplication somewhere else, or `vcf_header_lines` gets N copies of the
+shared blob.
+
+### 1.3 What the Parquet path does today
+
+- `VcfHeaderLineScratchCreator.java:109-113` — the `PARQUET` branch is a **stub**: it
+  writes only `sample_id` + `headerLineHash`. No header text, no `is_expected_unique`,
+  no dedup.
+- The Parquet header schema `headersRowSchema` (`CreateVariantIngestFiles.java:226`)
+  declares only 2 fields vs the 4-column scratch table.
+- `HeaderParquetFileWriter.writeJson` (`HeaderParquetFileWriter.java:38`) mirrors that
+  2-field shape.
+- The header Parquet file (`header_file.parquet`, `VcfHeaderLineScratchCreator.java:76`)
+  is written locally but **never uploaded** — the upload block globs only
+  `vet_*`/`ref_*`/`sample_chromosome_ploidy_*` (`GvsImportGenomes.wdl:586-596`) and then
+  `rm *.parquet` (`GvsImportGenomes.wdl:599`) deletes it.
+- The load chain never sees headers: `DiscoverParquetFiles` prefixes are only
+  `sample_chromosome_ploidy` / `vet` / `ref_ranges` (`GvsImportGenomes.wdl:278-279`).
+- The combination is explicitly blocked: `GvsImportGenomes.wdl:97-100`
+  ("*The combination of Parquet ingest and VCF header loading is not currently supported*").
+- A gate placeholder is left at `GvsImportGenomes.wdl:252`
+  ("*add a gate for Parquet header loading here once that's implemented*").
+
+### 1.4 The good news for the "same invocation" requirement
+
+The Parquet-generating task already localizes each VCF once
+(`GvsImportGenomes.wdl:551-553`) and runs a **single** `CreateVariantIngestFiles` call
+(`GvsImportGenomes.wdl:560`) that already passes `--enable-vcf-headers`
+(`GvsImportGenomes.wdl:575`). Header extraction piggybacks on the existing VCF read —
+**no second localization is required**. The work is finishing the plumbing, not adding a
+task.
+
+---
+
+## 2. Key findings / constraints
+
+1. **The merge does not dedup** (§1.2). Naive Parquet writing requires a dedup step to be
+   added.
+2. **`is_expected_unique` is an unused lever.** It cleanly separates the one shared blob
+   (dedup-worthy) from per-sample command lines (not dedup-worthy). Designs can route on it.
+3. **Per-sample invocations are isolated.** Each `CreateVariantIngestFiles` run sees one
+   gVCF and cannot see other samples' chunks without a shared store — so cross-sample
+   write-time dedup (as the BQ path does via BQ queries) is not naturally available offline.
+4. **Incremental ingest must be handled.** Callsets add samples in batches; the BQ path
+   checks *already-loaded* tables (`VcfHeaderLineScratchCreator.java:43-52`). Any Parquet
+   design must avoid re-inserting a hash already present in `vcf_header_lines` from a prior
+   batch.
+5. **The current BQ dedup is itself expensive** — see §5.
+
+---
+
+## 3. Design options
+
+### Option 1 — Naive write, dedup in the merge SQL (low risk)
+- Writer: emit full text + `is_expected_unique` for every chunk, every sample; drop the
+  existence queries.
+- Merge: change `process_sample_vcf_headers.py:21` from a blind INSERT to a **MERGE** into
+  `vcf_header_lines` on `vcf_header_lines_hash` (or `SELECT ... GROUP BY hash`), so it
+  dedups *and* is idempotent across batches (satisfies constraint #4).
+- **Cost:** max (transient) scratch bloat; one large dedup/MERGE query scanning the text
+  column; zero per-sample BQ round-trips during ingest.
+- **Pros:** simplest; keeps existing scratch + load machinery; ingest stays fully offline
+  and parallel (the point of the Parquet path).
+- **Cons:** transient N× storage; large dedup query.
+
+### Option 2 — Content-addressed header text (larger change)
+- Split writer output: (a) tiny per-sample **associations** (`sample_id`, `hash`,
+  `is_expected_unique`) → `sample_vcf_header`; (b) header **text** written to a GCS path
+  keyed by hash, e.g. `.../headers/text/<hash>.parquet`, with an `ifGenerationMatch=0`
+  precondition so identical concurrent writes are skipped.
+- Load: distinct hash-named objects → `vcf_header_lines` (one object = one row = inherently
+  deduped). Incremental ingest is free (object/hash already exists → skip).
+- **Pros:** shared blob stored once; no dedup query; **scratch table can be eliminated**.
+- **Cons:** `is_expected_unique = true` lines can explode into ~N tiny objects (GCS
+  object-count/listing cost); needs a bespoke loader (doesn't fit the superpartition FOFN
+  grouping in `DiscoverParquetFiles`).
+
+### Option 3 — Hybrid, routed by `is_expected_unique` (recommended)
+- `false` (shared blob): content-address it (Option 2) → stored once. The big win.
+- `true` (command lines): write naively inline with associations → no small-object
+  explosion, no dedup benefit lost (they were never going to dedup).
+- **Pros:** cost-optimal; uses the schema flag as intended.
+- **Cons:** two code paths in the writer.
+
+### Option 4 — Pre-load local consolidation
+- Dedup header Parquet by hash in a consolidation step before load (git precedent:
+  "Experimenting with local consolidation and deduping of parquet data").
+- **Cons:** already paid N× GCS writes; only saves BQ-side cost. Weaker than 2/3.
+
+**Recommendation:** implement **Option 1 first** (low risk, unblocks TSPS/AoU, benchmarks
+the "naive" cost for AC1), then evaluate **Option 3** if the naive cost is unacceptable.
+Options 1 and 3 share the same writer-schema and WDL wiring work; only the dedup locus
+differs.
+
+---
+
+## 4. Implementation work breakdown (Option 1, with Option 3 notes)
+
+### 4.1 Java — writer + schema
+- `CreateVariantIngestFiles.java:226` — expand `headersRowSchema` to the full 4 columns
+  (`sample_id`, `vcf_header_lines` text, `vcf_header_lines_hash`, `is_expected_unique`).
+- `VcfHeaderLineScratchCreator.java:109-113` — flesh out the `PARQUET` branch to write the
+  full record (text + hash + `is_expected_unique`); drop the write-time existence checks on
+  this path.
+- `HeaderParquetFileWriter.java:38` (`writeJson`) — extend to the full record shape.
+- *(Option 3)* route on `is_expected_unique`: content-address the shared blob, inline the
+  unique lines.
+- Reference template: commits `e852dcf27` / `2d48b4a84` (ref & ploidy Parquet writers) and
+  `gvs_ingest_refactoring.md` (note VS-1803 is called out there as the pending header work).
+
+### 4.2 WDL — `GvsImportGenomes.wdl`
+- Remove the block at `:97-100` (`CannotLoadHeadersWithParquetIngest`).
+- Upload the header Parquet in the generate task: extend the glob/copy block
+  (`:586-596`) to pick up `header_file.parquet` and copy it to a new
+  `.../vcf_header_lines_scratch/` GCS dir (before the `rm *.parquet` at `:599`).
+- `DiscoverParquetFiles` (`:273`, prefixes at `:278-279`): add `vcf_header_lines_scratch`
+  as a `regular_table_prefixes` entry so the FOFN grouping (`parse_and_group_files.py`)
+  picks it up. The loader derives the table name from the FOFN filename
+  (`load_parquet_to_bq.py:46-52`), so a `vcf_header_lines_scratch.fofn` loads into the
+  scratch table with no loader change.
+- Gate: wire `ProcessVCFHeaders` (`:249`, gate at `:252`) to also depend on
+  `LoadParquetFilesToBQ.done` when `use_parquet_ingest` (currently only
+  `LoadDataViaBigQueryWriteAPI.done`).
+
+### 4.3 Python — merge
+- `process_sample_vcf_headers.py:21` — change the `vcf_header_lines` INSERT to a
+  **MERGE**/dedup on `vcf_header_lines_hash` (dedups the naive-loaded scratch rows *and*
+  makes it idempotent across incremental batches). The `sample_vcf_header` INSERT
+  (`:24`) stays as-is (naturally unique per sample+hash).
+- `load_parquet_to_bq.py` — no change needed for Option 1 (raw load into scratch);
+  Option 2/3 would need a content-addressed loader.
+
+### 4.4 Table schema
+- No schema change to the three tables. `vcf_header_lines_scratch` stays as the load
+  target for Option 1. *(Option 2/3 could drop scratch for the Parquet path.)*
+
+---
+
+## 5. AC1 — cost of a naive header load into BQ
+
+"Naive" = Option 1. Measure and compare against the current BQ Write API path.
+
+**Option 1 (Parquet) cost components:**
+- transient scratch storage ≈ N samples × (blob + command-line text) bytes;
+- the BQ Parquet load-job bytes;
+- the dedup/MERGE query bytes scanned (dominated by the large text column).
+
+**Current BQ Write API path baseline (for comparison):**
+- `doRowsExistFor` runs a `SELECT COUNT(*)` per lookup (`BigQueryUtils.java:455`), called
+  **twice per chunk** (scratch + non-scratch) × ~2 chunks/sample ≈ **~4 BQ query jobs per
+  sample** — on the order of **~1.6M query jobs for a 400k-sample callset**, serialized
+  inside each ingest task, plus the streaming inserts.
+
+Escaping that per-sample query storm is a primary motivation; the naive Parquet approach
+trades it for transient storage + one dedup query.
+
+**Suggested measurement harness:** `GvsQuickstartVcfIntegration.wdl` (smallest end-to-end
+path with `load_vcf_headers = true`); capture bytes/slot-ms from the `cost_observability`
+table and BQ job stats for both paths at a fixed sample count, then extrapolate.
+
+---
+
+## 6. AC2 — consistency queries
+
+Consistency queries to be supplied by Aaron Hatcher. They will presumably assert
+equivalence between a BQ-loaded and a Parquet-loaded dataset. Expected checks:
+- row counts and distinct-hash counts in `vcf_header_lines` match across paths;
+- `sample_vcf_header` (sample_id, hash) set is identical across paths;
+- every `sample_vcf_header.vcf_header_lines_hash` resolves to a row in `vcf_header_lines`
+  (referential integrity; no orphan hashes);
+- reconstructed per-sample header text is byte-identical across paths.
+
+*(Placeholder — fill in once queries are provided.)*
+
+---
+
+## 7. Open questions / risks
+
+- **Small-object cost (Option 2/3):** how many distinct `is_expected_unique = true` chunks
+  arise at AoU scale? Determines whether content-addressing the unique lines is viable.
+- **MERGE cost at scale (Option 1):** the dedup MERGE scans the text column; confirm this
+  is cheaper than the query storm it replaces.
+- **`billing_project_id` not threaded to the loader** (`GvsImportGenomes.wdl:1248`,
+  VS-1955) — verify header loads don't need it.
+- **Scratch retention:** Option 1 keeps scratch; confirm `clean_up_scratch_table`
+  (`process_sample_vcf_headers.py:28-31`) still applies cleanly after a MERGE.
+
+---
+
+## 8. File / line reference index
+
+| Area | Location |
+|---|---|
+| Parquet header writer stub | `VcfHeaderLineScratchCreator.java:109-113` |
+| BQ write-time dedup | `VcfHeaderLineScratchCreator.java:93-108` |
+| Already-loaded existence checks | `VcfHeaderLineScratchCreator.java:43-52`, `BigQueryUtils.java:455` |
+| Header chunking | `CreateVariantIngestFiles.java:524-537` |
+| Parquet header schema (2-field) | `CreateVariantIngestFiles.java:226` |
+| Header Parquet file writer | `HeaderParquetFileWriter.java:38` |
+| Table schemas / creation | `GvsAssignIds.wdl:30-32`, `GvsAssignIds.wdl:96-129` |
+| Scratch→final merge (no dedup) | `process_sample_vcf_headers.py:21,24,28-31` |
+| Blocking guard | `GvsImportGenomes.wdl:97-100` |
+| Single-invocation ingest + `--enable-vcf-headers` | `GvsImportGenomes.wdl:551-575` |
+| Parquet upload glob | `GvsImportGenomes.wdl:586-599` |
+| Discover / load / gate | `GvsImportGenomes.wdl:278-279`, `:288`, `:252` |
+| Loader (table name from FOFN) | `load_parquet_to_bq.py:16,46-52` |

--- a/scripts/variantstore/docs/parquet/header_loading_design.md
+++ b/scripts/variantstore/docs/parquet/header_loading_design.md
@@ -90,14 +90,14 @@ localizes its VCFs independently (twice overall) rather than folding everything 
 
 **Purpose of the header phase.** The header-only ingest is an early **sanity check of the input gVCFs themselves**. Loading just the
 headers is one way to inspect each input's metadata (reference version, contig list,
-sample names, expected INFO/FORMAT/FILTER definitions, pipeline provenance, DRAGEN versions) and confirm the
+sample names, expected INFO/FORMAT/FILTER definitions, pipeline provenance, DRAGEN versions, whether reblocking was done, etc.) and confirm the
 cohort is well-formed and mutually consistent *before* committing to the expensive vet/ref
 ingest. This purpose must be preserved in the Parquet path.
 
 **The supported model.** Header loading runs as its **own** ingest first
 (`load_vcf_headers = true`, `load_vet_and_ref_ranges = false`); the loaded headers are then
 **manually inspected** with BQ queries to sanity-check the input gVCFs; and **only if that passes** is a
-second ingest run for vet / ref_ranges / sample_chromosome_ploidy (`load_vcf_headers = false`,
+second ingest run started for vet / ref_ranges / sample_chromosome_ploidy (`load_vcf_headers = false`,
 `load_vet_and_ref_ranges = true`). Three phases: *load headers → manually inspect inputs →
 load everything else*. This is the same operational model AoU already uses on the BQ path, and
 it is the **only** model supported on the Parquet path. It localizes the VCFs **twice** (once
@@ -197,6 +197,17 @@ gate passes.
 - `true` (command lines): write naively inline with associations → no small-object
   explosion, no dedup benefit lost (they were never going to dedup).
 - **Pros:** cost-optimal; uses the schema flag as intended.
+- **Pros (concurrency — the strongest structural argument):** content-addressing gives
+  **lock-free cross-shard dedup**. Generation is sharded (§1.5, `GvsImportGenomes.wdl:186`) and
+  shards are isolated (constraint #3), so no shard can see another's chunks. The BQ path solved
+  this with a *synchronous shared-table* existence check (`doRowsExistFor`), which is the source
+  of its ~1.6M-query storm (§5). Option 3 instead makes the **GCS object namespace the
+  coordination point**: concurrent shards racing to write the same `<hash>.parquet` are resolved
+  by the `ifGenerationMatch=0` precondition (first writer wins; the rest get a 412 and skip). So
+  the shared blob is written **once** across all shards with **no locks, no round-trips, and no
+  central table** — write-time-style dedup restored, but offline and contention-free. This holds
+  regardless of shard count and is unaffected by the concurrency caveat in §7.6 (the anti-join's
+  concurrent-writer gap), because the dedup happens at the storage layer, not via read-then-INSERT.
 - **Cons:** two code paths in the writer.
 - **Scaffold caveat:** the current `HYBRID` code (`VcfHeaderLineScratchCreator`, dormant behind
   the hardcoded strategy switch) is a *stub* — it writes the blob's association only and drops
@@ -212,6 +223,18 @@ gate passes.
 **Recommendation:** implement **Option 1 first** (low risk, unblocks TSPS/AoU, benchmarks
 the "naive" cost for AC1), then evaluate **Option 3** if the naive cost is unacceptable.
 Options 1 and 3 share the same writer-schema and WDL wiring work; only the dedup locus differs.
+
+**A note on preferring Option 3 despite the trivial cost.** The §6 dollar analysis says Option 1
+is fine — the N×B footprint is pennies and auto-cleaned. But cost is not the only axis. On
+*concurrency and design cleanliness* Option 3 is the better fit: it dedups the shared blob
+**structurally** at the storage layer (lock-free, shard-count-independent, §3 Option 3 pros)
+rather than deferring it to a single after-the-fact anti-join scan that is itself only
+sequentially — not concurrently — safe (§7.6). In other words, Option 3 makes the shared blob
+*"stored once"* an invariant of the write path instead of a property the load query has to
+reconstruct. That is a legitimate reason to prefer Option 3 as the eventual target even though
+the cost argument alone would not justify the extra engineering. The staging is deliberate:
+ship Option 1 to unblock and to get the AC1 measurement, then move to Option 3 for the cleaner
+concurrency story (and the smaller footprint) once the content-addressed loader is built.
 
 ---
 
@@ -384,6 +407,10 @@ of magnitude below an `N·B` term.
   (same as naive) but each object is tiny (no B), so transient storage and any residual
   dedup scan drop from **N·B** to **N·k·C** — orders of magnitude smaller. Best
   cost/footprint overall; moderate complexity (two writer paths + one bespoke blob loader).
+  **Beyond footprint, Option 3 also wins on concurrency:** the blob's *"stored once"* is
+  enforced lock-free across isolated shards by the `ifGenerationMatch=0` object namespace (§3
+  Option 3 pros), so — unlike Option 1's anti-join, whose idempotency is only sequential (§7.6)
+  — dedup is structural at the write layer and independent of shard count and promotion timing.
 - **Option 4 (pre-load consolidation)** — still pays the full **N·B** GCS write, then adds
   a consolidation VM that reads **N·B** to dedup locally before a tiny load. Saves the BQ
   dedup scan but not the write, and adds compute. Dominated by Option 3 on every axis.
@@ -404,9 +431,12 @@ financial: Option 1's downside is a ~20 GB transient footprint (auto-cleaned by
 `DeleteParquetFiles` after loading, with the 14-day lifecycle rule as an off-by-default
 backstop) and one ~20 GB scan; Options 2/3 shrink that to ~80 MB at the price of complexity
 (Opt 2 also trades it for an ~N-tiny-object problem). This argues for **Option 1 first**
-(cheapest to build, only real cost is transient storage that cleanup already handles) and
-**Option 3** only if the transient footprint or object count becomes a problem at full AoU
-scale.
+(cheapest to build, only real cost is transient storage that cleanup already handles). It does
+**not** argue against Option 3: the case for Option 3 is not the (trivial) dollars but the
+cleaner *concurrency* story — structural, lock-free, shard-independent blob dedup vs. Option 1's
+only-sequentially-idempotent anti-join (§3 Option 3 pros, §7.6). So the staging is "Option 1 to
+unblock, Option 3 as the eventual target," with the concurrency argument — not the footprint —
+being the thing that would pull Option 3 forward.
 
 ### 6.5 How to measure each (extends the AC1 harness)
 
@@ -522,6 +552,33 @@ Callsets are ingested in batches, so it matters which header tables persist:
   parquet is deleted after loading. Incremental **correctness rests on the anti-join INSERT +
   the persistent tables**, not on skip-detection.
 
+### 7.6 Re-run idempotency vs. concurrent-writer safety (review note)
+
+The anti-join INSERT makes the promotion idempotent across **sequential** re-runs (task retry,
+Cromwell resume, deliberate re-ingest). It does **not** make two promotions writing
+**concurrently** safe: two `INSERT ... SELECT ... LEFT JOIN t ... WHERE t.key IS NULL`
+statements can both observe a key as absent and both insert it, because BigQuery does **not**
+conflict-abort concurrent `INSERT`s the way it does `UPDATE`/`DELETE`/`MERGE` under optimistic
+concurrency. The result would be a duplicate row.
+
+This is **not** a live risk in the current wiring: `ProcessVCFHeaders`
+(`GvsImportGenomes.wdl:335`) is a **single, non-scattered** task that runs both anti-join
+INSERTs exactly once per workflow run. The per-shard scatter (`LoadParquetFilesToBQ`,
+`GvsImportGenomes.wdl:281-290`) only *appends* raw rows into `vcf_header_lines_scratch`
+(retry-idempotent via deterministic BQ load job IDs, §7.2) and never runs the anti-join — so no
+two shards race on the promotion. The **BQ path uses the same single-task promotion**, so this
+is not a Parquet-specific regression.
+
+The race would only appear if **two ingest runs promoted into the same dataset concurrently**.
+The WDL guarantees only the *within-run* single-task promotion above; whether two
+`GvsImportGenomes` runs can overlap on one dataset is an **orchestration-layer assumption** this
+design has NOT verified — it depends on how bulk-ingest / AoU schedules runs. **Open item:**
+confirm with the AoU/bulk-ingest owners that concurrent promotions into one dataset cannot
+happen. If they can, the anti-join alone is insufficient and the promotion must be serialized
+(a dataset-level lock / mutex step) or followed by a dedup pass; Option 3's content-addressed
+blob dedup (§3) sidesteps this entirely for the expensive shared blob.
+*(Raised in review by mcovarr on the VS-1968 doc.)*
+
 ---
 
 ## 8. AC2 — header-analysis queries WIP based on VS-1215
@@ -570,17 +627,23 @@ A/B check against a BQ-loaded dataset is wanted, the same tables can be compared
   when headers are in play. That header view read the **transient** `vcf_header_lines_scratch`
   table (emptied by `ProcessVCFHeaders`) UNION the `HEADERS_LOADED` status — **neither of which
   survives for Parquet**, so the view went empty and `is_loaded` was never set.
-  - **Fix applied:** point `samples_with_header_data` at the durable
-    `sample_vcf_header` table instead of transient scratch (`GvsImportGenomes.wdl`). This is
-    path-agnostic and removes the reliance on `HEADERS_LOADED` (aligns with the code's note
-    that `sample_load_status` "may no longer be needed").
+  - **Fix applied (review-endorsed):** point `samples_with_header_data` at the durable
+    `sample_vcf_header` table instead of transient scratch
+    (`GvsImportGenomes.wdl:1054-1058`), `UNION DISTINCT` the `HEADERS_LOADED` status
+    (`:952-960`, `:1036-1058`). This mirrors `samples_with_reference_data` /
+    `samples_with_variant_data` (data-presence source `UNION` `sample_load_status`) — exactly
+    the structure mcovarr recommended in review (VS-1968 doc): the Parquet side derives presence
+    from `sample_vcf_header`, and the `sample_load_status` `UNION` preserves legacy BQ-loaded
+    datasets. It is path-agnostic and removes reliance on `HEADERS_LOADED` for the Parquet path.
   - **Safe for the BQ path:** the view is a shared BQ/Parquet artifact, but the change doesn't
-    regress BQ — the `HEADERS_LOADED` status clause (still UNION'd in) covers the during-ingest
-    window before the scratch→final merge, and post-merge `sample_vcf_header` is populated for
-    BQ too, so no BQ samples drop out of the view.
-  - *Alternative (not chosen):* have the Parquet path write `HEADERS_LOADED` — but only at a
-    post-merge step (writing it during generation would mark "loaded" before the data is in
-    BigQuery). Left as an option if per-sample header status is wanted for parity.
+    regress BQ — the `HEADERS_LOADED` status clause (still UNION'd in, gated on the
+    `sample_load_status` table existing) covers the during-ingest window before the
+    scratch→final merge, and post-merge `sample_vcf_header` is populated for BQ too, so no BQ
+    samples drop out of the view. No BQ code-path change is required.
+  - **The Parquet path deliberately does not write `HEADERS_LOADED`** — per mcovarr's review
+    (VS-1968 doc), header-load presence is determined *by the view* (as vet/ref/ploidy already do),
+    not by a per-sample status row. Writing `HEADERS_LOADED` on the Parquet path was considered
+    and **rejected**.
   - **Verify in the Terra `quickstart*` run** (traced statically; not executed here).
 - **Small-object cost (Option 2/3):** how many distinct `is_expected_unique = true` chunks
   arise at AoU scale? Determines whether content-addressing the unique lines is viable.
@@ -590,6 +653,10 @@ A/B check against a BQ-loaded dataset is wanted, the same tables can be compared
   VS-1955) — verify header loads don't need it.
 - **Scratch retention:** Option 1 keeps scratch; confirm `clean_up_scratch_table`
   (`process_sample_vcf_headers.py:28-31`) still applies cleanly after the anti-join INSERT.
+- **Concurrent promotions into one dataset (§7.6):** the anti-join is only *sequentially*
+  idempotent. Confirm that two `GvsImportGenomes` in AoU/bulk-ingest runs cannot
+  overlap on the same dataset; if they can, serialize the promotion or move to Option 3's
+  content-addressed blob dedup.
 
 ---
 

--- a/scripts/variantstore/docs/parquet/header_loading_design.md
+++ b/scripts/variantstore/docs/parquet/header_loading_design.md
@@ -1,4 +1,4 @@
-# Loading VCF Headers on the Parquet Ingest Branch
+# Loading VCF Headers in the Parquet Code Path
 
 **Tickets:** VS-1968 — *[Spike] How to load headers in Parquet code path*
 

--- a/scripts/variantstore/docs/parquet/header_loading_design.md
+++ b/scripts/variantstore/docs/parquet/header_loading_design.md
@@ -210,7 +210,121 @@ table and BQ job stats for both paths at a fixed sample count, then extrapolate.
 
 ---
 
-## 6. AC2 — consistency queries
+## 6. Comparative cost of the design options
+
+AC1 (§5) covers the naive load (Option 1). This section puts Options 2–4 and the current
+BQ path on the same cost model so they can be compared directly. **Bottom line up front:**
+at header data volumes every Parquet option costs pennies in BQ/GCS dollars — the real
+differentiators are *transient storage footprint*, *GCS object count / small-file
+handling*, and *engineering complexity*, and the current BQ path's cost is an *operational*
+query storm rather than dollars.
+
+### 6.1 Cost model & parameters
+
+Per ingest batch of **N** samples (AoU ≈ 400k):
+
+- **B** — size of the shared non-command-line blob (`is_expected_unique = false`),
+  ~10–100 KB (working figure: 50 KB).
+- **k** — command-line chunks per sample (`is_expected_unique = true`), ~1–3, each ~**C**
+  bytes (small, ~200 B).
+- **d_B** — distinct shared blobs across the batch (usually 1; a few if samples span
+  pipeline/reference versions).
+- **d_C** — distinct command-line chunks (up to ≈N if genuinely per-sample; fewer if
+  pipelines share command lines).
+
+Cost dimensions (the BQ/GCS pricing levers):
+
+1. **Ingest-time BQ queries** — query jobs fired *inside* each `CreateVariantIngestFiles` run.
+2. **GCS write ops + bytes** uploaded.
+3. **GCS transient storage** — held until the 14-day lifecycle delete.
+4. **GCS object count** — drives discovery `ls` cost and BQ small-file load overhead.
+5. **BQ load jobs** — free in dollars, but subject to quota + small-file overhead.
+6. **BQ query bytes scanned for dedup** — the on-demand dollar driver.
+7. **Final BQ storage** — deduped; ~identical and negligible across all options.
+
+Representative unit prices (US, *verify current*): on-demand query **$6.25 / TiB scanned**;
+GCS Standard **~$0.02 / GB-month**; BQ Storage Write API **~$0.025 / GB** (streaming); BQ
+batch **load jobs are free**.
+
+### 6.2 Comparison table (dominant term per cell)
+
+| Dimension | Current BQ Write API | Opt 1 Naive+MERGE | Opt 2 Content-addr (all) | Opt 3 Hybrid | Opt 4 Pre-load consolidate |
+|---|---|---|---|---|---|
+| Ingest BQ queries | **~2(k+1)·N ≈ 1.6M** | 0 | 0 | 0 | 0 |
+| GCS bytes written | 0 | **N·B** | d_B·B + d_C·C | N·k·C + d_B·B | **N·B** |
+| GCS transient storage | 0 | **N·B** | d_B·B + d_C·C | N·k·C + d_B·B | N·B (then small) |
+| GCS object count | 0 | N | **d_B + d_C (→ ~N tiny)** | N (small) + d_B | N → small |
+| BQ load jobs | 0 (stream) | N/10k | ~N/10k (tiny files) | N/10k (small) | few |
+| BQ dedup scan | 0 | **N·B** | 0 | N·k·C | 0 (local) |
+| Streaming $ | d_B·B + assoc | 0 | 0 | 0 | 0 |
+| Extra compute | — | — | — | — | **consolidation VM reads N·B** |
+| Complexity / risk | (baseline) | Low | High | Medium | Med-High |
+
+Bold marks the dominant cost for each option. Note `C ≪ B`, so any `N·k·C` term is orders
+of magnitude below an `N·B` term.
+
+### 6.3 Per-option read
+
+- **Current BQ path** — negligible dollars (small bytes, cheap streaming) but its cost is
+  *operational*: ~1.6M query jobs against per-project query rate limits / concurrency,
+  serialized inside ingest tasks (`VcfHeaderLineScratchCreator.java:93-108`,
+  `BigQueryUtils.java:455`). This is the fragility the Parquet path exists to escape, not a
+  dollar problem.
+- **Option 1 (naive)** — the only nontrivial costs are transient GCS storage of **N·B**
+  (every sample's copy of the blob) for up to 14 days, plus one dedup MERGE that scans
+  **N·B** once. Both are ~N·B — cheap in absolute dollars (§6.4) but the largest
+  storage/scan footprint of the Parquet options. Zero ingest queries; lowest complexity.
+- **Option 2 (content-addressed, all chunks)** — eliminates N·B: the blob is stored once,
+  dedup is free via the object namespace, no MERGE scan. But `is_expected_unique = true`
+  lines can explode to **~N tiny objects**, which hits (a) `ls` discovery cost/time, (b) BQ
+  small-file load overhead, and (c) GCS Class-A op counts from N precondition writes.
+  Lowest bytes, worst object-count profile, highest complexity (bespoke loader).
+- **Option 3 (hybrid)** — keeps the blob content-addressed (stored once, no MERGE scan for
+  it) while writing the small command-line/association data the naive way. Object count ≈ N
+  (same as naive) but each object is tiny (no B), so transient storage and any residual
+  dedup scan drop from **N·B** to **N·k·C** — orders of magnitude smaller. Best
+  cost/footprint overall; moderate complexity (two writer paths + one bespoke blob loader).
+- **Option 4 (pre-load consolidation)** — still pays the full **N·B** GCS write, then adds
+  a consolidation VM that reads **N·B** to dedup locally before a tiny load. Saves the BQ
+  dedup scan but not the write, and adds compute. Dominated by Option 3 on every axis.
+
+### 6.4 Worked example (plausible numbers)
+
+N = 400,000; B = 50 KB; k = 1; C = 200 B; d_B = 1; d_C ≈ 400,000.
+
+| Quantity | Opt 1 | Opt 2 | Opt 3 |
+|---|---|---|---|
+| GCS bytes written | ~20 GB | ~80 MB | ~80 MB + 50 KB |
+| Transient storage (14 d) | ~20 GB → ~$0.14 | ~80 MB → <$0.01 | ~80 MB → <$0.01 |
+| GCS objects | ~400k | ~400k tiny | ~400k tiny + 1 |
+| BQ dedup scan | ~20 GB → ~$0.13 | 0 | ~80 MB → <$0.01 |
+
+**Takeaway:** every Parquet option is dollar-trivial. The decision is *operational*, not
+financial: Option 1's downside is a ~20 GB transient footprint (already auto-cleaned by the
+14-day lifecycle rule) and one ~20 GB scan; Options 2/3 shrink that to ~80 MB at the price
+of complexity (Opt 2 also trades it for an ~N-tiny-object problem). This argues for
+**Option 1 first** (cheapest to build, only real cost is transient storage the lifecycle
+already handles) and **Option 3** only if the transient footprint or object count becomes a
+problem at full AoU scale.
+
+### 6.5 How to measure each (extends the AC1 harness)
+
+Reuse the `GvsQuickstartVcfIntegration.wdl` harness at a fixed sample count and extrapolate
+by N:
+
+- **Ingest queries:** count BQ jobs per ingest step (`cost_observability` / INFORMATION_SCHEMA.JOBS);
+  confirm 0 for all Parquet options vs ~2(k+1)·N for the BQ path.
+- **GCS bytes/objects:** `gcloud storage du` and object counts on the parquet output dir
+  *before* the lifecycle delete.
+- **Dedup scan:** `totalBytesProcessed` / `totalSlotMs` from the MERGE job.
+- **Load:** job count + per-job duration from `load_parquet_to_bq.py` `stats.json`.
+- **Empirically measure the drivers** from one real gVCF header: **B** and **k** (they
+  dominate every formula), and **d_B** via
+  `SELECT COUNT(DISTINCT vcf_header_lines_hash) ... WHERE is_expected_unique = false`.
+
+---
+
+## 7. AC2 — consistency queries
 
 Consistency queries to be supplied by Aaron Hatcher. They will presumably assert
 equivalence between a BQ-loaded and a Parquet-loaded dataset. Expected checks:
@@ -224,7 +338,7 @@ equivalence between a BQ-loaded and a Parquet-loaded dataset. Expected checks:
 
 ---
 
-## 7. Open questions / risks
+## 8. Open questions / risks
 
 - **Small-object cost (Option 2/3):** how many distinct `is_expected_unique = true` chunks
   arise at AoU scale? Determines whether content-addressing the unique lines is viable.
@@ -237,7 +351,7 @@ equivalence between a BQ-loaded and a Parquet-loaded dataset. Expected checks:
 
 ---
 
-## 8. File / line reference index
+## 9. File / line reference index
 
 | Area | Location |
 |---|---|

--- a/scripts/variantstore/scripts/build_docker.sh
+++ b/scripts/variantstore/scripts/build_docker.sh
@@ -49,24 +49,10 @@ BASE_REPO="broad-dsde-methods/gvs"
 REPO_WITH_TAG="${BASE_REPO}/variants:${TAG}"
 docker tag "${IMAGE_ID}" "${REPO_WITH_TAG}"
 
-# Run unit tests before pushing.
-set +o errexit
-fail=0
-for test in test/test_*.py
-do
-    docker run --platform linux/amd64 --rm -v "$PWD":/in -t "${REPO_WITH_TAG}" bash -c "cd /in; python3 -m unittest $test"
-    if [ $? -ne 0 ]; then
-        fail=1
-        echo "$test has failed"
-    fi
-done
-
-if [ $fail -ne 0 ]; then
-    echo "One or more unit tests have failed, exiting."
-    exit $fail
-fi
-
-set -o errexit
+# Run the Python unit tests (including the BigQuery-emulator-backed header-load integration test)
+# inside the freshly built image before pushing. The runner also manages the emulator lifecycle and
+# is shared with CI (see run_python_unit_tests.sh); errexit aborts the build here if any test fails.
+./run_python_unit_tests.sh "${REPO_WITH_TAG}"
 
 GAR_TAG="us-central1-docker.pkg.dev/${REPO_WITH_TAG}"
 docker tag "${REPO_WITH_TAG}" "${GAR_TAG}"

--- a/scripts/variantstore/scripts/process_sample_vcf_headers.py
+++ b/scripts/variantstore/scripts/process_sample_vcf_headers.py
@@ -12,9 +12,7 @@ def vcf_header_lines_insert_sql(project_id, dataset_name):
     Deduplicating and idempotent: the Parquet ingest path writes the full header text for every chunk
     of every sample (no write-time dedup), and re-running (task retry, workflow resume, or re-ingest)
     inserts nothing already present -- the LEFT JOIN ... IS NULL skips hashes already in the target.
-    We use an anti-join INSERT rather than MERGE to match GVS convention (GVS uses MERGE nowhere) and
-    to avoid mutating-DML/streaming-buffer concerns entirely. See the VS-1968 design doc. This also
-    fixes a latent double-insert bug on the legacy BQ path.
+    See the VS-1968 design doc. This also fixes a latent double-insert bug on the legacy BQ path.
 
     The source subquery collapses to one row per hash; all texts for a given hash are identical by
     construction (the hash is an MD5 of the text), so ANY_VALUE is safe.

--- a/scripts/variantstore/scripts/process_sample_vcf_headers.py
+++ b/scripts/variantstore/scripts/process_sample_vcf_headers.py
@@ -1,34 +1,84 @@
 import argparse
 
-from google.cloud import bigquery
-from google.cloud.bigquery.job import QueryJobConfig
-import utils
-
 # add labels for DSP Cloud Cost Control Labeling and Reporting
 query_labels_map = {'service': 'gvs', 'team': 'variants', 'managedby': 'gvs_process_sample_vcf_headers'}
-default_config = QueryJobConfig(labels=query_labels_map, priority="INTERACTIVE", use_query_cache=True, use_legacy_sql=False)
-client = ''
-
-def process_sample_vcf_headers(project_id, dataset_name):
-    populate_tables_from_scratch(project_id, dataset_name)
-    clean_up_scratch_table(project_id, dataset_name)
-
-def populate_tables_from_scratch(project_id, dataset_name):
-    global client
-    client = bigquery.Client(project=project_id,
-                             default_query_job_config=default_config)
-
-    sql = f"INSERT INTO {project_id}.{dataset_name}.vcf_header_lines (vcf_header_lines_hash, vcf_header_lines, is_expected_unique) SELECT vcf_header_lines_hash, vcf_header_lines, is_expected_unique FROM {project_id}.{dataset_name}.vcf_header_lines_scratch WHERE vcf_header_lines IS NOT NULL"
-    utils.execute_with_retry(client, "vcf_header_lines", sql)
-
-    sql = f"INSERT INTO {project_id}.{dataset_name}.sample_vcf_header (sample_id, vcf_header_lines_hash) SELECT sample_id, vcf_header_lines_hash FROM {project_id}.{dataset_name}.vcf_header_lines_scratch"
-    utils.execute_with_retry(client, "sample_vcf_header", sql)
 
 
-def clean_up_scratch_table(project_id, dataset_name):
-    global client
-    sql = f"DELETE FROM {project_id}.{dataset_name}.vcf_header_lines_scratch WHERE vcf_header_lines_hash IS NOT NULL"
-    utils.execute_with_retry(client, "vcf_header_lines_scratch", sql)
+# --- SQL builders (pure functions, no BigQuery client needed -- unit-testable) ---------------------
+
+def vcf_header_lines_insert_sql(project_id, dataset_name):
+    """Anti-join INSERT that populates vcf_header_lines from the scratch table.
+
+    Deduplicating and idempotent: the Parquet ingest path writes the full header text for every chunk
+    of every sample (no write-time dedup), and re-running (task retry, workflow resume, or re-ingest)
+    inserts nothing already present -- the LEFT JOIN ... IS NULL skips hashes already in the target.
+    We use an anti-join INSERT rather than MERGE to match GVS convention (GVS uses MERGE nowhere) and
+    to avoid mutating-DML/streaming-buffer concerns entirely. See the VS-1968 design doc. This also
+    fixes a latent double-insert bug on the legacy BQ path.
+
+    The source subquery collapses to one row per hash; all texts for a given hash are identical by
+    construction (the hash is an MD5 of the text), so ANY_VALUE is safe.
+    """
+    return f"""
+        INSERT INTO `{project_id}.{dataset_name}.vcf_header_lines` (vcf_header_lines_hash, vcf_header_lines, is_expected_unique)
+        SELECT
+            s.vcf_header_lines_hash,
+            ANY_VALUE(s.vcf_header_lines),
+            ANY_VALUE(s.is_expected_unique)
+        FROM `{project_id}.{dataset_name}.vcf_header_lines_scratch` s
+        LEFT JOIN `{project_id}.{dataset_name}.vcf_header_lines` t USING (vcf_header_lines_hash)
+        WHERE s.vcf_header_lines IS NOT NULL AND t.vcf_header_lines_hash IS NULL
+        GROUP BY s.vcf_header_lines_hash
+    """
+
+
+def sample_vcf_header_insert_sql(project_id, dataset_name):
+    """Anti-join INSERT for the sample->hash association map.
+
+    Idempotent: only inserts (sample_id, hash) pairs not already present.
+    """
+    return f"""
+        INSERT INTO `{project_id}.{dataset_name}.sample_vcf_header` (sample_id, vcf_header_lines_hash)
+        SELECT DISTINCT s.sample_id, s.vcf_header_lines_hash
+        FROM `{project_id}.{dataset_name}.vcf_header_lines_scratch` s
+        LEFT JOIN `{project_id}.{dataset_name}.sample_vcf_header` t
+            USING (sample_id, vcf_header_lines_hash)
+        WHERE t.sample_id IS NULL
+    """
+
+
+def clean_up_scratch_sql(project_id, dataset_name):
+    """DELETE the migrated rows from the scratch table (naturally idempotent -- re-delete is a no-op)."""
+    return f"DELETE FROM `{project_id}.{dataset_name}.vcf_header_lines_scratch` WHERE vcf_header_lines_hash IS NOT NULL"
+
+
+# --- Execution (imports the BigQuery client lazily so the SQL builders stay dependency-free) --------
+
+def _make_client(project_id):
+    from google.cloud import bigquery
+    from google.cloud.bigquery.job import QueryJobConfig
+    default_config = QueryJobConfig(labels=query_labels_map, priority="INTERACTIVE",
+                                    use_query_cache=True, use_legacy_sql=False)
+    return bigquery.Client(project=project_id, default_query_job_config=default_config)
+
+
+def process_sample_vcf_headers(project_id, dataset_name, client=None):
+    import utils
+    if client is None:
+        client = _make_client(project_id)
+    populate_tables_from_scratch(project_id, dataset_name, client)
+    clean_up_scratch_table(project_id, dataset_name, client)
+
+
+def populate_tables_from_scratch(project_id, dataset_name, client):
+    import utils
+    utils.execute_with_retry(client, "vcf_header_lines", vcf_header_lines_insert_sql(project_id, dataset_name))
+    utils.execute_with_retry(client, "sample_vcf_header", sample_vcf_header_insert_sql(project_id, dataset_name))
+
+
+def clean_up_scratch_table(project_id, dataset_name, client):
+    import utils
+    utils.execute_with_retry(client, "vcf_header_lines_scratch", clean_up_scratch_sql(project_id, dataset_name))
 
 
 if __name__ == '__main__':

--- a/scripts/variantstore/scripts/run_python_unit_tests.sh
+++ b/scripts/variantstore/scripts/run_python_unit_tests.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# Runs the GVS Python unit tests (test/test_*.py) together with a throwaway BigQuery emulator so the
+# header-load integration test (test_process_sample_vcf_headers.py::TestHeaderLoadIntegration) runs
+# hermetically -- no GCP project or secrets required.
+#
+# Two execution modes so the emulator wiring and test loop live in one place, shared by both callers:
+#
+#   ./run_python_unit_tests.sh <runtime_docker_image>
+#       DOCKER MODE. Runs each test file inside the given image (which supplies python3 + the
+#       dependencies); the working-copy source is bind-mounted at /in. Used by build_docker.sh with
+#       the freshly built Variants image. Test containers join the emulator's Docker network and
+#       reach it by container name.
+#
+#   ./run_python_unit_tests.sh
+#       NATIVE MODE. Runs each test file with the host's python3 -- dependencies must already be
+#       installed (e.g. by a CI "install dependencies" step). The emulator's port is published to
+#       localhost. Used by the GitHub Actions workflow (VS-1983).
+#
+# Optional environment overrides:
+#   EMULATOR_IMAGE   BigQuery emulator image (default ghcr.io/goccy/bigquery-emulator:latest).
+#   EMULATOR_PORT    Host port for the emulator in native mode (default 9050).
+#   PYTHON_BIN       Python interpreter for native mode (default python3).
+#
+# Exit status is non-zero if any test file fails or the emulator does not start.
+
+set -o errexit -o nounset -o pipefail
+
+RUNTIME_IMAGE="${1:-}"
+if [[ -n "${RUNTIME_IMAGE}" ]]; then
+    MODE="docker"
+else
+    MODE="native"
+fi
+
+# Resolve to this script's directory (the scripts dir) so the test glob, bind mount, and relative
+# data-file paths are stable regardless of the caller's working directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+# TODO(VS-1983): pin to a specific emulator release once this stabilizes.
+EMULATOR_IMAGE="${EMULATOR_IMAGE:-ghcr.io/goccy/bigquery-emulator:latest}"
+EMULATOR_PORT="${EMULATOR_PORT:-9050}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+# $$-suffixed so concurrent runs (e.g. a local build while CI runs) do not collide.
+EMULATOR_NAME="gvs-bq-emulator-$$"
+EMULATOR_NETWORK="gvs-python-test-net-$$"
+EMULATOR_PROJECT="gvs-header-emulator"
+EMULATOR_DATASET="header_it"
+
+cleanup_emulator() {
+    docker rm -f "${EMULATOR_NAME}" > /dev/null 2>&1 || true
+    if [[ "${MODE}" == "docker" ]]; then
+        docker network rm "${EMULATOR_NETWORK}" > /dev/null 2>&1 || true
+    fi
+}
+trap cleanup_emulator EXIT
+
+# A plain `docker run` (not an Actions `services:` block) is used because we need to pass
+# --project/--dataset args, which service containers can't override. Docker mode puts the emulator on
+# a private network (test containers join it and reach it by name); native mode publishes the port so
+# the host python client can reach it at localhost.
+if [[ "${MODE}" == "docker" ]]; then
+    docker network create "${EMULATOR_NETWORK}" > /dev/null
+    docker run -d --platform linux/amd64 --name "${EMULATOR_NAME}" --network "${EMULATOR_NETWORK}" \
+        "${EMULATOR_IMAGE}" --project="${EMULATOR_PROJECT}" --dataset="${EMULATOR_DATASET}" > /dev/null
+    EMULATOR_ENDPOINT="http://${EMULATOR_NAME}:9050"
+else
+    docker run -d --platform linux/amd64 --name "${EMULATOR_NAME}" -p "${EMULATOR_PORT}:9050" \
+        "${EMULATOR_IMAGE}" --project="${EMULATOR_PROJECT}" --dataset="${EMULATOR_DATASET}" > /dev/null
+    EMULATOR_ENDPOINT="http://localhost:${EMULATOR_PORT}"
+fi
+
+echo "Waiting for the BigQuery emulator to start..."
+emulator_ready=0
+for _ in $(seq 1 60)
+do
+    if docker logs "${EMULATOR_NAME}" 2>&1 | grep -q "REST server listening"; then
+        emulator_ready=1
+        break
+    fi
+    sleep 1
+done
+if [[ "${emulator_ready}" -ne 1 ]]; then
+    echo "BigQuery emulator failed to start:" >&2
+    docker logs "${EMULATOR_NAME}" >&2 || true
+    exit 1
+fi
+echo "BigQuery emulator is up (mode=${MODE}, endpoint=${EMULATOR_ENDPOINT})."
+
+# Run each test file. The GVS_HEADER_IT_* env vars are consumed only by the header-load integration
+# test; other test files ignore them.
+fail=0
+for test in test/test_*.py
+do
+    set +o errexit
+    if [[ "${MODE}" == "docker" ]]; then
+        docker run --platform linux/amd64 --rm -v "${SCRIPT_DIR}":/in \
+            --network "${EMULATOR_NETWORK}" \
+            -e GVS_HEADER_IT_PROJECT="${EMULATOR_PROJECT}" \
+            -e GVS_HEADER_IT_DATASET="${EMULATOR_DATASET}" \
+            -e GVS_HEADER_IT_ENDPOINT="${EMULATOR_ENDPOINT}" \
+            -t "${RUNTIME_IMAGE}" bash -c "cd /in; python3 -m unittest ${test}"
+        rc=$?
+    else
+        # Invoke by bare module name with the test dir on PYTHONPATH so the stdlib `test` package
+        # does not shadow our local test/ directory.
+        module="$(basename "${test}" .py)"
+        GVS_HEADER_IT_PROJECT="${EMULATOR_PROJECT}" \
+        GVS_HEADER_IT_DATASET="${EMULATOR_DATASET}" \
+        GVS_HEADER_IT_ENDPOINT="${EMULATOR_ENDPOINT}" \
+        PYTHONPATH="${SCRIPT_DIR}:${SCRIPT_DIR}/test" "${PYTHON_BIN}" -m unittest "${module}"
+        rc=$?
+    fi
+    set -o errexit
+    if [[ ${rc} -ne 0 ]]; then
+        fail=1
+        echo "${test} has failed"
+    fi
+done
+
+if [[ ${fail} -ne 0 ]]; then
+    echo "One or more Python unit tests have failed."
+    exit 1
+fi
+echo "All Python unit tests passed."

--- a/scripts/variantstore/scripts/test/header_loading_e2e_local/README.md
+++ b/scripts/variantstore/scripts/test/header_loading_e2e_local/README.md
@@ -58,10 +58,19 @@ Pass an iteration count as the first argument (e.g. `./run_header_loading_e2e.sh
 
 ## Expected output
 
-- Each `verify` prints **`3 / 3 / 0`** (`header_lines` / `sample_assocs` /
-  `scratch_remaining`) for the parquet dataset.
+- Each `verify` reports **`3 / 3 / 0`** (`header_lines` / `sample_assocs` /
+  `scratch_remaining`) and now **hard-fails** if the counts are off. These are
+  chunk/row counts, not VCF-header-line counts — each `vcf_header_lines` row is a
+  comma-joined blob of many header lines. Override the expected count with
+  `EXPECT_HEADER_CHUNKS` for a different input VCF. On the **BQ path** only,
+  `scratch_remaining > 0` is tolerated (streaming-buffer wrinkle, below); the
+  **parquet path** must drain to `0`.
 - Each `ab_compare` prints **`0 / 0`** for both `vcf_header_lines` and
   `sample_vcf_header`.
+- The final step reconstructs the sample's full header from
+  `sample_vcf_header` ⋈ `vcf_header_lines` and asserts it is **non-empty** (proves
+  the split is losslessly reversible; exact equality to the BQ path is already
+  covered by `ab_compare`).
 - The counts are identical across every iteration.
 
 ### Known benign wrinkle: BQ scratch_remaining

--- a/scripts/variantstore/scripts/test/header_loading_e2e_local/README.md
+++ b/scripts/variantstore/scripts/test/header_loading_e2e_local/README.md
@@ -1,0 +1,79 @@
+# Local End-to-End Header-Loading Test (VS-1803)
+
+`run_header_loading_e2e.sh` is a **manual developer harness** that validates VCF
+header loading across both GVS ingest paths - **Parquet** and **BQ**. It is **not run in CI** — it creates
+real BigQuery datasets and requires authenticated `bq`/`gcloud` access, so it must
+be run by hand against a throwaway project.
+
+## What it validates
+
+For each iteration it runs the full flow on both paths and compares them:
+
+| Path | Flow |
+|---|---|
+| **Parquet** | `CreateVariantIngestFiles --output-type PARQUET` → `bq load` the local parquet into `vcf_header_lines_scratch` → promote (`process_sample_vcf_headers.py`) → verify |
+| **BQ (Write API)** | `CreateVariantIngestFiles --output-type BQ` (writes scratch directly) → promote → verify |
+
+It then:
+
+- **A/B compares** the two datasets' final tables (`vcf_header_lines` and
+  `sample_vcf_header`) — they must be byte-for-byte identical.
+- **Repeats** the whole flow (2× by default) to prove **idempotency**: the final
+  table counts must not change on re-runs. The parquet path stays put because the
+  promotion is an anti-join INSERT; the BQ path stays put because
+  `CreateVariantIngestFiles` short-circuits via `HEADERS_LOADED` in
+  `sample_load_status`.
+
+## Prerequisites
+
+- Authenticated `gcloud` / `bq` (`gcloud auth login`, `gcloud auth application-default login`).
+- A **throwaway** GCP project you can create and drop datasets in.
+- A built `gatk` (`./gradlew clean shadowJar`) — or point `GATK` at one.
+- `python3` on `PATH` for the promotion script.
+
+## Running
+
+Three env vars are required; the rest have defaults.
+
+```bash
+PROJECT=my-throwaway-project \
+INPUT_VCF=gs://.../sample.reblocked.g.vcf.gz \
+INTERVALS=gs://.../wgs_calling_regions.hg38.interval_list \
+  ./run_header_loading_e2e.sh          # 2 iterations, datasets KEPT for inspection
+```
+
+Optional overrides (defaults in parentheses):
+
+| Var | Default | Purpose |
+|---|---|---|
+| `DATASET_PREFIX` | `header_loading_e2e` | parquet ds = `<prefix>`, BQ ds = `<prefix>_bq` |
+| `SAMPLE_ID` | `1` | gVCS sample id used for ingest |
+| `REF_VERSION` | `38` | reference version passed to the tool |
+| `WORK_DIR` | `./header_loading_e2e_work` | where local parquet is generated |
+| `GATK` | `<repo>/gatk` | path to the gatk launcher |
+| `PROMOTE` | `<repo>/scripts/variantstore/scripts/process_sample_vcf_headers.py` | promotion script |
+| `TEARDOWN` | `0` | set `1` to drop both datasets + work dir at the end |
+
+Pass an iteration count as the first argument (e.g. `./run_header_loading_e2e.sh 3`).
+
+## Expected output
+
+- Each `verify` prints **`3 / 3 / 0`** (`header_lines` / `sample_assocs` /
+  `scratch_remaining`) for the parquet dataset.
+- Each `ab_compare` prints **`0 / 0`** for both `vcf_header_lines` and
+  `sample_vcf_header`.
+- The counts are identical across every iteration.
+
+### Known benign wrinkle: BQ scratch_remaining
+
+On the **BQ path**, the scratch cleanup `DELETE` can fail against rows still in
+BigQuery's streaming buffer ("would affect rows in the streaming buffer"). The
+script tolerates this (prints a `WARN` and continues) because the final tables are
+already committed — only `scratch_remaining` may read `> 0` until the buffer
+flushes (a few minutes, worst case ~90). The parquet path uses batch `bq load`, so
+it is unaffected and drains to `0` immediately.
+
+## Cleanup
+
+If run with `TEARDOWN=0` (the default), the script prints the exact `bq rm` /
+`rm -rf` commands to remove the two datasets and the work dir when you're done.

--- a/scripts/variantstore/scripts/test/header_loading_e2e_local/run_header_loading_e2e.sh
+++ b/scripts/variantstore/scripts/test/header_loading_e2e_local/run_header_loading_e2e.sh
@@ -50,6 +50,10 @@ INTERVALS=${INTERVALS:?Set INTERVALS to an interval_list path or gs:// URI}
 DATASET_PREFIX=${DATASET_PREFIX:-header_loading_e2e}
 SAMPLE_ID=${SAMPLE_ID:-1}
 REF_VERSION=${REF_VERSION:-38}
+# Number of vcf_header_lines chunks/rows expected for the sample (3 for HG00405).
+# Each chunk is a comma-joined blob of many header lines, NOT one VCF line -- so this
+# is a row/chunk count, not a header-line count. Override for a different input VCF.
+EXPECT_HEADER_CHUNKS=${EXPECT_HEADER_CHUNKS:-3}
 WORK_DIR=${WORK_DIR:-$PWD/header_loading_e2e_work}
 TEARDOWN=${TEARDOWN:-0}
 
@@ -85,6 +89,7 @@ create_header_tables() {  # $1 = dataset, $2 = "with_load_status" (optional)
 # Run CreateVariantIngestFiles for one output type. $1 = PARQUET|BQ, $2 = dataset, $3 = out dir
 ingest() {
   rm -rf "$3"
+  mkdir -p "$3"
   "$GATK" CreateVariantIngestFiles \
     -V "$INPUT_VCF" \
     -L "$INTERVALS" \
@@ -123,12 +128,24 @@ promote() {  # $1 = dataset
   fi
 }
 
-verify() {  # $1 = dataset  (expect 3 / 3 / 0)
-  bq query --use_legacy_sql=false "
+# Assert the final counts. $1 = dataset, $2 = "strict" (parquet: scratch must be 0)
+# or "" (BQ: tolerate scratch_remaining > 0 while the streaming buffer flushes).
+# Counts are header_lines / sample_assocs / scratch_remaining; expect N / N / 0
+# where N = EXPECT_HEADER_CHUNKS. header_lines/sample_assocs are chunk/row counts,
+# not VCF-header-line counts (each chunk packs many header lines).
+verify() {
+  local ds=$1 strict=${2:-} hl sa sr
+  read -r hl sa sr < <(bq query --use_legacy_sql=false --format=csv "
     SELECT
-      (SELECT COUNT(*) FROM \`$PROJECT.$1.vcf_header_lines\`)         AS header_lines,
-      (SELECT COUNT(*) FROM \`$PROJECT.$1.sample_vcf_header\`)        AS sample_assocs,
-      (SELECT COUNT(*) FROM \`$PROJECT.$1.vcf_header_lines_scratch\`) AS scratch_remaining"
+      (SELECT COUNT(*) FROM \`$PROJECT.$ds.vcf_header_lines\`),
+      (SELECT COUNT(*) FROM \`$PROJECT.$ds.sample_vcf_header\`),
+      (SELECT COUNT(*) FROM \`$PROJECT.$ds.vcf_header_lines_scratch\`)" | tail -n +2 | tr ',' ' ')
+  echo "  header_lines=$hl  sample_assocs=$sa  scratch_remaining=$sr  (expect $EXPECT_HEADER_CHUNKS / $EXPECT_HEADER_CHUNKS / 0)"
+  [[ "$hl" == "$EXPECT_HEADER_CHUNKS" ]] || { echo "  FAIL: expected $EXPECT_HEADER_CHUNKS vcf_header_lines rows, got '$hl'"; return 1; }
+  [[ "$sa" == "$EXPECT_HEADER_CHUNKS" ]] || { echo "  FAIL: expected $EXPECT_HEADER_CHUNKS sample_vcf_header assocs, got '$sa'"; return 1; }
+  if [[ "$strict" == "strict" ]]; then
+    [[ "$sr" == "0" ]] || { echo "  FAIL: expected scratch drained to 0, got '$sr'"; return 1; }
+  fi
 }
 
 ab_compare() {  # every count must be 0
@@ -150,14 +167,21 @@ ab_compare() {  # every count must be 0
       (SELECT COUNT(*) FROM (SELECT * FROM b EXCEPT DISTINCT SELECT * FROM p)) AS in_bq_not_parquet"
 }
 
-# Reconstruct the sample's full header text from the tables (the design-doc sanity check).
+# Reconstruct the sample's full header text from the tables (the design-doc sanity
+# check that the split is losslessly reversible) and assert it is non-empty. Note the
+# reconstructed text is hundreds of VCF lines packed into $EXPECT_HEADER_CHUNKS
+# comma-joined chunks -- exact equality to the BQ path is covered by ab_compare (0/0),
+# so here we only prove the sample_vcf_header -> vcf_header_lines join reassembles content.
 show_reconstructed_header() {  # $1 = dataset
   echo "-- reconstructed header for sample $SAMPLE_ID from $1 --"
-  bq query --use_legacy_sql=false --format=csv "
+  local full
+  full=$(bq query --use_legacy_sql=false --format=csv "
     SELECT STRING_AGG(h.vcf_header_lines, '\n') AS full_header
     FROM \`$PROJECT.$1.sample_vcf_header\` s
     JOIN \`$PROJECT.$1.vcf_header_lines\`  h USING (vcf_header_lines_hash)
-    WHERE s.sample_id = $SAMPLE_ID" | tail -n +2
+    WHERE s.sample_id = $SAMPLE_ID" | tail -n +2)
+  [[ -n "$full" && "$full" != '""' ]] || { echo "  FAIL: reconstructed header is empty for sample $SAMPLE_ID"; return 1; }
+  echo "$full"
 }
 
 ### ---- Setup (once) ------------------------------------------------------------
@@ -174,7 +198,7 @@ for i in $(seq 1 "$ITERATIONS"); do
   ( cd "$PQ_DIR" && load_parquet_to_scratch )
   promote "$PQ_DS"
   echo "== parquet counts (expect 3 / 3 / 0) =="
-  verify "$PQ_DS"
+  verify "$PQ_DS" strict
 
   echo "--- BQ path ($BQ_DS) ---"
   ingest BQ "$BQ_DS" "$BQ_DIR"

--- a/scripts/variantstore/scripts/test/header_loading_e2e_local/run_header_loading_e2e.sh
+++ b/scripts/variantstore/scripts/test/header_loading_e2e_local/run_header_loading_e2e.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+#
+# VS-1803 — local, manual end-to-end test for VCF header loading.
+#
+# Exercises BOTH ingest paths and proves they agree, then re-runs to prove idempotency:
+#   PARQUET path:  CreateVariantIngestFiles --output-type PARQUET -> bq load into scratch
+#                  -> promote (anti-join INSERT + scratch cleanup) -> verify
+#   BQ path:       CreateVariantIngestFiles --output-type BQ (writes scratch directly)
+#                  -> promote -> verify
+#   A/B:           diff the two datasets' final tables (must be identical)
+#
+# This is a MANUAL developer harness. It is NOT run in CI. It creates real BigQuery
+# datasets in a project you supply and (optionally) tears them down at the end.
+# See README.md in this directory for prerequisites and expected output.
+#
+# Required env vars (no safe defaults):
+#   PROJECT      GCP project that owns the throwaway datasets, e.g. gvs-internal
+#   INPUT_VCF    a (reblocked) gVCF, local path or gs:// URI
+#   INTERVALS    an interval_list, local path or gs:// URI
+#
+# Optional env vars (defaults shown):
+#   DATASET_PREFIX  header_loading_e2e   # parquet ds = <prefix>, BQ ds = <prefix>_bq
+#   SAMPLE_ID       1
+#   REF_VERSION     38
+#   WORK_DIR        ./header_loading_e2e_work   # where local parquet is generated
+#   GATK            <repo>/gatk
+#   PROMOTE         <repo>/scripts/variantstore/scripts/process_sample_vcf_headers.py
+#   TEARDOWN        0                    # 1 = drop both datasets + work dir at the end
+#
+# Usage:
+#   PROJECT=my-proj INPUT_VCF=gs://.../sample.g.vcf.gz INTERVALS=gs://.../calling.interval_list \
+#     ./run_header_loading_e2e.sh            # 2 iterations, datasets KEPT
+#   ... ./run_header_loading_e2e.sh 3        # 3 iterations
+#   TEARDOWN=1 ... ./run_header_loading_e2e.sh
+#
+set -euo pipefail
+
+### ---- Locate the repo (this script lives in scripts/variantstore/scripts/test/E2E_local) ----
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
+
+### ---- Config ------------------------------------------------------------------
+GATK=${GATK:-$REPO_ROOT/gatk}
+PROMOTE=${PROMOTE:-$REPO_ROOT/scripts/variantstore/scripts/process_sample_vcf_headers.py}
+
+PROJECT=${PROJECT:?Set PROJECT to a GCP project that can own throwaway datasets}
+INPUT_VCF=${INPUT_VCF:?Set INPUT_VCF to a (reblocked) gVCF path or gs:// URI}
+INTERVALS=${INTERVALS:?Set INTERVALS to an interval_list path or gs:// URI}
+
+DATASET_PREFIX=${DATASET_PREFIX:-header_loading_e2e}
+SAMPLE_ID=${SAMPLE_ID:-1}
+REF_VERSION=${REF_VERSION:-38}
+WORK_DIR=${WORK_DIR:-$PWD/header_loading_e2e_work}
+TEARDOWN=${TEARDOWN:-0}
+
+PQ_DS=$DATASET_PREFIX          # parquet path dataset
+BQ_DS=${DATASET_PREFIX}_bq     # BQ (Write API) path dataset
+PQ_DIR=$WORK_DIR/parquet
+BQ_DIR=$WORK_DIR/bq
+
+ITERATIONS=${1:-2}             # run count (>=2 to see idempotency)
+
+### ---- Helpers -----------------------------------------------------------------
+banner() { echo; echo "==================== $* ===================="; }
+
+ensure_dataset() {   # $1 = dataset name
+  bq show "$PROJECT:$1" >/dev/null 2>&1 || bq --location=US mk --dataset "$PROJECT:$1"
+}
+
+ensure_table() {     # $1 = dataset, $2 = table, $3 = schema
+  bq show "$PROJECT:$1.$2" >/dev/null 2>&1 || bq mk --table "$PROJECT:$1.$2" "$3"
+}
+
+create_header_tables() {  # $1 = dataset, $2 = "with_load_status" (optional)
+  ensure_table "$1" vcf_header_lines_scratch 'sample_id:INTEGER,vcf_header_lines:STRING,vcf_header_lines_hash:STRING,is_expected_unique:BOOLEAN'
+  ensure_table "$1" vcf_header_lines         'vcf_header_lines_hash:STRING,vcf_header_lines:STRING,is_expected_unique:BOOLEAN'
+  ensure_table "$1" sample_vcf_header        'sample_id:INTEGER,vcf_header_lines_hash:STRING'
+  # The BQ path (unlike parquet) reads/writes per-sample load status for idempotency
+  # (CreateVariantIngestFiles.onTraversalStart -> LoadStatus.getSampleLoadState).
+  if [[ "${2:-}" == "with_load_status" ]]; then
+    ensure_table "$1" sample_load_status 'sample_id:INTEGER,status:STRING,event_timestamp:TIMESTAMP'
+  fi
+}
+
+# Run CreateVariantIngestFiles for one output type. $1 = PARQUET|BQ, $2 = dataset, $3 = out dir
+ingest() {
+  rm -rf "$3"
+  "$GATK" CreateVariantIngestFiles \
+    -V "$INPUT_VCF" \
+    -L "$INTERVALS" \
+    --gvs-sample-id "$SAMPLE_ID" \
+    --output-directory "$3" \
+    -IG FORTY \
+    --force-loading-from-non-allele-specific false \
+    --ignore-above-gq-threshold false \
+    --project-id "$PROJECT" \
+    --dataset-name "$2" \
+    --enable-reference-ranges false \
+    --enable-vet false \
+    --output-type "$1" \
+    --ref-version "$REF_VERSION" \
+    --skip-loading-vqsr-fields false \
+    --enable-vcf-headers true
+}
+
+# Load the generated parquet into the scratch table (what LoadParquetFilesToBQ does in the WDL).
+load_parquet_to_scratch() {
+  bq load --source_format=PARQUET \
+    "$PROJECT:$PQ_DS.vcf_header_lines_scratch" \
+    "$PQ_DIR/vcf_header_lines_scratch_${SAMPLE_ID}.parquet"
+}
+
+# scratch -> final promotion (anti-join INSERT + scratch cleanup). Tolerates the BQ
+# streaming-buffer DELETE failure: the finals are committed regardless; scratch drains
+# once the Write API buffer flushes (can take a few minutes, worst case ~90).
+promote() {  # $1 = dataset
+  if python3 "$PROMOTE" --project_id="$PROJECT" --dataset_name="$1"; then
+    echo "  promote OK for $1"
+  else
+    echo "  WARN: promote returned non-zero for $1 — most likely the streaming-buffer"
+    echo "        DELETE on scratch cleanup (BQ path). Final tables are still correct;"
+    echo "        scratch_remaining may stay >0 until the buffer flushes. Benign."
+  fi
+}
+
+verify() {  # $1 = dataset  (expect 3 / 3 / 0)
+  bq query --use_legacy_sql=false "
+    SELECT
+      (SELECT COUNT(*) FROM \`$PROJECT.$1.vcf_header_lines\`)         AS header_lines,
+      (SELECT COUNT(*) FROM \`$PROJECT.$1.sample_vcf_header\`)        AS sample_assocs,
+      (SELECT COUNT(*) FROM \`$PROJECT.$1.vcf_header_lines_scratch\`) AS scratch_remaining"
+}
+
+ab_compare() {  # every count must be 0
+  echo "-- A/B diff: vcf_header_lines (hash,text,is_expected_unique) — expect 0/0 --"
+  bq query --use_legacy_sql=false "
+    WITH
+    p AS (SELECT vcf_header_lines_hash, vcf_header_lines, is_expected_unique FROM \`$PROJECT.$PQ_DS.vcf_header_lines\`),
+    b AS (SELECT vcf_header_lines_hash, vcf_header_lines, is_expected_unique FROM \`$PROJECT.$BQ_DS.vcf_header_lines\`)
+    SELECT
+      (SELECT COUNT(*) FROM (SELECT * FROM p EXCEPT DISTINCT SELECT * FROM b)) AS in_parquet_not_bq,
+      (SELECT COUNT(*) FROM (SELECT * FROM b EXCEPT DISTINCT SELECT * FROM p)) AS in_bq_not_parquet"
+  echo "-- A/B diff: sample_vcf_header (sample_id,hash) — expect 0/0 --"
+  bq query --use_legacy_sql=false "
+    WITH
+    p AS (SELECT sample_id, vcf_header_lines_hash FROM \`$PROJECT.$PQ_DS.sample_vcf_header\`),
+    b AS (SELECT sample_id, vcf_header_lines_hash FROM \`$PROJECT.$BQ_DS.sample_vcf_header\`)
+    SELECT
+      (SELECT COUNT(*) FROM (SELECT * FROM p EXCEPT DISTINCT SELECT * FROM b)) AS in_parquet_not_bq,
+      (SELECT COUNT(*) FROM (SELECT * FROM b EXCEPT DISTINCT SELECT * FROM p)) AS in_bq_not_parquet"
+}
+
+# Reconstruct the sample's full header text from the tables (the design-doc sanity check).
+show_reconstructed_header() {  # $1 = dataset
+  echo "-- reconstructed header for sample $SAMPLE_ID from $1 --"
+  bq query --use_legacy_sql=false --format=csv "
+    SELECT STRING_AGG(h.vcf_header_lines, '\n') AS full_header
+    FROM \`$PROJECT.$1.sample_vcf_header\` s
+    JOIN \`$PROJECT.$1.vcf_header_lines\`  h USING (vcf_header_lines_hash)
+    WHERE s.sample_id = $SAMPLE_ID" | tail -n +2
+}
+
+### ---- Setup (once) ------------------------------------------------------------
+banner "SETUP: datasets + tables (project=$PROJECT, prefix=$DATASET_PREFIX)"
+ensure_dataset "$PQ_DS";  create_header_tables "$PQ_DS"
+ensure_dataset "$BQ_DS";  create_header_tables "$BQ_DS" with_load_status
+
+### ---- Iterate ----------------------------------------------------------------
+for i in $(seq 1 "$ITERATIONS"); do
+  banner "ITERATION $i / $ITERATIONS"
+
+  echo "--- PARQUET path ($PQ_DS) ---"
+  ingest PARQUET "$PQ_DS" "$PQ_DIR"
+  ( cd "$PQ_DIR" && load_parquet_to_scratch )
+  promote "$PQ_DS"
+  echo "== parquet counts (expect 3 / 3 / 0) =="
+  verify "$PQ_DS"
+
+  echo "--- BQ path ($BQ_DS) ---"
+  ingest BQ "$BQ_DS" "$BQ_DIR"
+  promote "$BQ_DS"
+  echo "== bq counts (expect 3 / 3 / 0; scratch_remaining may be >0 on early passes"
+  echo "   due to the streaming buffer — see promote WARN above) =="
+  verify "$BQ_DS"
+
+  echo "--- A/B comparison (parquet vs BQ) ---"
+  ab_compare
+done
+
+banner "IDEMPOTENCY: header_lines/sample_assocs above should be identical across all $ITERATIONS iterations"
+
+show_reconstructed_header "$PQ_DS"
+
+### ---- Teardown ---------------------------------------------------------------
+if [[ "$TEARDOWN" == "1" ]]; then
+  banner "TEARDOWN"
+  bq rm -r -f --dataset "$PROJECT:$PQ_DS"
+  bq rm -r -f --dataset "$PROJECT:$BQ_DS"
+  rm -rf "$WORK_DIR"
+else
+  banner "DATASETS KEPT (TEARDOWN=0)"
+  echo "To clean up when done:"
+  echo "  bq rm -r -f --dataset $PROJECT:$PQ_DS"
+  echo "  bq rm -r -f --dataset $PROJECT:$BQ_DS"
+  echo "  rm -rf $WORK_DIR"
+fi

--- a/scripts/variantstore/scripts/test/test_process_sample_vcf_headers.py
+++ b/scripts/variantstore/scripts/test/test_process_sample_vcf_headers.py
@@ -1,0 +1,123 @@
+import os
+import hashlib
+import unittest
+
+import process_sample_vcf_headers as psh
+
+PROJECT = "test-project"
+DATASET = "test_dataset"
+
+
+def _norm(sql):
+    """Collapse all runs of whitespace to single spaces so assertions are formatting-independent."""
+    return " ".join(sql.split())
+
+
+class TestHeaderLoadSql(unittest.TestCase):
+    """Unit tests for the anti-join INSERT SQL builders (no BigQuery client required)."""
+
+    def test_vcf_header_lines_is_anti_join_insert(self):
+        sql = _norm(psh.vcf_header_lines_insert_sql(PROJECT, DATASET))
+        # Targets the right table via INSERT (not MERGE).
+        self.assertIn(f"INSERT INTO `{PROJECT}.{DATASET}.vcf_header_lines` "
+                      "(vcf_header_lines_hash, vcf_header_lines, is_expected_unique)", sql)
+        self.assertNotIn("MERGE", sql.upper())
+        # Anti-join against the target on the hash key, keeping only rows not already present.
+        self.assertIn(f"LEFT JOIN `{PROJECT}.{DATASET}.vcf_header_lines` t USING (vcf_header_lines_hash)", sql)
+        self.assertIn("t.vcf_header_lines_hash IS NULL", sql)
+        # Skips association-only (NULL text) scratch rows and dedups the source by hash.
+        self.assertIn("s.vcf_header_lines IS NOT NULL", sql)
+        self.assertIn("GROUP BY s.vcf_header_lines_hash", sql)
+
+    def test_sample_vcf_header_is_anti_join_insert(self):
+        sql = _norm(psh.sample_vcf_header_insert_sql(PROJECT, DATASET))
+        self.assertIn(f"INSERT INTO `{PROJECT}.{DATASET}.sample_vcf_header` "
+                      "(sample_id, vcf_header_lines_hash)", sql)
+        self.assertNotIn("MERGE", sql.upper())
+        self.assertIn("SELECT DISTINCT s.sample_id, s.vcf_header_lines_hash", sql)
+        self.assertIn(f"LEFT JOIN `{PROJECT}.{DATASET}.sample_vcf_header` t "
+                      "USING (sample_id, vcf_header_lines_hash)", sql)
+        self.assertIn("t.sample_id IS NULL", sql)
+
+    def test_clean_up_scratch_is_delete(self):
+        sql = _norm(psh.clean_up_scratch_sql(PROJECT, DATASET))
+        self.assertTrue(sql.startswith("DELETE FROM"), sql)
+        self.assertIn(f"`{PROJECT}.{DATASET}.vcf_header_lines_scratch`", sql)
+
+
+@unittest.skipUnless(
+    os.environ.get("GVS_HEADER_IT_PROJECT") and os.environ.get("GVS_HEADER_IT_DATASET"),
+    "Set GVS_HEADER_IT_PROJECT and GVS_HEADER_IT_DATASET (a throwaway dataset) to run the BigQuery "
+    "integration test.",
+)
+class TestHeaderLoadIntegration(unittest.TestCase):
+    """Real-BigQuery test of dedup + idempotency. Skipped unless the env vars above are set.
+
+    Creates the three header tables in the given (throwaway) dataset, loads scratch with rows that
+    share a hash across samples plus per-sample unique lines, runs the load, then loads and runs it a
+    SECOND time to prove re-ingest inserts nothing new.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        from google.cloud import bigquery
+        cls.bigquery = bigquery
+        cls.project = os.environ["GVS_HEADER_IT_PROJECT"]
+        cls.dataset = os.environ["GVS_HEADER_IT_DATASET"]
+        cls.client = bigquery.Client(project=cls.project)
+        cls.fq = lambda _cls, t: f"{cls.project}.{cls.dataset}.{t}"
+
+    def _run(self, sql):
+        self.client.query(sql).result()
+
+    def _count(self, table):
+        rows = list(self.client.query(f"SELECT COUNT(*) AS c FROM `{self.fq(table)}`").result())
+        return rows[0].c
+
+    def _create_tables(self):
+        self._run(f"CREATE OR REPLACE TABLE `{self.fq('vcf_header_lines_scratch')}` "
+                  "(sample_id INT64, vcf_header_lines STRING, vcf_header_lines_hash STRING, is_expected_unique BOOL)")
+        self._run(f"CREATE OR REPLACE TABLE `{self.fq('vcf_header_lines')}` "
+                  "(vcf_header_lines_hash STRING, vcf_header_lines STRING, is_expected_unique BOOL)")
+        self._run(f"CREATE OR REPLACE TABLE `{self.fq('sample_vcf_header')}` "
+                  "(sample_id INT64, vcf_header_lines_hash STRING)")
+
+    def _load_scratch(self):
+        # Populate via DML INSERT (not streaming) so the later DELETE isn't blocked by a streaming buffer.
+        def md5(s):
+            return hashlib.md5(s.encode("utf-8")).hexdigest()
+        blob, cmd1, cmd2 = "BLOB", "CMD1", "CMD2"
+        rows = [
+            (1, blob, md5(blob), "false"),   # shared blob, sample 1
+            (2, blob, md5(blob), "false"),   # same hash, sample 2 -> dedups to one vcf_header_lines row
+            (1, cmd1, md5(cmd1), "true"),
+            (2, cmd2, md5(cmd2), "true"),
+        ]
+        values = ", ".join(f"({sid}, '{txt}', '{h}', {u})" for (sid, txt, h, u) in rows)
+        self._run(f"INSERT INTO `{self.fq('vcf_header_lines_scratch')}` "
+                  f"(sample_id, vcf_header_lines, vcf_header_lines_hash, is_expected_unique) VALUES {values}")
+
+    def test_dedup_and_idempotency(self):
+        self._create_tables()
+
+        # First ingest.
+        self._load_scratch()
+        psh.process_sample_vcf_headers(self.project, self.dataset, client=self.client)
+        self.assertEqual(self._count("vcf_header_lines"), 3, "one row per distinct hash (BLOB, CMD1, CMD2)")
+        self.assertEqual(self._count("sample_vcf_header"), 4, "distinct (sample_id, hash) pairs")
+        self.assertEqual(self._count("vcf_header_lines_scratch"), 0, "scratch cleaned up after load")
+
+        # Second ingest of the same batch: anti-join INSERTs must add nothing.
+        self._load_scratch()
+        psh.process_sample_vcf_headers(self.project, self.dataset, client=self.client)
+        self.assertEqual(self._count("vcf_header_lines"), 3, "re-ingest must not duplicate header lines")
+        self.assertEqual(self._count("sample_vcf_header"), 4, "re-ingest must not duplicate associations")
+
+    @classmethod
+    def tearDownClass(cls):
+        for t in ("vcf_header_lines_scratch", "vcf_header_lines", "sample_vcf_header"):
+            cls.client.query(f"DROP TABLE IF EXISTS `{cls.project}.{cls.dataset}.{t}`").result()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/variantstore/scripts/test/test_process_sample_vcf_headers.py
+++ b/scripts/variantstore/scripts/test/test_process_sample_vcf_headers.py
@@ -14,30 +14,21 @@ def _norm(sql):
 
 
 class TestHeaderLoadSql(unittest.TestCase):
-    """Unit tests for the anti-join INSERT SQL builders (no BigQuery client required)."""
+    """Intent-level guards on the SQL builders (no BigQuery client required).
 
-    def test_vcf_header_lines_is_anti_join_insert(self):
+    These deliberately assert only the properties that must hold for ANY correct rewrite -- the right
+    target table and INSERT-vs-DELETE. Behavior (dedup + idempotency) is covered by
+    TestHeaderLoadIntegration below; we intentionally do NOT pin the exact join text here, since an
+    equivalent rewrite (e.g. NOT EXISTS) would be just as correct.
+    """
+
+    def test_vcf_header_lines_insert_targets_right_table(self):
         sql = _norm(psh.vcf_header_lines_insert_sql(PROJECT, DATASET))
-        # Targets the right table via INSERT (not MERGE).
-        self.assertIn(f"INSERT INTO `{PROJECT}.{DATASET}.vcf_header_lines` "
-                      "(vcf_header_lines_hash, vcf_header_lines, is_expected_unique)", sql)
-        self.assertNotIn("MERGE", sql.upper())
-        # Anti-join against the target on the hash key, keeping only rows not already present.
-        self.assertIn(f"LEFT JOIN `{PROJECT}.{DATASET}.vcf_header_lines` t USING (vcf_header_lines_hash)", sql)
-        self.assertIn("t.vcf_header_lines_hash IS NULL", sql)
-        # Skips association-only (NULL text) scratch rows and dedups the source by hash.
-        self.assertIn("s.vcf_header_lines IS NOT NULL", sql)
-        self.assertIn("GROUP BY s.vcf_header_lines_hash", sql)
+        self.assertIn(f"INSERT INTO `{PROJECT}.{DATASET}.vcf_header_lines`", sql)
 
-    def test_sample_vcf_header_is_anti_join_insert(self):
+    def test_sample_vcf_header_insert_targets_right_table(self):
         sql = _norm(psh.sample_vcf_header_insert_sql(PROJECT, DATASET))
-        self.assertIn(f"INSERT INTO `{PROJECT}.{DATASET}.sample_vcf_header` "
-                      "(sample_id, vcf_header_lines_hash)", sql)
-        self.assertNotIn("MERGE", sql.upper())
-        self.assertIn("SELECT DISTINCT s.sample_id, s.vcf_header_lines_hash", sql)
-        self.assertIn(f"LEFT JOIN `{PROJECT}.{DATASET}.sample_vcf_header` t "
-                      "USING (sample_id, vcf_header_lines_hash)", sql)
-        self.assertIn("t.sample_id IS NULL", sql)
+        self.assertIn(f"INSERT INTO `{PROJECT}.{DATASET}.sample_vcf_header`", sql)
 
     def test_clean_up_scratch_is_delete(self):
         sql = _norm(psh.clean_up_scratch_sql(PROJECT, DATASET))
@@ -64,7 +55,24 @@ class TestHeaderLoadIntegration(unittest.TestCase):
         cls.bigquery = bigquery
         cls.project = os.environ["GVS_HEADER_IT_PROJECT"]
         cls.dataset = os.environ["GVS_HEADER_IT_DATASET"]
-        cls.client = bigquery.Client(project=cls.project)
+        # If GVS_HEADER_IT_ENDPOINT is set, talk to a local BigQuery emulator
+        # (e.g. ghcr.io/goccy/bigquery-emulator) with anonymous credentials so this
+        # runs hermetically in CI with no GCP project or secrets. Unset -> real BigQuery.
+        endpoint = os.environ.get("GVS_HEADER_IT_ENDPOINT")
+        # utils.execute_with_retry reads client._default_query_job_config.labels, so the client must
+        # be built with a default query job config (production's _make_client does the same).
+        default_config = bigquery.QueryJobConfig(labels={}, use_legacy_sql=False)
+        if endpoint:
+            from google.api_core.client_options import ClientOptions
+            from google.auth.credentials import AnonymousCredentials
+            cls.client = bigquery.Client(
+                project=cls.project,
+                credentials=AnonymousCredentials(),
+                client_options=ClientOptions(api_endpoint=endpoint),
+                default_query_job_config=default_config,
+            )
+        else:
+            cls.client = bigquery.Client(project=cls.project, default_query_job_config=default_config)
         cls.fq = lambda _cls, t: f"{cls.project}.{cls.dataset}.{t}"
 
     def _run(self, sql):

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -94,14 +94,6 @@ workflow GvsImportGenomes {
     }
   }
 
-  if (load_vcf_headers && use_parquet_ingest) {
-    call Utils.TerminateWorkflow as CannotLoadHeadersWithParquetIngest {
-      input:
-      message = "The combination of Parquet ingest and VCF header loading is not currently supported.",
-      basic_docker = effective_basic_docker,
-    }
-  }
-
   call Utils.GetReference {
     input:
       reference_name = reference_name,
@@ -245,76 +237,81 @@ workflow GvsImportGenomes {
     }
   }
 
-  if (load_vcf_headers) {
-    call ProcessVCFHeaders {
+  # Load whatever Parquet we generated into BigQuery. Headers and vet/ref/ploidy are discovered and
+  # loaded together here; header data lands in the vcf_header_lines_scratch table. A caller wanting the
+  # AoU-style gated phasing (load + sanity-check headers, THEN load the rest) does so by running this
+  # workflow twice -- once with load_vcf_headers=true/load_vet_and_ref_ranges=false, then the reverse.
+  # See the VS-1968 design doc, section 1.5. (No intra-run gate between the two phases is implemented.)
+  if (use_parquet_ingest && (load_vet_and_ref_ranges || load_vcf_headers)) {
+    String defined_parquet_output_dir = select_first([parquet_output_gcs_dir])
+
+    # Table prefixes to discover/load/verify. vcf_header_lines_scratch is included only when headers
+    # were generated (its table may not exist otherwise). vet/ref_ranges/ploidy prefixes are harmless
+    # to include for a headers-only run -- no such files will be present to match.
+    Array[String] parquet_regular_prefixes = if load_vcf_headers
+      then ["sample_chromosome_ploidy", "vcf_header_lines_scratch"]
+      else ["sample_chromosome_ploidy"]
+    Array[String] parquet_superpartitioned_prefixes = ["vet", "ref_ranges"]
+
+    # Set up lifecycle rules for parquet directories before loading
+    if (configure_parquet_lifecycle) {
+      call ConfigureParquetLifecycle {
+        input:
+          output_gcs_dir = defined_parquet_output_dir,
+          billing_project_id = billing_project_id,
+          variants_docker = effective_variants_docker,
+      }
+    }
+
+    # Discover and load Parquet files into BigQuery after all data has been created.
+    call DiscoverParquetFiles {
       input:
-        variants_docker = effective_variants_docker,
-        go = select_all(LoadDataViaBigQueryWriteAPI.done), # add a gate for Parquet header loading here once that's implemented
-        dataset_name = dataset_name,
+        output_gcs_dir = defined_parquet_output_dir,
         project_id = project_id,
+        dataset_name = dataset_name,
+        regular_table_prefixes = parquet_regular_prefixes,
+        superpartitioned_table_prefixes = parquet_superpartitioned_prefixes,
+        go = flatten([
+          select_all([ConfigureParquetLifecycle.done]),
+          select_all(GenerateParquetFilesFromInputGVCFs.done)
+        ]),
+        variants_docker = effective_variants_docker,
+    }
+
+    scatter (fofn in DiscoverParquetFiles.file_fofns) {
+      call LoadParquetFilesToBQ {
+        input:
+          project_id = project_id,
+          dataset_name = dataset_name,
+          fofn_file = fofn,
+          batch_size = 10000,
+          variants_docker = effective_variants_docker,
+      }
+    }
+
+    call VerifyParquetLoading {
+      input:
+        project_id = project_id,
+        dataset_name = dataset_name,
+        gcs_files_list = DiscoverParquetFiles.all_files_list,
+        regular_table_prefixes = parquet_regular_prefixes,
+        superpartitioned_table_prefixes = parquet_superpartitioned_prefixes,
+        go = LoadParquetFilesToBQ.done,
+        variants_docker = effective_variants_docker,
+    }
+
+    if (delete_parquet_files_after_loading && VerifyParquetLoading.all_loaded) {
+      call DeleteParquetFiles {
+        input:
+          output_gcs_dir = defined_parquet_output_dir,
+          use_alternate_delete_strategy = use_alternate_parquet_delete_strategy,
+          billing_project_id = billing_project_id,
+          cloud_sdk_docker = effective_cloud_sdk_docker,
+      }
     }
   }
 
   if (load_vet_and_ref_ranges) {
-    if (use_parquet_ingest) {
-      String defined_parquet_output_dir = select_first([parquet_output_gcs_dir])
-
-      # Set up lifecycle rules for parquet directories before loading
-      if (configure_parquet_lifecycle) {
-        call ConfigureParquetLifecycle {
-          input:
-            output_gcs_dir = defined_parquet_output_dir,
-            billing_project_id = billing_project_id,
-            variants_docker = effective_variants_docker,
-        }
-      }
-
-      # Discover and load Parquet files into BigQuery after all data has been created.
-      call DiscoverParquetFiles {
-        input:
-          output_gcs_dir = defined_parquet_output_dir,
-          project_id = project_id,
-          dataset_name = dataset_name,
-          regular_table_prefixes = ["sample_chromosome_ploidy"],
-          superpartitioned_table_prefixes = ["vet", "ref_ranges"],
-          go = flatten([
-            select_all([ConfigureParquetLifecycle.done]),
-            select_all(GenerateParquetFilesFromInputGVCFs.done)
-          ]),
-          variants_docker = effective_variants_docker,
-      }
-
-      scatter (fofn in DiscoverParquetFiles.file_fofns) {
-        call LoadParquetFilesToBQ {
-          input:
-            project_id = project_id,
-            dataset_name = dataset_name,
-            fofn_file = fofn,
-            batch_size = 10000,
-            variants_docker = effective_variants_docker,
-        }
-      }
-
-      call VerifyParquetLoading {
-        input:
-          project_id = project_id,
-          dataset_name = dataset_name,
-          gcs_files_list = DiscoverParquetFiles.all_files_list,
-          go = LoadParquetFilesToBQ.done,
-          variants_docker = effective_variants_docker,
-      }
-
-      if (delete_parquet_files_after_loading && VerifyParquetLoading.all_loaded) {
-        call DeleteParquetFiles {
-          input:
-            output_gcs_dir = defined_parquet_output_dir,
-            use_alternate_delete_strategy = use_alternate_parquet_delete_strategy,
-            billing_project_id = billing_project_id,
-            cloud_sdk_docker = effective_cloud_sdk_docker,
-        }
-      }
-    }
-
     call SetIsLoadedColumn {
       input:
         # A BQ Write API-flavored invocation of `LoadData` actually loads all data into vet and ref ranges tables, but a
@@ -329,6 +326,21 @@ workflow GvsImportGenomes {
         project_id = project_id,
         dataset_name = dataset_name,
         cloud_sdk_docker = effective_cloud_sdk_docker,
+    }
+  }
+
+  # Merge the loaded header scratch data into vcf_header_lines / sample_vcf_header. Gate on whichever
+  # load path ran: the Parquet header load (VerifyParquetLoading) or the BQ Write API.
+  if (load_vcf_headers) {
+    call ProcessVCFHeaders {
+      input:
+        variants_docker = effective_variants_docker,
+        go = flatten([
+          select_all([VerifyParquetLoading.done]),
+          select_all(LoadDataViaBigQueryWriteAPI.done)
+        ]),
+        dataset_name = dataset_name,
+        project_id = project_id,
     }
   }
 
@@ -582,21 +594,33 @@ task ProcessInputGVCFs {
         rm ${updated_input_vcf}.tbi
 
         OUTPUT_GCS_DIR=$(echo ~{parquet_output_gcs_dir} | sed 's/\/$//')
-        # the file name is a little wonky, so let's just grab the file using such a star statement
-        vet_parquet_file=`ls vet_*.parquet`
-        ref_parquet_file=`ls ref_*.parquet`
-        ploidy_parquet_file=`ls sample_chromosome_ploidy_*.parquet`
 
-        # parse the table superpartition out of the file name
-        table_number=$(echo "$vet_parquet_file" | cut -d'_' -f2)
+        if [[ "~{load_vet_and_ref_ranges}" = 'true' ]]
+        then
+          # the file name is a little wonky, so let's just grab the file using such a star statement
+          vet_parquet_file=`ls vet_*.parquet`
+          ref_parquet_file=`ls ref_*.parquet`
+          ploidy_parquet_file=`ls sample_chromosome_ploidy_*.parquet`
 
-        # copy the vet and ref parquet files to the gcs bucket in the right place
-        gcloud storage ~{"--billing-project " + billing_project_id} cp $vet_parquet_file ${OUTPUT_GCS_DIR}/vet/$table_number/$vet_parquet_file
-        gcloud storage ~{"--billing-project " + billing_project_id} cp $ref_parquet_file ${OUTPUT_GCS_DIR}/ref_ranges/$table_number/$ref_parquet_file
-        gcloud storage ~{"--billing-project " + billing_project_id} cp $ploidy_parquet_file ${OUTPUT_GCS_DIR}/sample_chromosome_ploidy/$ploidy_parquet_file
+          # parse the table superpartition out of the file name
+          table_number=$(echo "$vet_parquet_file" | cut -d'_' -f2)
+
+          # copy the vet and ref parquet files to the gcs bucket in the right place
+          gcloud storage ~{"--billing-project " + billing_project_id} cp $vet_parquet_file ${OUTPUT_GCS_DIR}/vet/$table_number/$vet_parquet_file
+          gcloud storage ~{"--billing-project " + billing_project_id} cp $ref_parquet_file ${OUTPUT_GCS_DIR}/ref_ranges/$table_number/$ref_parquet_file
+          gcloud storage ~{"--billing-project " + billing_project_id} cp $ploidy_parquet_file ${OUTPUT_GCS_DIR}/sample_chromosome_ploidy/$ploidy_parquet_file
+        fi
+
+        if [[ "~{load_vcf_headers}" = 'true' ]]
+        then
+          # Header parquet is named vcf_header_lines_scratch_<sampleId>.parquet so DiscoverParquetFiles
+          # groups it under the vcf_header_lines_scratch table.
+          header_parquet_file=`ls vcf_header_lines_scratch_*.parquet`
+          gcloud storage ~{"--billing-project " + billing_project_id} cp $header_parquet_file ${OUTPUT_GCS_DIR}/vcf_header_lines_scratch/$header_parquet_file
+        fi
 
         # cleanup after ourselves
-        rm *.parquet
+        rm -f *.parquet
       else
         rm input_vcf_$i.vcf.gz
         rm input_vcf_$i.vcf.gz.tbi
@@ -1015,11 +1039,21 @@ task CreateSampleDataViews {
           SET headers_load_status_clause = '';
         END IF;
 
+        -- Read the DURABLE sample->header map, not the transient scratch table. `vcf_header_lines_scratch`
+        -- is emptied by ProcessVCFHeaders after each merge, so a view over it goes empty once headers are
+        -- loaded; combined with the Parquet path not writing HEADERS_LOADED, that left this view empty for
+        -- Parquet callsets and prevented SetIsLoadedColumn from ever setting is_loaded. sample_vcf_header
+        -- persists and is populated for both the BQ and Parquet paths. See the VS-1968 design doc.
+        --
+        -- Safe for the BQ path: the HEADERS_LOADED status clause (UNION'd below) still covers the
+        -- during-ingest window before the scratch->final merge, and post-merge sample_vcf_header is
+        -- populated for BQ as well -- so switching the data-presence source from scratch to
+        -- sample_vcf_header does not lose any BQ samples from this view.
         SET create_header_data_view = """
 
           CREATE OR REPLACE VIEW `~{project_id}.~{dataset_name}.samples_with_header_data` AS
           (
-          SELECT DISTINCT sample_id FROM `~{project_id}.~{dataset_name}.vcf_header_lines_scratch`
+          SELECT DISTINCT sample_id FROM `~{project_id}.~{dataset_name}.sample_vcf_header`
 
           """ || headers_load_status_clause || ");";
 
@@ -1122,7 +1156,7 @@ task ConfigureParquetLifecycle {
       "action": {"type": "Delete"},
       "condition": {
         "age": 14,
-        "matchesPrefix": ["${BUCKET_PATH_PREFIX}vet/", "${BUCKET_PATH_PREFIX}ref_ranges/", "${BUCKET_PATH_PREFIX}sample_chromosome_ploidy/"]
+        "matchesPrefix": ["${BUCKET_PATH_PREFIX}vet/", "${BUCKET_PATH_PREFIX}ref_ranges/", "${BUCKET_PATH_PREFIX}sample_chromosome_ploidy/", "${BUCKET_PATH_PREFIX}vcf_header_lines_scratch/"]
       }
     }
 EOF
@@ -1282,6 +1316,8 @@ task VerifyParquetLoading {
     String project_id
     String dataset_name
     File gcs_files_list
+    Array[String] regular_table_prefixes = ["sample_chromosome_ploidy"]
+    Array[String] superpartitioned_table_prefixes = ["vet", "ref_ranges"]
     # Intentionally unused: this input exists solely to enforce task ordering - the upstream task's `done` output
     # is passed here to prevent this task from running until the upstream task has completed.
     #@ except: UnusedInput
@@ -1302,6 +1338,8 @@ task VerifyParquetLoading {
       --project-id ~{project_id} \
       --dataset-name ~{dataset_name} \
       --gcs-files-list ~{gcs_files_list} \
+      --regular-table-prefixes ~{sep=" " regular_table_prefixes} \
+      --superpartitioned-table-prefixes ~{sep=" " superpartitioned_table_prefixes} \
       --output-dir verification_output
   >>>
 
@@ -1348,6 +1386,10 @@ task DeleteParquetFiles {
       gcloud storage ls ~{"--billing-project " + billing_project_id} \
         "${OUTPUT_GCS_DIR}/vet/" "${OUTPUT_GCS_DIR}/ref_ranges/" > parquet_dirs.txt
       echo "${OUTPUT_GCS_DIR}/sample_chromosome_ploidy/" >> parquet_dirs.txt
+      # Only present when headers were loaded; guard on existence so data-only runs don't fail here.
+      if gcloud storage ls ~{"--billing-project " + billing_project_id} "${OUTPUT_GCS_DIR}/vcf_header_lines_scratch/" >/dev/null 2>&1; then
+        echo "${OUTPUT_GCS_DIR}/vcf_header_lines_scratch/" >> parquet_dirs.txt
+      fi
 
       # Iterate over all Google Cloud paths in parquet_dirs.txt and delete all objects therein
       echo "Deleting Parquet files..."

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -311,26 +311,9 @@ workflow GvsImportGenomes {
     }
   }
 
-  if (load_vet_and_ref_ranges) {
-    call SetIsLoadedColumn {
-      input:
-        # A BQ Write API-flavored invocation of `LoadData` actually loads all data into vet and ref ranges tables, but a
-        # Parquet-flavored invocation of `LoadData` only generates Parquet files from input gVCFs.
-        # Because the loading of Parquet data into BigQuery is handled by a chain of WDL tasks subsequent to
-        # `GenerateParquetFilesFromInputGVCFs`, the `go` trigger for setting the `is_loaded` column is the `done` output
-        # of the last task in that chain, `VerifyParquetLoading`. The other component of the `go` trigger is the
-        # `LoadDataViaBigQueryWriteAPI.done` corresponding to the Write API flow.
-        # Intentionally using select_first to pick whichever of the two mutually exclusive code paths (Parquet vs WriteAPI) ran.
-        #@ except: UnnecessaryFunctionCall
-        go = select_all(select_first([[VerifyParquetLoading.done], LoadDataViaBigQueryWriteAPI.done])),
-        project_id = project_id,
-        dataset_name = dataset_name,
-        cloud_sdk_docker = effective_cloud_sdk_docker,
-    }
-  }
-
   # Merge the loaded header scratch data into vcf_header_lines / sample_vcf_header. Gate on whichever
   # load path ran: the Parquet header load (VerifyParquetLoading) or the BQ Write API.
+  # Declared before SetIsLoadedColumn because that task may depend on this one's `done` (see below).
   if (load_vcf_headers) {
     call ProcessVCFHeaders {
       input:
@@ -341,6 +324,34 @@ workflow GvsImportGenomes {
         ]),
         dataset_name = dataset_name,
         project_id = project_id,
+    }
+  }
+
+  if (load_vet_and_ref_ranges) {
+    call SetIsLoadedColumn {
+      input:
+        # A BQ Write API-flavored invocation of `LoadData` actually loads all data into vet and ref ranges tables, but a
+        # Parquet-flavored invocation of `LoadData` only generates Parquet files from input gVCFs.
+        # Because the loading of Parquet data into BigQuery is handled by a chain of WDL tasks subsequent to
+        # `GenerateParquetFilesFromInputGVCFs`, the `go` trigger for setting the `is_loaded` column is the `done` output
+        # of the last task in that chain, `VerifyParquetLoading`. The other component of the `go` trigger is the
+        # `LoadDataViaBigQueryWriteAPI.done` corresponding to the Write API flow.
+        # Intentionally using select_first to pick whichever of the two mutually exclusive code paths (Parquet vs WriteAPI) ran.
+        #
+        # Also gate on ProcessVCFHeaders.done: this task computes is_loaded from `samples_with_all_data`, which
+        # JOINs `samples_with_header_data` (backed by `sample_vcf_header` on the Parquet path). That table is
+        # populated by ProcessVCFHeaders, and the Parquet path writes no HEADERS_LOADED status to rescue the
+        # view. When a single run sets both load_vcf_headers and load_vet_and_ref_ranges, without this edge the
+        # two tasks race and is_loaded is silently left FALSE. select_all makes it a no-op for data-only runs
+        # (headers loaded in a prior run, so sample_vcf_header is already populated).
+        #@ except: UnnecessaryFunctionCall
+        go = flatten([
+          select_all(select_first([[VerifyParquetLoading.done], LoadDataViaBigQueryWriteAPI.done])),
+          select_all([ProcessVCFHeaders.done])
+        ]),
+        project_id = project_id,
+        dataset_name = dataset_name,
+        cloud_sdk_docker = effective_cloud_sdk_docker,
     }
   }
 
@@ -667,6 +678,11 @@ task ProcessVCFHeaders {
       --project_id=~{project_id} \
       --dataset_name ~{dataset_name}
   >>>
+
+  output {
+    # Exists so downstream tasks (e.g. SetIsLoadedColumn) can order themselves after the header merge.
+    Boolean done = true
+  }
 
   runtime {
     docker: variants_docker
@@ -1026,10 +1042,12 @@ task CreateSampleDataViews {
       DECLARE create_header_data_view STRING;
       DECLARE create_all_sample_data_view STRING;
 
+      -- Probe sample_vcf_header, the table the view below actually reads (it is created alongside
+      -- vcf_header_lines_scratch when load_vcf_headers is set), so the guard matches its dependency.
       SET header_table_exists = (
         SELECT COUNT(1) FROM
         `~{project_id}.~{dataset_name}.INFORMATION_SCHEMA.TABLES`
-        WHERE table_name = 'vcf_header_lines_scratch'
+        WHERE table_name = 'sample_vcf_header'
       );
 
       IF header_table_exists > 0 THEN

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/CreateVariantIngestFiles.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/CreateVariantIngestFiles.java
@@ -226,8 +226,10 @@ public final class CreateVariantIngestFiles extends VariantWalker {
     public final MessageType headersRowSchema = MessageTypeParser
             .parseMessageType("""
             message HeaderRow {
-            	required int64 sample_id;
-            	required binary headerLineHash (UTF8);
+                required int64 sample_id;
+                optional binary vcf_header_lines (UTF8);
+                required binary vcf_header_lines_hash (UTF8);
+                required boolean is_expected_unique;
             }
             """);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/CreateVariantIngestFiles.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/CreateVariantIngestFiles.java
@@ -223,7 +223,9 @@ public final class CreateVariantIngestFiles extends VariantWalker {
             }
             """);
 
-    public final MessageType headersRowSchema = MessageTypeParser
+    // static so tests can assert against the exact production shape (see VcfHeaderLineScratchCreatorUnitTest)
+    // rather than hand-copying it.
+    public static final MessageType headersRowSchema = MessageTypeParser
             .parseMessageType("""
             message HeaderRow {
                 required int64 sample_id;

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/VcfHeaderLineScratchCreator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/VcfHeaderLineScratchCreator.java
@@ -23,6 +23,24 @@ import java.util.concurrent.ExecutionException;
 public class VcfHeaderLineScratchCreator {
     private static final Logger logger = LogManager.getLogger(VcfHeaderLineScratchCreator.class);
 
+    /**
+     * How the Parquet ingest path writes VCF header data. See the VS-1968 design doc for details.
+     * <ul>
+     *   <li>{@link #NAIVE} (Option 1): write the full header text for every chunk of every sample;
+     *       deduplication happens later in the scratch&rarr;final MERGE.</li>
+     *   <li>{@link #HYBRID} (Option 3): route on {@code is_expected_unique} &mdash; write per-sample
+     *       unique (command-line) chunks inline, and content-address the shared blob to GCS keyed by
+     *       its hash. Content-addressing is not yet implemented (see the branch in {@link #apply}).</li>
+     * </ul>
+     */
+    public enum HeaderParquetStrategy {
+        NAIVE,
+        HYBRID
+    }
+
+    // TODO(VS-1803): promote this to a real CLI/WDL parameter. Hardcoded for now.
+    private static final HeaderParquetStrategy PARQUET_STRATEGY = HeaderParquetStrategy.NAIVE;
+
     private final CommonCode.OutputType outputType;
     private final Long sampleId;
     private final String projectId;
@@ -32,8 +50,6 @@ public class VcfHeaderLineScratchCreator {
     private HeaderParquetFileWriter vcfHeaderParquetFileWriter = null;
     private static final String NON_SCRATCH_TABLE_NAME = "vcf_header_lines";
     private static final String SCRATCH_TABLE_NAME = "vcf_header_lines_scratch";
-
-    private static final String HEADER_FILETYPE_PREFIX = "header_file";
 
 
     public static boolean doScratchRowsExistFor(String projectId, String datasetName, Long sampleId) {
@@ -72,15 +88,17 @@ public class VcfHeaderLineScratchCreator {
                     vcfHeaderBQJsonWriter = new PendingBQWriter(projectId, datasetName, SCRATCH_TABLE_NAME);
                     break;
                 case PARQUET:
-                    // TODO ensure that there doesn't need to be a table_number or inputVcfFileName--it's all tables/samples, yes?
-                    final File parquetOutputFile = new File(outputDirectory, HEADER_FILETYPE_PREFIX + ".parquet");
+                    // One header file per sample. Name it "<SCRATCH_TABLE_NAME>_<sampleId>.parquet" so the
+                    // loader groups it under the vcf_header_lines_scratch table and parses the sample id
+                    // (regular-table pattern: /<prefix>_<sampleId>...parquet). See the VS-1968 design doc.
+                    final File parquetOutputFile = new File(outputDirectory, SCRATCH_TABLE_NAME + "_" + this.sampleId + ".parquet");
                     vcfHeaderParquetFileWriter = new HeaderParquetFileWriter(new Path(parquetOutputFile.toURI()), headersRowSchema, CompressionCodecName.SNAPPY);
                     break;
 
             }
         }
         catch (Exception e) {
-            throw new UserException("Could not create VCF Header Scratch Table Writer", e);
+            throw new UserException("Could not create Vcf Header Scratch Table Writer", e);
         }
 
     }
@@ -106,11 +124,35 @@ public class VcfHeaderLineScratchCreator {
                         throw new IOException("BQ exception", ex);
                     }
                     break;
-                case PARQUET:
-                    String chunkHash = Utils.calcMD5(headerChunk.getKey());
-                    JSONObject record = HeaderParquetFileWriter.writeJson(this.sampleId, chunkHash);
-                    vcfHeaderParquetFileWriter.write(record);
+                case PARQUET: {
+                    // The Parquet path does no write-time dedup (that would reintroduce the per-sample BQ
+                    // query storm); dedup + idempotency happen in the scratch->final load. See the design doc.
+                    final String chunkHash = Utils.calcMD5(headerChunk.getKey());
+                    final Boolean isExpectedUnique = headerChunk.getValue();
+                    switch (PARQUET_STRATEGY) {
+                        case NAIVE:
+                            // Option 1: write the full record for every chunk of every sample.
+                            vcfHeaderParquetFileWriter.write(
+                                    HeaderParquetFileWriter.writeJson(this.sampleId, headerChunk.getKey(), chunkHash, isExpectedUnique));
+                            break;
+                        case HYBRID:
+                            if (isExpectedUnique) {
+                                // Option 3: per-sample command-line chunks don't dedup; write text inline.
+                                vcfHeaderParquetFileWriter.write(
+                                        HeaderParquetFileWriter.writeJson(this.sampleId, headerChunk.getKey(), chunkHash, true));
+                            } else {
+                                // Option 3: the shared blob is content-addressed to GCS keyed by its hash so it is
+                                // stored once. Here we emit only the sample_id->hash association (NULL text).
+                                // TODO(VS-1803): write the blob text to gs://.../headers/text/<hash>.parquet with an
+                                //   ifGenerationMatch=0 precondition, and load those objects into vcf_header_lines.
+                                //   Until that exists, HYBRID does NOT persist the shared blob text.
+                                vcfHeaderParquetFileWriter.write(
+                                        HeaderParquetFileWriter.writeJson(this.sampleId, null, chunkHash, false));
+                            }
+                            break;
+                    }
                     break;
+                }
             }
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/VcfHeaderLineScratchCreator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/VcfHeaderLineScratchCreator.java
@@ -24,17 +24,26 @@ public class VcfHeaderLineScratchCreator {
     private static final Logger logger = LogManager.getLogger(VcfHeaderLineScratchCreator.class);
 
     /**
-     * How the Parquet ingest path writes VCF header data. See the VS-1968 design doc for details.
-     * <ul>
-     *   <li>{@link #NAIVE} (Option 1): write the full header text for every chunk of every sample;
-     *       deduplication happens later in the scratch&rarr;final MERGE.</li>
-     *   <li>{@link #HYBRID} (Option 3): route on {@code is_expected_unique} &mdash; write per-sample
-     *       unique (command-line) chunks inline, and content-address the shared blob to GCS keyed by
-     *       its hash. Content-addressing is not yet implemented (see the branch in {@link #apply}).</li>
-     * </ul>
+     * How the Parquet ingest path writes VCF header data to the scratch file. Most header text is a large
+     * blob that is identical across all samples in a callset (only a few command-line chunks differ per
+     * sample), so the strategies trade off write simplicity against how many redundant copies of that
+     * shared blob get written. See the VS-1968 design doc for the full analysis.
      */
     public enum HeaderParquetStrategy {
+        /**
+         * Write the full header text for every chunk of every sample, redundant copies of the shared blob
+         * included. Deduplication happens downstream in the scratch&rarr;final promotion, so the scratch
+         * file is larger but the write path is trivial. This is the only implemented strategy.
+         */
         NAIVE,
+
+        /**
+         * Deduplicate the shared blob at write time by routing on {@code is_expected_unique}: per-sample
+         * unique (command-line) chunks are written inline, while the shared blob is content-addressed to
+         * GCS keyed by its hash so it is stored exactly once for the whole callset. Cheaper at scale, but
+         * the GCS content-addressing half is not yet implemented &mdash; selecting this today throws
+         * (see {@link #apply}).
+         */
         HYBRID
     }
 
@@ -98,7 +107,7 @@ public class VcfHeaderLineScratchCreator {
             }
         }
         catch (Exception e) {
-            throw new UserException("Could not create Vcf Header Scratch Table Writer", e);
+            throw new UserException("Could not create VCF Header Scratch Table writer", e);
         }
 
     }
@@ -131,25 +140,21 @@ public class VcfHeaderLineScratchCreator {
                     final Boolean isExpectedUnique = headerChunk.getValue();
                     switch (PARQUET_STRATEGY) {
                         case NAIVE:
-                            // Option 1: write the full record for every chunk of every sample.
+                            // Write the full record for every chunk of every sample; dedup happens downstream.
                             vcfHeaderParquetFileWriter.write(
                                     HeaderParquetFileWriter.writeJson(this.sampleId, headerChunk.getKey(), chunkHash, isExpectedUnique));
                             break;
                         case HYBRID:
-                            if (isExpectedUnique) {
-                                // Option 3: per-sample command-line chunks don't dedup; write text inline.
-                                vcfHeaderParquetFileWriter.write(
-                                        HeaderParquetFileWriter.writeJson(this.sampleId, headerChunk.getKey(), chunkHash, true));
-                            } else {
-                                // Option 3: the shared blob is content-addressed to GCS keyed by its hash so it is
-                                // stored once. Here we emit only the sample_id->hash association (NULL text).
-                                // TODO(VS-1803): write the blob text to gs://.../headers/text/<hash>.parquet with an
-                                //   ifGenerationMatch=0 precondition, and load those objects into vcf_header_lines.
-                                //   Until that exists, HYBRID does NOT persist the shared blob text.
-                                vcfHeaderParquetFileWriter.write(
-                                        HeaderParquetFileWriter.writeJson(this.sampleId, null, chunkHash, false));
-                            }
-                            break;
+                            // The shared blob is content-addressed to GCS keyed by its hash (see the enum
+                            // javadoc), and that half is not yet implemented -- so HYBRID cannot durably persist
+                            // the shared blob text, and selecting it would silently drop header data.
+                            // Fail loudly rather than write a partial, lossy scratch file.
+                            // TODO(VS-1803): write the blob text to gs://.../headers/text/<hash>.parquet with an
+                            //   ifGenerationMatch=0 precondition, load those objects into vcf_header_lines, then
+                            //   restore the routing here and promote PARQUET_STRATEGY to a real CLI/WDL parameter.
+                            throw new UnsupportedOperationException(
+                                    "HYBRID header Parquet strategy is not yet implemented (shared-blob content-addressing " +
+                                    "is incomplete; see TODO VS-1803). Use NAIVE until it lands.");
                     }
                     break;
                 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/VcfHeaderLineScratchCreator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/VcfHeaderLineScratchCreator.java
@@ -12,7 +12,6 @@ import org.broadinstitute.hellbender.tools.gvs.ingest.parquet.HeaderParquetFileW
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.gvs.bigquery.BigQueryUtils;
 import org.broadinstitute.hellbender.utils.gvs.bigquery.PendingBQWriter;
-import org.json.JSONObject;
 
 import java.io.File;
 import java.io.IOException;
@@ -123,11 +122,12 @@ public class VcfHeaderLineScratchCreator {
                         Boolean isExpectedUnique = headerChunk.getValue();
                         boolean vcfScratchHeaderRowsExist = doScratchRowsExistFor(this.projectId, this.datasetName, chunkHash);
                         boolean vcfNonScratchHeaderRowsExist = doNonScratchRowsExistFor(this.projectId, this.datasetName, chunkHash);
+                        // Both paths must emit identical rows, so share one record builder (writeJson).
                         if (vcfScratchHeaderRowsExist || vcfNonScratchHeaderRowsExist) {
-                            vcfHeaderBQJsonWriter.addJsonRow(createJson(this.sampleId, null, chunkHash, isExpectedUnique));
+                            vcfHeaderBQJsonWriter.addJsonRow(HeaderParquetFileWriter.writeJson(this.sampleId, null, chunkHash, isExpectedUnique));
                         }
                         else {
-                            vcfHeaderBQJsonWriter.addJsonRow(createJson(this.sampleId, headerChunk.getKey(), chunkHash, isExpectedUnique));
+                            vcfHeaderBQJsonWriter.addJsonRow(HeaderParquetFileWriter.writeJson(this.sampleId, headerChunk.getKey(), chunkHash, isExpectedUnique));
                         }
                     } catch (Descriptors.DescriptorValidationException | ExecutionException | InterruptedException ex) {
                         throw new IOException("BQ exception", ex);
@@ -160,18 +160,6 @@ public class VcfHeaderLineScratchCreator {
                 }
             }
         }
-    }
-
-    public JSONObject createJson(Long sampleId, String headerChunk, String headerHash, Boolean isExpectedUnique) {
-        JSONObject record = new JSONObject();
-        record.put("sample_id", sampleId);
-
-        if (headerChunk != null) {
-            record.put("vcf_header_lines", headerChunk);
-        }
-        record.put("vcf_header_lines_hash", headerHash);
-        record.put("is_expected_unique", isExpectedUnique);
-        return record;
     }
 
     public void commitData() {

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/parquet/HeaderParquetFileWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/parquet/HeaderParquetFileWriter.java
@@ -10,7 +10,15 @@ import java.io.IOException;
 /**
  * Parquet writer for VCF header information.
  * <p>
- * This writer stores sample ID and header line hash associations in Parquet format.
+ * This writer stores sample ID and header line hash associations in Parquet format. The record shape
+ * intentionally mirrors the {@code vcf_header_lines_scratch} BigQuery table so the file can be loaded
+ * by column name (see the VS-1968 design doc). The expected columns and their BigQuery types are:
+ * <ul>
+ *   <li>{@code sample_id} &mdash; INTEGER, required</li>
+ *   <li>{@code vcf_header_lines} &mdash; STRING, nullable (omitted for association-only rows)</li>
+ *   <li>{@code vcf_header_lines_hash} &mdash; STRING, required</li>
+ *   <li>{@code is_expected_unique} &mdash; BOOLEAN, required</li>
+ * </ul>
  */
 public class HeaderParquetFileWriter extends AbstractParquetFileWriter {
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/parquet/HeaderParquetFileWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/parquet/HeaderParquetFileWriter.java
@@ -30,15 +30,26 @@ public class HeaderParquetFileWriter extends AbstractParquetFileWriter {
 
     /**
      * Creates a JSON object representing a header record.
-     * 
+     * <p>
+     * Column names intentionally match the {@code vcf_header_lines_scratch} BigQuery table so the
+     * resulting Parquet file can be loaded into that table by name (see the VS-1968 design doc).
+     *
      * @param sampleId the sample ID
-     * @param headerLineHash the hash of the header line
+     * @param headerChunk the header text chunk; may be {@code null} to write an association-only row
+     *                    (sample_id -> hash) without the text, mirroring the BQ path's dedup behavior
+     * @param headerLineHash the MD5 hash of the header chunk
+     * @param isExpectedUnique whether this chunk is expected to differ per sample
      * @return a JSON object containing the header information
      */
-    public static JSONObject writeJson(Long sampleId, String headerLineHash) {
+    public static JSONObject writeJson(Long sampleId, String headerChunk, String headerLineHash, Boolean isExpectedUnique) {
         JSONObject record = new JSONObject();
         record.put("sample_id", sampleId);
-        record.put("headerLineHash", headerLineHash);
+        // Omit the (nullable) text column entirely when null so the Parquet writer skips it.
+        if (headerChunk != null) {
+            record.put("vcf_header_lines", headerChunk);
+        }
+        record.put("vcf_header_lines_hash", headerLineHash);
+        record.put("is_expected_unique", isExpectedUnique);
         return record;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/parquet/ParquetWriteSupport.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/gvs/ingest/parquet/ParquetWriteSupport.java
@@ -67,6 +67,7 @@ public class ParquetWriteSupport extends WriteSupport<JSONObject> {
                 switch(col.getPrimitiveType().getPrimitiveTypeName()) {
                     case INT64 -> recordConsumer.addLong(record.getLong(columnName));
                     case FLOAT -> recordConsumer.addFloat(record.getFloat(columnName));
+                    case BOOLEAN -> recordConsumer.addBoolean(record.getBoolean(columnName));
                     case BINARY -> recordConsumer.addBinary(Binary.fromString(record.getString(columnName)));
                     default ->
                             throw new UnsupportedOperationException("Haven't implemented other types yet! Can't process column " + columnName + " with type " + col.getPrimitiveType().getName());

--- a/src/test/java/org/broadinstitute/hellbender/tools/gvs/ingest/VcfHeaderLineScratchCreatorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/gvs/ingest/VcfHeaderLineScratchCreatorUnitTest.java
@@ -1,0 +1,131 @@
+package org.broadinstitute.hellbender.tools.gvs.ingest;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.hadoop.example.GroupReadSupport;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.MessageTypeParser;
+import org.broadinstitute.hellbender.tools.gvs.common.CommonCode;
+import org.broadinstitute.hellbender.tools.gvs.ingest.parquet.HeaderParquetFileWriter;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Unit tests for VS-1803 header-loading-on-Parquet: the {@code writeJson} record shape and the
+ * end-to-end NAIVE Parquet write path (schema + {@code is_expected_unique} BOOLEAN support).
+ */
+public class VcfHeaderLineScratchCreatorUnitTest {
+
+    private static final long SAMPLE_ID = 100;
+
+    // Must match CreateVariantIngestFiles#headersRowSchema and the vcf_header_lines_scratch BQ table.
+    private static final MessageType HEADERS_ROW_SCHEMA = MessageTypeParser.parseMessageType("""
+            message HeaderRow {
+                required int64 sample_id;
+                optional binary vcf_header_lines (UTF8);
+                required binary vcf_header_lines_hash (UTF8);
+                required boolean is_expected_unique;
+            }
+            """);
+
+    @Test
+    public void testWriteJsonFullRecord() {
+        final JSONObject record = HeaderParquetFileWriter.writeJson(5L, "##contig=<ID=chr1>", "hash1", true);
+        Assert.assertEquals(record.getLong("sample_id"), 5L);
+        Assert.assertEquals(record.getString("vcf_header_lines"), "##contig=<ID=chr1>");
+        Assert.assertEquals(record.getString("vcf_header_lines_hash"), "hash1");
+        Assert.assertTrue(record.getBoolean("is_expected_unique"));
+    }
+
+    @Test
+    public void testWriteJsonNullChunkOmitsText() {
+        // A null chunk yields an association-only row: the (nullable) text column must be omitted so
+        // the Parquet writer skips it, matching the BQ path's NULL-text dedup rows.
+        final JSONObject record = HeaderParquetFileWriter.writeJson(5L, null, "hash1", false);
+        Assert.assertFalse(record.has("vcf_header_lines"), "text column should be absent for a null chunk");
+        Assert.assertEquals(record.getLong("sample_id"), 5L);
+        Assert.assertEquals(record.getString("vcf_header_lines_hash"), "hash1");
+        Assert.assertFalse(record.getBoolean("is_expected_unique"));
+    }
+
+    /**
+     * End-to-end NAIVE strategy: write header chunks via VcfHeaderLineScratchCreator to a real Parquet
+     * file, read it back, and assert every column round-trips — including the boolean is_expected_unique,
+     * which exercises the BOOLEAN case added to ParquetWriteSupport.
+     */
+    @Test
+    public void testNaiveParquetRoundTrip() throws IOException {
+        final File outputDir = Files.createTempDirectory("vcf-header-parquet-test").toFile();
+        try {
+            // A shared blob (is_expected_unique=false) plus a per-sample command line (true).
+            final Map<String, Boolean> headers = new LinkedHashMap<>();
+            headers.put("##contig=<ID=chr1>\n##contig=<ID=chr2>\n##INFO=<ID=AF>", false);
+            headers.put("##GATKCommandLine=<ID=HaplotypeCaller,sampleA>", true);
+
+            final VcfHeaderLineScratchCreator creator = new VcfHeaderLineScratchCreator(
+                    SAMPLE_ID, "test", "test", outputDir, CommonCode.OutputType.PARQUET, HEADERS_ROW_SCHEMA);
+            creator.apply(headers);
+            creator.commitData();
+
+            final File parquetFile = new File(outputDir, "vcf_header_lines_scratch_" + SAMPLE_ID + ".parquet");
+            Assert.assertTrue(parquetFile.exists(), "expected vcf_header_lines_scratch_<sampleId>.parquet to be written");
+
+            // hash -> (text, is_expected_unique) as read back from Parquet.
+            final Map<String, String> readText = new HashMap<>();
+            final Map<String, Boolean> readUnique = new HashMap<>();
+            int rowCount = 0;
+            try (ParquetReader<Group> reader = ParquetReader
+                    .builder(new GroupReadSupport(), new Path(parquetFile.toURI()))
+                    .withConf(new Configuration())
+                    .build()) {
+                Group row;
+                while ((row = reader.read()) != null) {
+                    rowCount++;
+                    final GroupType schema = row.getType();
+                    Assert.assertEquals(row.getLong("sample_id", 0), SAMPLE_ID);
+                    final String hash = row.getString("vcf_header_lines_hash", 0);
+                    // NAIVE writes the full text for every chunk.
+                    Assert.assertEquals(row.getFieldRepetitionCount(schema.getFieldIndex("vcf_header_lines")), 1,
+                            "NAIVE strategy should always write the text column");
+                    final String text = row.getString("vcf_header_lines", 0);
+                    final boolean unique = row.getBoolean("is_expected_unique", 0);
+                    readText.put(hash, text);
+                    readUnique.put(hash, unique);
+                }
+            }
+
+            Assert.assertEquals(rowCount, headers.size(), "one Parquet row per header chunk");
+            for (final Map.Entry<String, Boolean> chunk : headers.entrySet()) {
+                final String expectedHash = Utils.calcMD5(chunk.getKey());
+                Assert.assertEquals(readText.get(expectedHash), chunk.getKey(), "text should round-trip by hash");
+                Assert.assertEquals(readUnique.get(expectedHash), chunk.getValue(), "is_expected_unique should round-trip");
+            }
+        } finally {
+            deleteRecursively(outputDir);
+        }
+    }
+
+    private static void deleteRecursively(final File file) {
+        final File[] children = file.listFiles();
+        if (children != null) {
+            for (final File child : children) {
+                deleteRecursively(child);
+            }
+        }
+        // best-effort cleanup
+        //noinspection ResultOfMethodCallIgnored
+        file.delete();
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/gvs/ingest/VcfHeaderLineScratchCreatorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/gvs/ingest/VcfHeaderLineScratchCreatorUnitTest.java
@@ -7,7 +7,6 @@ import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.example.GroupReadSupport;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.MessageTypeParser;
 import org.broadinstitute.hellbender.tools.gvs.common.CommonCode;
 import org.broadinstitute.hellbender.tools.gvs.ingest.parquet.HeaderParquetFileWriter;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -30,15 +29,8 @@ public class VcfHeaderLineScratchCreatorUnitTest {
 
     private static final long SAMPLE_ID = 100;
 
-    // Must match CreateVariantIngestFiles#headersRowSchema and the vcf_header_lines_scratch BQ table.
-    private static final MessageType HEADERS_ROW_SCHEMA = MessageTypeParser.parseMessageType("""
-            message HeaderRow {
-                required int64 sample_id;
-                optional binary vcf_header_lines (UTF8);
-                required binary vcf_header_lines_hash (UTF8);
-                required boolean is_expected_unique;
-            }
-            """);
+    // Reference the production schema directly so the test can never assert a stale shape.
+    private static final MessageType HEADERS_ROW_SCHEMA = CreateVariantIngestFiles.headersRowSchema;
 
     @Test
     public void testWriteJsonFullRecord() {


### PR DESCRIPTION
## Summary
See [VS-1803](https://broadworkbench.atlassian.net/browse/VS-1803) for support for loading parquet headers
See related [VS-1968](https://broadworkbench.atlassian.net/browse/VS-1968) for the discussion/spike for Parquet Headers Design.

VCF header loading was previously supported only on the legacy BigQuery Write API ingest path. Selecting `--output-type PARQUET` together with header loading hard-failed in `GvsImportGenomes.wdl` with:

> The combination of Parquet ingest and VCF header loading is not currently supported.

This PR removes that restriction and makes the Parquet path produce the **same** header tables as the BQ path. On the Parquet path, `CreateVariantIngestFiles` writes a local `vcf_header_lines_scratch_<sampleId>.parquet` file, the WDL uploads it alongside the vet/ref-ranges Parquet output, and it is loaded into `vcf_header_lines_scratch` and promoted into `vcf_header_lines` / `sample_vcf_header` by the existing `ProcessVCFHeaders` step. The end state is byte-for-byte identical to the BQ path.

## Changes

### Java (delivered via `load_data_gatk_override` jar)
- **`CreateVariantIngestFiles.java`** — enable the header-writing path when `--output-type PARQUET`; defer the `HEADERS_LOADED` status write to after promotion, consistent with the Parquet lifecycle. `HeaderRow` schema carries `sample_id`, `vcf_header_lines` (nullable), `vcf_header_lines_hash`, `is_expected_unique`.
- **`VcfHeaderLineScratchCreator.java`** — write scratch header rows to Parquet. Introduces a `HeaderParquetStrategy` enum (`NAIVE` / `HYBRID`) with self-documenting Javadoc; only `NAIVE` is implemented, and the unimplemented `HYBRID` branch **fails fast** (throws `UnsupportedOperationException`) rather than silently dropping shared-blob header text.
- **`parquet/HeaderParquetFileWriter.java`** — build the header record; class Javadoc documents the exact Parquet↔BigQuery column names and types.
- **`parquet/ParquetWriteSupport.java`** — add a `BOOLEAN` write case (guarded by the existing presence/non-null check before the write).

### WDL
- **`GvsImportGenomes.wdl`** — remove the unsupported-combination guard; wire the Parquet path to emit, upload, load, and promote the header scratch file. Include `vcf_header_lines_scratch` in the discover/load/verify prefixes and in the lifecycle/delete logic. `ProcessVCFHeaders` now runs after either Parquet verification or the BigQuery Write API load. The "samples with header data" view reads the durable `sample_vcf_header` table (union'd with the `HEADERS_LOADED` status clause, which still covers the BQ during-ingest window).

### Promotion script
- **`process_sample_vcf_headers.py`** — refactored into unit-testable SQL builders; scratch→final promotion via idempotent anti-join `INSERT`s plus scratch cleanup, shared by both ingest paths. This also fixes a latent double-insert into `vcf_header_lines` on the legacy BQ path.

### Docs
- **`scripts/variantstore/docs/parquet/header_loading_design.md`** — design doc (VS-1968) covering the operational model, idempotency/repeatability, and the strategy trade-offs.

### Tests
- **`VcfHeaderLineScratchCreatorUnitTest.java`** (new, CI-covered) — Parquet record shape + `NAIVE` round-trip.
- **`test/test_process_sample_vcf_headers.py`** (new) — SQL-builder unit tests, plus an env-gated integration test that exercises idempotency and the `DELETE` cleanup against real BigQuery.
- **`test/header_loading_e2e_local/`** (new) — a manual developer harness (`run_header_loading_e2e.sh` + README) that runs the full pipeline on both paths, A/B compares them, and repeats to prove idempotency. As a final sanity check the harness rebuilds the sample's full VCF header from the normalized tables (`sample_vcf_header` ⋈ `vcf_header_lines`, `ST
RING_AGG` over the chunks) and asserts it is non-empty — confirming the header split is losslessly reversible from what the Parquet path wrote.**Not run in CI** — requires authenticated `bq`/`gcloud` and a throwaway project. 

## Operator run sequence

To load headers via the Parquet path, run `GvsImportGenomes` (or the bulk-ingest wrapper) with:

```
use_parquet_ingest    = true
load_vcf_headers      = true
parquet_output_gcs_dir = gs://<writable-bucket>/<path>/   # required; no default. Must be writable by the runtime service account.
```

For the AoU two-phase pattern, run twice against the same dataset: a **headers-only** pass first, then the remaining data. Header promotion is idempotent — re-runs (task retry, workflow resume, or re-ingest) insert nothing already present.

## Testing

Ran HG00405 in Terra(GvsBulkIngestGenomes workl=flow)through three configurations against isolated datasets:

- Baseline BQ (pre-change WDL)
- Branch BQ path (A)
- Branch Parquet path (B)

Also see  local harness at `scripts/variantstore/scripts/test/header_loading_e2e_local/run_header_loading_e2e.sh` for running local end-to-end tests directly without the WDLs.

**A/B equivalence.** A/B diffs (`EXCEPT DISTINCT`, both directions) on `vcf_header_lines` (hash, text, `is_expected_unique`) and `sample_vcf_header` (sample_id, hash) were **0 / 0** in every comparison — the Parquet path produces header tables identical to the BQ path. The anti-join promotion SQL was also validated directly against BigQuery.

**Idempotency.** The local harness runs each path for ≥2 iterations against the same dataset and re-checks the final tables after every pass. Results were stable across re-runs:

**Round-trip reconstruction.** As a final sanity check the harness rebuilds the sample's full VCF header from the normalized tables (`sample_vcf_header` ⋈ `vcf_header_lines`, `STRING_AGG` over the chunks) and asserts it is non-empty — confirming the header split is losslessly reversible from what the Parquet path wrote.

- `vcf_header_lines` and `sample_vcf_header` row counts were unchanged after the second (and subsequent) ingest+promote — no duplicate rows.
- `vcf_header_lines_scratch` drained to **0** after promotion on each pass (final counts **3 / 3 / 0** for HG00405).
- Re-runs insert nothing already present: the Parquet path relies on the anti-join (`LEFT JOIN ... WHERE t.hash IS NULL` skips hashes already promoted); the BQ path additionally short-circuits ingest via the per-sample `HEADERS_LOADED` status. This covers the real-world repeat triggers — task retry, workflow resume, and re-ingest of the same sample.

Verified end-to-end on Terra (Parquet + header loading now runs to completion) and via the local harness manually — not run in CI; see its README at `scripts/variantstore/scripts/test/header_loading_e2e_local/README` and results attached to [VS-1803](https://broadworkbench.atlassian.net/browse/VS-1803).

## Known non-regression (tracked separately)

On the BQ path, `sample_load_status` gets **two** `HEADERS_LOADED` rows per sample; the Parquet path writes **one**. This double-write pre-exists on `ah_var_store` (`CreateVariantIngestFiles.onTraversalSuccess`) and is harmless to idempotency, since load-state checks key on presence, not count. Not addressed here — see [VS-1980](https://broadworkbench.atlassian.net/browse/VS-1980).

## Miscellaneous
- **`GvsAssignIds.wdl`** (missing-dataset fail-fast preflight) — see [VS-1982](https://broadworkbench.atlassian.net/browse/VS-1982)
- **`.dockstore.yml`** branch-filter addition — a temporary hook for Dockstore/Terra testing, not part of the feature. Will be removed before final merge.


[VS-1968]: https://broadworkbench.atlassian.net/browse/VS-1968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VS-1980]: https://broadworkbench.atlassian.net/browse/VS-1980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[VS-1803]: https://broadworkbench.atlassian.net/browse/VS-1803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ