### PR TITLE
Add --output-cram-version option (default 3.1) for CRAM output

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/StandardArgumentDefinitions.java
@@ -26,6 +26,7 @@ public final class StandardArgumentDefinitions {
     public static final String ENABLE_ALL_ANNOTATIONS = "enable-all-annotations";
     public static final String CREATE_OUTPUT_BAM_INDEX_LONG_NAME = "create-output-bam-index";
     public static final String CREATE_OUTPUT_BAM_MD5_LONG_NAME = "create-output-bam-md5";
+    public static final String OUTPUT_CRAM_VERSION_LONG_NAME = "output-cram-version";
     public static final String CREATE_OUTPUT_VARIANT_INDEX_LONG_NAME = "create-output-variant-index";
     public static final String CREATE_OUTPUT_VARIANT_MD5_LONG_NAME = "create-output-variant-md5";
     public static final String MAX_VARIANTS_PER_SHARD_LONG_NAME = "max-variants-per-shard";

--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -88,6 +88,12 @@ public abstract class GATKTool extends CommandLineProgram {
             doc = "If true, create a MD5 digest for any BAM/SAM/CRAM file created", optional=true, common = true)
     public boolean createOutputBamMD5 = false;
 
+    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_CRAM_VERSION_LONG_NAME,
+            doc = "The CRAM version ('3.0' or '3.1') to write for CRAM output. Ignored for BAM/SAM output. " +
+                  "Note that CRAM 3.1 (the default) cannot be read by tools that only support CRAM 3.0.",
+            optional = true, common = true)
+    public String outputCramVersion = ConfigFactory.getInstance().getGATKConfig().outputCramVersion();
+
     @Argument(fullName=StandardArgumentDefinitions.CREATE_OUTPUT_VARIANT_INDEX_LONG_NAME,
             shortName=StandardArgumentDefinitions.CREATE_OUTPUT_VARIANT_INDEX_SHORT_NAME,
             doc = "If true, create a VCF index when writing a coordinate-sorted VCF file.", optional=true, common = true)
@@ -864,7 +870,8 @@ public abstract class GATKTool extends CommandLineProgram {
                 getHeaderForSAMWriter(),
                 preSorted,
                 createOutputBamIndex,
-                createOutputBamMD5
+                createOutputBamMD5,
+                ReadUtils.getCRAMVersion(outputCramVersion)
             )
         );
     }

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
@@ -5,6 +5,7 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SBIIndexWriter;
 import htsjdk.samtools.SamFileHeaderMerger;
 import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
+import htsjdk.samtools.cram.common.CramVersions;
 import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.GZIIndex;
 import htsjdk.variant.vcf.VCFHeaderLine;
@@ -16,6 +17,7 @@ import org.broadinstitute.barclay.argparser.CommandLinePluginDescriptor;
 import org.broadinstitute.hellbender.cmdline.GATKPlugin.GATKAnnotationPluginDescriptor;
 import org.broadinstitute.hellbender.cmdline.GATKPlugin.GATKReadFilterPluginDescriptor;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.*;
 import org.broadinstitute.hellbender.engine.FeatureDataSource;
 import org.broadinstitute.hellbender.engine.FeatureManager;
@@ -133,6 +135,11 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
             shortName = StandardArgumentDefinitions.CREATE_OUTPUT_BAM_INDEX_SHORT_NAME,
             doc = "If true, create a BAM index when writing a coordinate-sorted BAM file.", optional = true, common = true)
     public boolean createOutputBamIndex = ConfigFactory.getInstance().getGATKConfig().createOutputBamIndex();
+
+    @Argument(fullName = StandardArgumentDefinitions.OUTPUT_CRAM_VERSION_LONG_NAME,
+            doc = "The CRAM version to write for CRAM output. Spark tools can only write CRAM 3.1; specifying 3.0 will cause the tool to fail.",
+            optional = true, common = true)
+    public String outputCramVersion = ConfigFactory.getInstance().getGATKConfig().outputCramVersion();
 
     @Argument(fullName = CREATE_OUTPUT_BAM_SPLITTING_INDEX_LONG_NAME,
             doc = "If true, create a BAM splitting index (SBI) when writing a coordinate-sorted BAM file.", optional = true, common = true)
