### PR TITLE
CleanVcf - PostHoc updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 src/test/resources
 src/test/resources/*
 build/
+bin/

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,3 @@
 src/test/resources
 src/test/resources/*
 build/
-bin/

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVReviseMultiallelicCnvs.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVReviseMultiallelicCnvs.java
@@ -215,7 +215,7 @@ public class SVReviseMultiallelicCnvs extends VariantWalker {
             for (final Genotype genotype : genotypes) {
                 final GenotypeBuilder gb = new GenotypeBuilder(genotype);
                 gb.noGQ();
-                gb.alleles(Arrays.asList(Allele.NO_CALL, Allele.NO_CALL));
+                gb.alleles(Arrays.asList(Allele.NO_CALL));
                 gb.attribute(GATKSVVCFConstants.COPY_NUMBER_FORMAT, genotype.getExtendedAttribute(GATKSVVCFConstants.RD_CN));
                 gb.attribute(GATKSVVCFConstants.COPY_NUMBER_QUALITY_FORMAT, genotype.getExtendedAttribute(GATKSVVCFConstants.RD_GQ));
                 updatedGenotypes.add(gb.make());
@@ -294,7 +294,7 @@ public class SVReviseMultiallelicCnvs extends VariantWalker {
             for (final Genotype genotype : genotypes) {
                 final GenotypeBuilder gb = new GenotypeBuilder(genotype);
                 gb.noGQ();
-                gb.alleles(Arrays.asList(Allele.NO_CALL, Allele.NO_CALL));
+                gb.alleles(Arrays.asList(Allele.NO_CALL));
                 gb.attribute(GATKSVVCFConstants.COPY_NUMBER_FORMAT, genotype.getExtendedAttribute(GATKSVVCFConstants.RD_CN));
                 gb.attribute(GATKSVVCFConstants.COPY_NUMBER_QUALITY_FORMAT, genotype.getExtendedAttribute(GATKSVVCFConstants.RD_GQ));
                 updatedGenotypes.add(gb.make());

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVReviseMultiallelicCnvs.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVReviseMultiallelicCnvs.java
@@ -61,6 +61,7 @@ public class SVReviseMultiallelicCnvs extends VariantWalker {
     private Set<String> outlierSamples;
 
     private double maxVF;
+    private double maxVFAllSamples;
 
     private static final int MIN_LARGE_EVENT_SIZE = 1000;
     private static final int MIN_MULTIALLELIC_EVENT_SIZE = 5000;
@@ -79,6 +80,8 @@ public class SVReviseMultiallelicCnvs extends VariantWalker {
 
         // Populate maxVf based on sample information
         maxVF = Math.max((getHeaderForVariants().getGenotypeSamples().size() - outlierSamples.size()) * 0.01, 2);
+        // PESR genotype overdispersion uses a threshold computed over all samples (outliers included)
+        maxVFAllSamples = Math.max(getHeaderForVariants().getGenotypeSamples().size() * 0.01, 2);
 
         // Filter specific header lines
         final VCFHeader header = getHeaderForVariants();
@@ -148,7 +151,7 @@ public class SVReviseMultiallelicCnvs extends VariantWalker {
                 numGtOver2 += 1;
             }
         }
-        if (numGtOver2 > maxVF) {
+        if (numGtOver2 > maxVFAllSamples) {
             builder.attribute(GATKSVVCFConstants.PESR_GT_OVERDISPERSION, true);
         }
     }
@@ -178,7 +181,8 @@ public class SVReviseMultiallelicCnvs extends VariantWalker {
         final List<Integer> allowedAlleleIndices = Arrays.asList(-1, 0, 1);
         final boolean hasCn0Alt = variant.getAlternateAlleles().stream().anyMatch(a -> a.getDisplayString().equals("<CN0>"));
 
-        if (genotypes.stream().anyMatch(g -> g.getAlleles().stream().anyMatch(a -> !allowedAlleleIndices.contains(variant.getAlleleIndex(a))))) {
+        if (genotypes.stream().filter(g -> !outlierSamples.contains(g.getSampleName()))
+                .anyMatch(g -> g.getAlleles().stream().anyMatch(a -> !allowedAlleleIndices.contains(variant.getAlleleIndex(a))))) {
             gt5kbFilter = true;
         } else if ((eventLength >= MIN_MULTIALLELIC_EVENT_SIZE || hasCn0Alt) && !multiallelicFilter) {
             gt5kbFilter = true;
@@ -187,11 +191,11 @@ public class SVReviseMultiallelicCnvs extends VariantWalker {
         List<Genotype> updatedGenotypes = new ArrayList<>(genotypes.size());
         if (gt5kbFilter) {
             for (final Genotype genotype : genotypes) {
-                if (genotype.isNoCall() || !genotype.hasGQ()) {
+                if ((genotype.getPloidy() == 2 && genotype.isNoCall()) || !genotype.hasGQ()) {
                     updatedGenotypes.add(genotype);
                     continue;
                 }
-                
+
                 final GenotypeBuilder gb = new GenotypeBuilder(genotype);
                 final Object rdCn = genotype.getExtendedAttribute(GATKSVVCFConstants.RD_CN);
                 if (rdCn != null && Integer.parseInt(rdCn.toString()) >= 2) {
@@ -208,10 +212,10 @@ public class SVReviseMultiallelicCnvs extends VariantWalker {
 
         updatedGenotypes = new ArrayList<>(genotypes.size());
         if (multiallelicFilter) {
-            for (final Genotype genotype : genotypes) {               
+            for (final Genotype genotype : genotypes) {
                 final GenotypeBuilder gb = new GenotypeBuilder(genotype);
                 gb.noGQ();
-                gb.alleles(Arrays.asList(Allele.NO_CALL));
+                gb.alleles(Arrays.asList(Allele.NO_CALL, Allele.NO_CALL));
                 gb.attribute(GATKSVVCFConstants.COPY_NUMBER_FORMAT, genotype.getExtendedAttribute(GATKSVVCFConstants.RD_CN));
                 gb.attribute(GATKSVVCFConstants.COPY_NUMBER_QUALITY_FORMAT, genotype.getExtendedAttribute(GATKSVVCFConstants.RD_GQ));
                 updatedGenotypes.add(gb.make());
@@ -256,7 +260,8 @@ public class SVReviseMultiallelicCnvs extends VariantWalker {
         final List<Integer> allowedAlleleIndices = Arrays.asList(-1, 0, 1);
         final boolean hasCn0Alt = variant.getAlternateAlleles().stream().anyMatch(a -> a.getDisplayString().equals("<CN0>"));
 
-        if (genotypes.stream().anyMatch(g -> g.getAlleles().stream().anyMatch(a -> !allowedAlleleIndices.contains(variant.getAlleleIndex(a))))) {
+        if (genotypes.stream().filter(g -> !outlierSamples.contains(g.getSampleName()))
+                .anyMatch(g -> g.getAlleles().stream().anyMatch(a -> !allowedAlleleIndices.contains(variant.getAlleleIndex(a))))) {
             gt5kbFilter = true;
         } else if ((eventLength >= MIN_MULTIALLELIC_EVENT_SIZE || hasCn0Alt) && !multiallelicFilter) {
             gt5kbFilter = true;
@@ -265,7 +270,7 @@ public class SVReviseMultiallelicCnvs extends VariantWalker {
         List<Genotype> updatedGenotypes = new ArrayList<>(genotypes.size());
         if (gt5kbFilter) {
             for (final Genotype genotype : genotypes) {
-                if (genotype.isNoCall() || !genotype.hasGQ()) {
+                if ((genotype.getPloidy() == 2 && genotype.isNoCall()) || !genotype.hasGQ()) {
                     updatedGenotypes.add(genotype);
                     continue;
                 }
@@ -289,7 +294,7 @@ public class SVReviseMultiallelicCnvs extends VariantWalker {
             for (final Genotype genotype : genotypes) {
                 final GenotypeBuilder gb = new GenotypeBuilder(genotype);
                 gb.noGQ();
-                gb.alleles(Arrays.asList(Allele.NO_CALL));
+                gb.alleles(Arrays.asList(Allele.NO_CALL, Allele.NO_CALL));
                 gb.attribute(GATKSVVCFConstants.COPY_NUMBER_FORMAT, genotype.getExtendedAttribute(GATKSVVCFConstants.RD_CN));
                 gb.attribute(GATKSVVCFConstants.COPY_NUMBER_QUALITY_FORMAT, genotype.getExtendedAttribute(GATKSVVCFConstants.RD_GQ));
                 updatedGenotypes.add(gb.make());
@@ -328,6 +333,7 @@ public class SVReviseMultiallelicCnvs extends VariantWalker {
         if (alleles.size() == 1 && alleles.get(0).isReference()) return true;
         else if (alleles.size() == 2 && alleles.get(0).isReference() && alleles.get(1).isReference()) return true;
         else if (alleles.size() == 1 && alleles.get(0).isNoCall()) return true;
+        else if (alleles.size() == 2 && alleles.get(0).isNoCall() && alleles.get(1).isNoCall()) return true;
         return false;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVReviseOverlappingCnvs.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVReviseOverlappingCnvs.java
@@ -472,11 +472,16 @@ public class SVReviseOverlappingCnvs extends MultiplePassVariantWalker {
 
         Map<String, Set<String>> supportMap = new HashMap<>();
         for (final Genotype genotype : variant.getGenotypes()) {
-            final String supportStr = genotype.hasExtendedAttribute(GATKSVVCFConstants.EV)
+            final String rawEv = genotype.hasExtendedAttribute(GATKSVVCFConstants.EV)
                     ? genotype.getExtendedAttribute(GATKSVVCFConstants.EV).toString()
                     : "";
+            // EV may be encoded as a numeric index into GATKSVVCFConstants.EV_VALUES rather than
+            // the resolved comma-delimited support string, depending on upstream VCF formatting.
+            final String supportStr = rawEv.matches("\\d+")
+                    ? GATKSVVCFConstants.EV_VALUES.get(Integer.parseInt(rawEv))
+                    : rawEv;
             final Set<String> supportSet = new HashSet<>();
-            if (!supportStr.isEmpty()) {
+            if (supportStr != null && !supportStr.isEmpty()) {
                 supportSet.addAll(Arrays.asList(supportStr.split(",")));
             }
             supportMap.put(genotype.getSampleName(), supportSet);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVReviseOverlappingCnvs.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVReviseOverlappingCnvs.java
@@ -363,8 +363,7 @@ public class SVReviseOverlappingCnvs extends MultiplePassVariantWalker {
             final String sampleName = entry.getKey();
             final Genotype genotype = variant.getGenotype(sampleName);
 
-            // Skip true no-call genotypes (e.g., females on chrY); depth-only placeholder
-            // genotypes are haploid no-calls and must still be eligible for revision.
+            // Skip true no-call genotypes (e.g., females on chrY); depth-only no-calls are haploid and still eligible
             if (genotype.getPloidy() == 2 && genotype.isNoCall()) {
                 continue;
             }
@@ -412,8 +411,7 @@ public class SVReviseOverlappingCnvs extends MultiplePassVariantWalker {
         for (final Genotype genotype : genotypes) {
             final String sampleName = genotype.getSampleName();
 
-            // Skip true no-call genotypes (e.g., females on chrY); depth-only placeholder
-            // genotypes are haploid no-calls and must still be eligible for revision.
+            // Skip true no-call genotypes (e.g., females on chrY); depth-only no-calls are haploid and still eligible
             if (genotype.getPloidy() == 2 && genotype.isNoCall()) {
                 updatedGenotypes.add(genotype);
                 continue;
@@ -475,8 +473,7 @@ public class SVReviseOverlappingCnvs extends MultiplePassVariantWalker {
             final String rawEv = genotype.hasExtendedAttribute(GATKSVVCFConstants.EV)
                     ? genotype.getExtendedAttribute(GATKSVVCFConstants.EV).toString()
                     : "";
-            // EV may be encoded as a numeric index into GATKSVVCFConstants.EV_VALUES rather than
-            // the resolved comma-delimited support string, depending on upstream VCF formatting.
+            // EV may be a numeric index into GATKSVVCFConstants.EV_VALUES instead of the resolved support string
             final String supportStr = rawEv.matches("\\d+")
                     ? GATKSVVCFConstants.EV_VALUES.get(Integer.parseInt(rawEv))
                     : rawEv;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVReviseOverlappingCnvs.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVReviseOverlappingCnvs.java
@@ -362,12 +362,13 @@ public class SVReviseOverlappingCnvs extends MultiplePassVariantWalker {
 
             final String sampleName = entry.getKey();
             final Genotype genotype = variant.getGenotype(sampleName);
-            
-            // Skip no-call genotypes (e.g., females on chrY)
-            if (genotype.isNoCall()) {
+
+            // Skip true no-call genotypes (e.g., females on chrY); depth-only placeholder
+            // genotypes are haploid no-calls and must still be eligible for revision.
+            if (genotype.getPloidy() == 2 && genotype.isNoCall()) {
                 continue;
             }
-            
+
             final String largerId = event.getLeft();
             final String largerSvType = event.getRight();
             final int currentRdCn = currentCopyNumbers.get(variantId).getOrDefault(sampleName, 0);
@@ -383,10 +384,11 @@ public class SVReviseOverlappingCnvs extends MultiplePassVariantWalker {
             if (newVal != -1) {
                 final GenotypeBuilder gb = new GenotypeBuilder(genotype);
                 gb.alleles(Arrays.asList(variant.getReference(), variant.getAlternateAllele(0)));
-                if (!genotype.hasExtendedAttribute(GATKSVVCFConstants.RD_CN)) continue;
-
-                final int rdCn = Integer.parseInt(genotype.getExtendedAttribute(GATKSVVCFConstants.RD_CN).toString());
-                gb.GQ(rdCn);
+                if (genotype.hasExtendedAttribute(GATKSVVCFConstants.RD_GQ)) {
+                    gb.GQ(Integer.parseInt(genotype.getExtendedAttribute(GATKSVVCFConstants.RD_GQ).toString()));
+                } else {
+                    gb.noGQ();
+                }
                 revisedGenotypes.put(sampleName, gb.make());
             }
         }
@@ -409,9 +411,10 @@ public class SVReviseOverlappingCnvs extends MultiplePassVariantWalker {
         // Replace revised alleles and copy numbers
         for (final Genotype genotype : genotypes) {
             final String sampleName = genotype.getSampleName();
-            
-            // Skip no-call genotypes (e.g., females on chrY)
-            if (genotype.isNoCall()) {
+
+            // Skip true no-call genotypes (e.g., females on chrY); depth-only placeholder
+            // genotypes are haploid no-calls and must still be eligible for revision.
+            if (genotype.getPloidy() == 2 && genotype.isNoCall()) {
                 updatedGenotypes.add(genotype);
                 continue;
             }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVReviseOverlappingMultiallelics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVReviseOverlappingMultiallelics.java
@@ -36,13 +36,40 @@ public class SVReviseOverlappingMultiallelics extends MultiplePassVariantWalker 
     private VariantContextWriter vcfWriter;
 
     private final List<VariantContext> overlappingVariantsBuffer = new ArrayList<>();
+    private final List<OverlapCandidate> overlapCandidates = new ArrayList<>();
     private final Set<String> filteredVariantIds = new HashSet<>();
 
     @Override
     protected int numberOfPasses() { return 2; }
 
     @Override
-    protected void afterNthPass(int n) {}
+    protected void afterNthPass(final int n) {
+        if (n == 0) {
+            resolveRedundantMultiallelics();
+        }
+    }
+
+    /**
+     * Resolves which of each overlapping pair of multiallelic sites is redundant. Candidates must be
+     * processed in descending order of the driving (larger) variant's length, so that a larger variant's
+     * own redundancy status is always settled before it is used to judge smaller overlapping variants.
+     */
+    private void resolveRedundantMultiallelics() {
+        overlapCandidates.sort((a, b) -> {
+            final int cmp = Integer.compare(b.largerLength, a.largerLength);
+            if (cmp != 0) {
+                return cmp;
+            }
+            return Integer.compare(b.smallerLength, a.smallerLength);
+        });
+        for (final OverlapCandidate candidate : overlapCandidates) {
+            if (!filteredVariantIds.contains(candidate.largerId)) {
+                filteredVariantIds.add(candidate.smallerId);
+            }
+        }
+        overlapCandidates.clear();
+        overlappingVariantsBuffer.clear();
+    }
 
     @Override
     public void onTraversalStart() {
@@ -79,7 +106,7 @@ public class SVReviseOverlappingMultiallelics extends MultiplePassVariantWalker 
                 || (vc.getStart() + vc.getAttributeAsInt(GATKSVVCFConstants.SVLEN, 0)) < variant.getStart());
         for (final VariantContext bufferedVariant : overlappingVariantsBuffer) {
             if (overlaps(bufferedVariant, variant)) {
-                processVariantPair(bufferedVariant, variant);
+                collectVariantPair(bufferedVariant, variant);
             }
         }
         overlappingVariantsBuffer.add(variant);
@@ -94,7 +121,7 @@ public class SVReviseOverlappingMultiallelics extends MultiplePassVariantWalker 
         vcfWriter.add(builder.make());
     }
 
-    private void processVariantPair(final VariantContext v1, final VariantContext v2) {
+    private void collectVariantPair(final VariantContext v1, final VariantContext v2) {
         // Determine larger variant, swapping if necessary
         VariantContext largerVariant = v1;
         VariantContext smallerVariant = v2;
@@ -111,9 +138,22 @@ public class SVReviseOverlappingMultiallelics extends MultiplePassVariantWalker 
             return;
         }
 
-        // Filter variant based on conditions
-        if (!filteredVariantIds.contains(largerVariant.getID())) {
-            filteredVariantIds.add(smallerVariant.getID());
+        overlapCandidates.add(new OverlapCandidate(largerVariant.getID(), smallerVariant.getID(),
+                Math.max(length1, length2), Math.min(length1, length2)));
+    }
+
+    private static final class OverlapCandidate {
+        private final String largerId;
+        private final String smallerId;
+        private final int largerLength;
+        private final int smallerLength;
+
+        private OverlapCandidate(final String largerId, final String smallerId,
+                                  final int largerLength, final int smallerLength) {
+            this.largerId = largerId;
+            this.smallerId = smallerId;
+            this.largerLength = largerLength;
+            this.smallerLength = smallerLength;
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVReviseOverlappingMultiallelics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/sv/SVReviseOverlappingMultiallelics.java
@@ -49,11 +49,7 @@ public class SVReviseOverlappingMultiallelics extends MultiplePassVariantWalker 
         }
     }
 
-    /**
-     * Resolves which of each overlapping pair of multiallelic sites is redundant. Candidates must be
-     * processed in descending order of the driving (larger) variant's length, so that a larger variant's
-     * own redundancy status is always settled before it is used to judge smaller overlapping variants.
-     */
+    // Resolves redundant multiallelic pairs, processing largest driving variant first so status settles before use
     private void resolveRedundantMultiallelics() {
         overlapCandidates.sort((a, b) -> {
             final int cmp = Integer.compare(b.largerLength, a.largerLength);


### PR DESCRIPTION
This PR is a follow-up from  #9319  - it resolves some disparities involved when migrating _CleanVcf_ into a GATK-based implementation. It is intended to accompany [this PR](https://github.com/broadinstitute/gatk-sv/pull/953) for GATK-SV.