@@ -359,6 +366,17 @@ public abstract class GATKSparkTool extends SparkCommandLineProgram {
      * @param header the header to write.
      */
     public void writeReads(final JavaSparkContext ctx, final String outputFile, JavaRDD<GATKRead> reads, SAMFileHeader header, final boolean sortReadsToHeader) {
+        // The Spark CRAM writer (via disq) can only produce CRAM 3.1; it cannot honor a 3.0 request. Fail loudly
+        // rather than silently writing 3.1 when the user asked for 3.0. (getCRAMVersion also validates the value.)
+        if (outputFile.endsWith(FileExtensions.CRAM) && ReadUtils.getCRAMVersion(outputCramVersion) == CramVersions.CRAM_v3) {
+            throw new UserException(String.format(
+                    "CRAM 3.0 output is not supported by GATK Spark tools.%n" +
+                    "The Spark CRAM writer can only produce CRAM 3.1, but '3.0' was requested via --%s.%n" +
+                    "To write CRAM 3.0, use the equivalent non-Spark tool (e.g. PrintReads instead of PrintReadsSpark); " +
+                    "otherwise omit --%s (or set it to 3.1) to write CRAM 3.1.",
+                    StandardArgumentDefinitions.OUTPUT_CRAM_VERSION_LONG_NAME,
+                    StandardArgumentDefinitions.OUTPUT_CRAM_VERSION_LONG_NAME));
+        }
         try {
             ReadsSparkSink.writeReads(ctx, outputFile,
                     hasReference() ? referenceArguments.getReferenceSpecifier() : null,

--- a/src/main/java/org/broadinstitute/hellbender/utils/config/GATKConfig.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/config/GATKConfig.java
@@ -172,4 +172,7 @@ public interface GATKConfig extends Mutable, Accessible {
 
     @DefaultValue("true")
     boolean createOutputBamIndex();
+
+    @DefaultValue("3.1")
+    String outputCramVersion();
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ReadUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ReadUtils.java
@@ -1,6 +1,9 @@
 package org.broadinstitute.hellbender.utils.read;
 
 import htsjdk.samtools.*;
+import htsjdk.samtools.cram.common.CRAMVersion;
+import htsjdk.samtools.cram.common.CramVersions;
+import htsjdk.samtools.cram.structure.CRAMEncodingStrategy;
 import htsjdk.samtools.util.FileExtensions;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -948,8 +951,27 @@ public final class ReadUtils {
         final Path referenceFile,
         final SAMFileHeader header,
         final boolean preSorted,
-        boolean createOutputBamIndex,
+        final boolean createOutputBamIndex,
         final boolean createMD5)
+    {
+        return createCommonSAMWriter(outputPath, referenceFile, header, preSorted, createOutputBamIndex, createMD5, null);
+    }
+
+    /**
+     * Create a common SAMFileWriter for use with GATK tools, requesting a specific CRAM version for CRAM output.
+     *
+     * @param cramVersion - the CRAM version to write for CRAM output; if null, htsjdk's default is used. Ignored for
+     *                      non-CRAM output.
+     * @see #createCommonSAMWriter(Path, Path, SAMFileHeader, boolean, boolean, boolean)
+     */
+    public static SAMFileWriter createCommonSAMWriter(
+        final Path outputPath,
+        final Path referenceFile,
+        final SAMFileHeader header,
+        final boolean preSorted,
+        boolean createOutputBamIndex,
+        final boolean createMD5,
+        final CRAMVersion cramVersion)
     {
         Utils.nonNull(outputPath);
         Utils.nonNull(header);
@@ -961,7 +983,26 @@ public final class ReadUtils {
         }
 
         final SAMFileWriterFactory factory = new SAMFileWriterFactory().setCreateIndex(createOutputBamIndex).setCreateMd5File(createMD5);
+        if (cramVersion != null && outputPath.toString().endsWith(FileExtensions.CRAM)) {
+            // Only affects CRAM output; BAM/SAM writers ignore the encoding strategy.
+            factory.setCRAMEncodingStrategy(new CRAMEncodingStrategy().setCramVersion(cramVersion));
+        }
         return ReadUtils.createCommonSAMWriterFromFactory(factory, outputPath, referenceFile, header, preSorted);
+    }
+
+    /**
+     * Map a user-supplied CRAM version string ("3.0" or "3.1") to the corresponding htsjdk {@link CRAMVersion},
+     * throwing a {@link UserException.BadInput} for any other value.
+     */
+    public static CRAMVersion getCRAMVersion(final String cramVersionString) {
+        Utils.nonNull(cramVersionString);
+        switch (cramVersionString.trim()) {
+            case "3.0": return CramVersions.CRAM_v3;
+            case "3.1": return CramVersions.CRAM_v3_1;
+            default:
+                throw new UserException.BadInput(String.format(
+                    "Unsupported CRAM version '%s'. Supported values are '3.0' and '3.1'.", cramVersionString));
+        }
     }
 
     /**

--- a/src/main/resources/org/broadinstitute/hellbender/utils/config/GATKConfig.properties
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/config/GATKConfig.properties
@@ -83,4 +83,5 @@ annotation_packages = org.broadinstitute.hellbender.tools.walkers.annotator
 cloudPrefetchBuffer = 40
 cloudIndexPrefetchBuffer = -1
 createOutputBamIndex = true
+outputCramVersion = 3.1
 gcsMaxRetries = 20

--- a/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
@@ -22,6 +22,47 @@ import java.util.List;
 
 public final class PrintReadsIntegrationTest extends AbstractPrintReadsIntegrationTest {
 
+    @DataProvider(name = "cramVersionData")
+    public Object[][] cramVersionData() {
+        return new Object[][] {
+                {null,  (byte) 3, (byte) 1}, // default -> htsjdk default (3.1)
+                {"3.0", (byte) 3, (byte) 0},
+                {"3.1", (byte) 3, (byte) 1},
+        };
+    }
+
+    @Test(dataProvider = "cramVersionData")
+    public void testOutputCramVersion(final String requestedVersion, final byte expectedMajor, final byte expectedMinor) throws IOException {
+        final File in = new File(TEST_DATA_DIR, "print_reads.bam");
+        final File ref = new File(TEST_DATA_DIR, "print_reads.fasta");
+        final File out = createTempFile("printreads.cramversion", ".cram");
+
+        final ArgumentsBuilder args = new ArgumentsBuilder()
+                .addInput(in)
+                .addReference(ref)
+                .addOutput(out);
+        if (requestedVersion != null) {
+            args.add(StandardArgumentDefinitions.OUTPUT_CRAM_VERSION_LONG_NAME, requestedVersion);
+        }
+        runCommandLine(args);
+
+        final byte[] magic = new byte[6];
+        try (final java.io.InputStream is = new java.io.FileInputStream(out)) { is.read(magic); }
+        Assert.assertEquals(new String(magic, 0, 4), "CRAM");
+        Assert.assertEquals(magic[4], expectedMajor, "CRAM major version");
+        Assert.assertEquals(magic[5], expectedMinor, "CRAM minor version");
+    }
+
+    @Test(expectedExceptions = org.broadinstitute.hellbender.exceptions.UserException.BadInput.class)
+    public void testOutputCramVersionRejectsBadValue() {
+        final File in = new File(TEST_DATA_DIR, "print_reads.bam");
+        final File ref = new File(TEST_DATA_DIR, "print_reads.fasta");
+        final File out = createTempFile("printreads.badcramversion", ".cram");
+        runCommandLine(new ArgumentsBuilder()
+                .addInput(in).addReference(ref).addOutput(out)
+                .add(StandardArgumentDefinitions.OUTPUT_CRAM_VERSION_LONG_NAME, "3.2"));
+    }
+
     @Test(dataProvider="testingData")
     public void testFileToFileWithMD5(String fileIn, String extOut, String reference) throws Exception {
         doFileToFile(fileIn, extOut, reference, true);

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintReadsSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintReadsSparkIntegrationTest.java
@@ -31,6 +31,38 @@ import java.util.List;
 @Test(groups = "spark")
 public final class PrintReadsSparkIntegrationTest extends AbstractPrintReadsIntegrationTest {
 
+    // Spark CRAM output (via disq) can only write CRAM 3.1; requesting 3.0 must fail loudly rather than
+    // silently writing 3.1.
+    @Test(groups = "spark", expectedExceptions = org.broadinstitute.hellbender.exceptions.UserException.class)
+    public void testOutputCramVersion30FailsOnSpark() {
+        final File in = new File(getTestDataDir(), "print_reads.bam");
+        final File ref = new File(getTestDataDir(), "print_reads.fasta");
+        final File out = GATKBaseTest.createTempFile("printReadsSpark.cramversion", ".cram");
+        runCommandLine(new ArgumentsBuilder()
+                .addInput(in)
+                .addReference(ref)
+                .addOutput(out)
+                .add(StandardArgumentDefinitions.OUTPUT_CRAM_VERSION_LONG_NAME, "3.0"));
+    }
+
+    // Explicitly requesting the supported version (3.1) on the CLI must succeed and write CRAM 3.1.
+    @Test(groups = "spark")
+    public void testOutputCramVersion31SucceedsOnSpark() throws java.io.IOException {
+        final File in = new File(getTestDataDir(), "print_reads.bam");
+        final File ref = new File(getTestDataDir(), "print_reads.fasta");
+        final File out = GATKBaseTest.createTempFile("printReadsSpark.cramversion31", ".cram");
+        runCommandLine(new ArgumentsBuilder()
+                .addInput(in)
+                .addReference(ref)
+                .addOutput(out)
+                .add(StandardArgumentDefinitions.OUTPUT_CRAM_VERSION_LONG_NAME, "3.1"));
+        final byte[] magic = new byte[6];
+        try (final java.io.InputStream is = new java.io.FileInputStream(out)) { is.read(magic); }
+        Assert.assertEquals(new String(magic, 0, 4), "CRAM");
+        Assert.assertEquals(magic[4], (byte) 3, "CRAM major version");
+        Assert.assertEquals(magic[5], (byte) 1, "CRAM minor version");
+    }
+
     @Test()
     public void testUnSortedRoundTrip() throws Exception {
         // This is a technically incorrectly sam with a header indicating that it is coordinate sorted when it is actually

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/ReadUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/ReadUtilsUnitTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.utils.read;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import htsjdk.samtools.*;
+import htsjdk.samtools.cram.common.CramVersions;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
 import htsjdk.samtools.util.SequenceUtil;
@@ -581,6 +582,46 @@ public final class ReadUtilsUnitTest extends GATKBaseTest {
     // NM/MD on the inputs so the FULL record - including NM/MD - survives the CRAM strip-and-regenerate
     // round-trip. Unlike testCreate*SAMWriter (which normalizes NM/MD/TLEN away), this asserts the
     // regenerated tags are correct rather than merely tolerated. CRAM cases only (needs a reference).
+    @DataProvider(name = "cramVersions")
+    public Object[][] cramVersions() {
+        return new Object[][] {
+                {CramVersions.CRAM_v3,   (byte) 3, (byte) 0},
+                {CramVersions.CRAM_v3_1, (byte) 3, (byte) 1},
+        };
+    }
+
+    // createCommonSAMWriter must honor the requested CRAM version (verified by the on-disk CRAM magic bytes).
+    @Test(dataProvider = "cramVersions")
+    public void testCreateCommonSAMWriterHonorsCramVersion(final htsjdk.samtools.cram.common.CRAMVersion requested,
+                                                           final byte expectedMajor, final byte expectedMinor) throws Exception {
+        final File sam = getTestFile("print_reads.sam");
+        final File ref = getTestFile("print_reads.fasta");
+        final File out = createTempFile("cramVersion", ".cram");
+        try (final SamReader reader = SamReaderFactory.makeDefault().referenceSequence(ref).open(sam);
+             final SAMFileWriter writer = ReadUtils.createCommonSAMWriter(
+                     out.toPath(), ref.toPath(), reader.getFileHeader(), false, false, false, requested)) {
+            for (final SAMRecord rec : reader) {
+                writer.addAlignment(rec);
+            }
+        }
+        final byte[] magic = new byte[6];
+        try (final java.io.InputStream is = new java.io.FileInputStream(out)) { is.read(magic); }
+        Assert.assertEquals(new String(magic, 0, 4), "CRAM");
+        Assert.assertEquals(magic[4], expectedMajor, "CRAM major version");
+        Assert.assertEquals(magic[5], expectedMinor, "CRAM minor version");
+    }
+
+    @Test
+    public void testGetCRAMVersionMapping() {
+        Assert.assertSame(ReadUtils.getCRAMVersion("3.0"), CramVersions.CRAM_v3);
+        Assert.assertSame(ReadUtils.getCRAMVersion("3.1"), CramVersions.CRAM_v3_1);
+    }
+
+    @Test(expectedExceptions = org.broadinstitute.hellbender.exceptions.UserException.BadInput.class)
+    public void testGetCRAMVersionRejectsBadValue() {
+        ReadUtils.getCRAMVersion("3.2");
+    }
+
     @Test(dataProvider = "createSAMWriter")
     public void testCreateSAMWriterCramLosslessNmMd(
             final File bamFile,


### PR DESCRIPTION
htsjdk 5.0.0 defaults CRAM writes to 3.1; some downstream tools only read 3.0. Add a common `--output-cram-version` argument (values 3.0/3.1, config-backed default 3.1 via GATKConfig) to control the CRAM output version.

- ReadUtils.createCommonSAMWriter: new overload accepting a CRAMVersion, applied via SAMFileWriterFactory.setCRAMEncodingStrategy for CRAM output only; getCRAMVersion(String) maps 3.0/3.1 to htsjdk CramVersions and rejects other values.
- GATKTool (walker tools): honors the requested version through createSAMWriter.
- GATKSparkTool: the Spark CRAM writer (disq) can only produce 3.1, so requesting 3.0 for CRAM output fails with a clear UserException rather than silently writing 3.1.

Tests: ReadUtilsUnitTest (writer honors version via on-disk magic bytes; version-string mapping and bad-value rejection); PrintReadsIntegrationTest (3.0/3.1/default end-to-end + bad value); PrintReadsSparkIntegrationTest (3.0 fails on Spark).