### PR TITLE
Make gcnvkernel work with current PyMC, PyTensor and NumPy

### DIFF
--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/__init__.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/__init__.py
@@ -1,4 +1,28 @@
+import warnings
+
 from pymc import __version__ as pymc_version
+
+# gcnvkernel uses PyMC's variational inference internals, so it is sensitive to PyMC releases.
+# MINIMUM_PYMC_VERSION is enforced; TESTED_PYMC_VERSION is the release this code is developed
+# and validated against, and anything else only warns, so that environments which cannot pin
+# PyMC exactly (Linux distributions, conda-forge, Homebrew, ...) are still able to run.
+MINIMUM_PYMC_VERSION = "5.10.1"
+TESTED_PYMC_VERSION = "5.10.1"
+
+
+def _version_tuple(version: str):
+    return tuple(int(part) for part in version.split(".")[:3] if part.isdigit())
+
+
+if _version_tuple(pymc_version) < _version_tuple(MINIMUM_PYMC_VERSION):
+    raise ImportError("gcnvkernel requires PyMC {0} or later; version found: {1}; "
+                      "please upgrade the PyMC module in your python environment "
+                      "accordingly.".format(MINIMUM_PYMC_VERSION, pymc_version))
+
+if pymc_version != TESTED_PYMC_VERSION:
+    warnings.warn("gcnvkernel is tested against PyMC {0}; version found: {1}. "
+                  "Results are expected to be correct but have not been validated "
+                  "against this version.".format(TESTED_PYMC_VERSION, pymc_version))
 
 from ._version import __version__
 from .io import io_commons, io_consts, io_ploidy, io_denoising_calling, \
@@ -25,7 +49,3 @@ from .tasks.task_cohort_denoising_calling import CohortDenoisingAndCallingMainTa
 from .tasks.task_cohort_ploidy_determination import CohortPloidyInferenceTask
 from .tasks.inference_task_base import ConvergenceError
 from .utils import cli_commons, math
-
-assert pymc_version == "5.10.1", "gcnvkernel currently only supports PyMC 5.10.1; version found: {0}; " \
-                                 "please upgrade or downgrade the PyMC module in your python environment " \
-                                 "accordingly.".format(pymc_version)

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/inference/deterministic_annealing.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/inference/deterministic_annealing.py
@@ -1,15 +1,15 @@
 import pymc as pm
-from .. import types
+from pymc.variational.approximations import MeanField
+from pymc.variational.inference import Inference
+from pymc.variational.opvi import Approximation, Operator
 
-Operator = pm.operators.Operator
-Inference = pm.Inference
-MeanField = pm.MeanField
+from .. import types
 
 
 class KLThermal(Operator):
     """Kullback-Leibler divergence operator with finite temperature."""
     def __init__(self,
-                 approx: pm.approximations.Approximation,
+                 approx: Approximation,
                  temperature: types.TensorSharedVariable):
         """Initializer.
 

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/inference/param_tracker.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/inference/param_tracker.py
@@ -42,7 +42,7 @@ class VariationalParameterTracker:
             self._var_trans_dict[var_name] = (inv_trans, inv_trans_var_name)
             self.tracked_var_values_dict[inv_trans_var_name] = []
 
-    def _extract_param_mean(self, approx: pm.approximations.MeanField) -> Dict[str, np.ndarray]:
+    def _extract_param_mean(self, approx: pm.MeanField) -> Dict[str, np.ndarray]:
         mu_flat_view = approx.mean.get_value(borrow=True)
         vmap_list = io_commons.get_var_map_list_from_mean_field_approx(approx)
         out = dict()

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_commons.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_commons.py
@@ -22,6 +22,24 @@ _logger = logging.getLogger(__name__)
 VarMap = collections.namedtuple('VarMap', 'var, slc, shp, dtyp')
 
 
+def scalar_to_str(value) -> str:
+    """Returns the string representation of a python or numpy scalar.
+
+    NumPy renders the repr of its scalars as e.g. "np.float64(1.0)" since 2.0.0, which the GATK
+    tools reading these files cannot parse, so numpy scalars are converted to the equivalent
+    python scalar first.
+
+    Args:
+        value: a python or numpy scalar
+
+    Returns:
+        a string
+    """
+    if isinstance(value, np.generic):
+        value = value.item()
+    return repr(value)
+
+
 def read_csv(input_file: str,
              dtypes_dict: Dict[str, object] = None,
              mandatory_columns_set: Set[str] = None,

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_denoising_calling.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_denoising_calling.py
@@ -132,7 +132,7 @@ class SampleDenoisingAndCallingPosteriorsWriter:
                     f.write(comment + comment_line + '\n')
             f.write(delimiter.join(copy_number_header_columns) + '\n')
             for ti in range(ndarray_tc.shape[0]):
-                f.write(delimiter.join([repr(x) for x in ndarray_tc[ti, :]]) + '\n')
+                f.write(delimiter.join([io_commons.scalar_to_str(x) for x in ndarray_tc[ti, :]]) + '\n')
 
     def __call__(self):
         # write gcnvkernel version

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_intervals_and_counts.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_intervals_and_counts.py
@@ -211,6 +211,7 @@ def write_interval_list_to_tsv_file(output_file: str, interval_list: List[Interv
                            + mutual_annotation_key_list)
         out.write(header + '\n')
         for interval in interval_list:
-            row = '\t'.join([interval.contig, repr(interval.start), repr(interval.end)] +
+            row = '\t'.join([interval.contig, io_commons.scalar_to_str(interval.start),
+                            io_commons.scalar_to_str(interval.end)] +
                             [str(interval.annotations[key]) for key in mutual_annotation_key_list])
             out.write(row + '\n')

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_metadata.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_metadata.py
@@ -43,7 +43,8 @@ def write_sample_coverage_metadata(sample_metadata_collection: SampleMetadataCol
         writer.writerow(header)
         for sample_name in sample_names:
             sample_coverage_metadata = sample_metadata_collection.get_sample_coverage_metadata(sample_name)
-            row = ([sample_name] + [repr(sample_coverage_metadata.n_j[j]) for j in range(len(contig_list))])
+            row = ([sample_name] + [io_commons.scalar_to_str(sample_coverage_metadata.n_j[j])
+                                    for j in range(len(contig_list))])
             writer.writerow(row)
 
 

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_ploidy.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/io/io_ploidy.py
@@ -90,8 +90,9 @@ class SamplePloidyWriter:
             f.write(header + '\n')
             for j, contig in enumerate(sample_ploidy_metadata.contig_list):
                 f.write(delimiter.join([contig,
-                                        repr(sample_ploidy_metadata.ploidy_j[j]),
-                                        repr(sample_ploidy_metadata.ploidy_genotyping_quality_j[j])]) + '\n')
+                                        io_commons.scalar_to_str(sample_ploidy_metadata.ploidy_j[j]),
+                                        io_commons.scalar_to_str(
+                                            sample_ploidy_metadata.ploidy_genotyping_quality_j[j])]) + '\n')
 
     @staticmethod
     def _write_sample_read_depth(sample_posterior_path: str,
@@ -106,8 +107,8 @@ class SamplePloidyWriter:
             header = delimiter.join([io_consts.global_read_depth_column_name,
                                      io_consts.average_ploidy_column_name])
             f.write(header + '\n')
-            f.write(delimiter.join([repr(sample_read_depth_metadata.global_read_depth),
-                                    repr(sample_read_depth_metadata.average_ploidy)]) + '\n')
+            f.write(delimiter.join([io_commons.scalar_to_str(sample_read_depth_metadata.global_read_depth),
+                                    io_commons.scalar_to_str(sample_read_depth_metadata.average_ploidy)]) + '\n')
 
     def __call__(self):
         for si, sample_name in enumerate(self.ploidy_workspace.sample_names):

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/commons.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/commons.py
@@ -9,6 +9,12 @@ from pymc.util import makeiter
 from pymc.variational.opvi import _known_scan_ignored_inputs
 from typing import Tuple, Generator
 
+try:
+    from pymc.pytensorf import compile_pymc
+except ImportError:
+    # PyMC renamed compile_pymc to compile in 5.16.0.
+    from pymc.pytensorf import compile as compile_pymc
+
 _logger = logging.getLogger(__name__)
 
 _log_2_pi = 1.837877066409345  # np.log(2 * np.pi)
@@ -241,7 +247,7 @@ def get_sampling_generator_for_model_approximation(approx: pm.MeanField, node,
     node_sample = approx.symbolic_sample_over_posterior(node)
     node_sample = approx.set_size_and_deterministic(node_sample, s=1, d=False)
     # must use compile_pymc to pass random_seed for reproducible sampling
-    node_sample_func = pm.pytensorf.compile_pymc(inputs=[], outputs=node_sample,
-                                                 random_seed=approx.rng.randint(2**30, dtype=np.int64))
+    node_sample_func = compile_pymc(inputs=[], outputs=node_sample,
+                                    random_seed=approx.rng.randint(2**30, dtype=np.int64))
 
     return (node_sample_func()[0] for _ in range(num_samples))

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/model_denoising_calling.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/model_denoising_calling.py
@@ -12,16 +12,16 @@ import scipy.sparse as sp
 import pytensor
 import pytensor.sparse as pst
 import pytensor.tensor as pt
-from pytensor.tensor.shape import unbroadcast
 from pymc import Normal, Deterministic, Potential, Lognormal, Exponential, TruncatedNormal, Uniform
 
 from . import commons
 from .fancy_model import GeneralizedContinuousModel
 from .pytensor_hmm import PytensorForwardBackward
-from .. import config, types
+from .. import config, pytensor_compat, types
 from ..structs.interval import Interval, GCContentAnnotation
 from ..structs.metadata import SampleMetadataCollection
 from ..tasks.inference_task_base import HybridInferenceParameters
+from ..pytensor_compat import SparseConstant, unbroadcast
 
 _logger = logging.getLogger(__name__)
 
@@ -450,7 +450,7 @@ class DenoisingCallingWorkspace:
 
         # GC bias factors
         # (to be initialized by calling `initialize_bias_inference_vars`)
-        self.W_gc_tg: Optional[pst.SparseConstant] = None
+        self.W_gc_tg: Optional[SparseConstant] = None
 
         # auxiliary data structures for hybrid q_c_expectation_mode calculation
         # (to be initialized by calling `initialize_bias_inference_vars`)
@@ -592,7 +592,7 @@ class DenoisingCallingWorkspace:
         return np.log(trans_tkl)
 
     @staticmethod
-    def _create_sparse_gc_bin_tensor_tg(interval_list: List[Interval], num_gc_bins: int) -> pst.SparseConstant:
+    def _create_sparse_gc_bin_tensor_tg(interval_list: List[Interval], num_gc_bins: int) -> SparseConstant:
         """Creates a sparse 2d pytensor tensor with shape (num_intervals, gc_bin). The sparse
         tensor represents a 1-hot mapping of each interval to its GC bin index. The range [0, 1]
         is uniformly divided into num_gc_bins.
@@ -611,7 +611,7 @@ class DenoisingCallingWorkspace:
         indptr = np.arange(0, num_intervals + 1)
         scipy_gc_matrix = sp.csr_matrix((data, indices, indptr), shape=(num_intervals, num_gc_bins),
                                         dtype=types.small_uint)
-        pytensor_gc_matrix: pst.SparseConstant = pst.as_sparse(scipy_gc_matrix)
+        pytensor_gc_matrix: SparseConstant = pst.as_sparse(scipy_gc_matrix)
         return pytensor_gc_matrix
 
     @staticmethod
@@ -705,7 +705,7 @@ class DenoisingModel(GeneralizedContinuousModel):
     # PR #8561 some broadcastable arguments in the distributions below in PyMC3 were removed
     """The gCNV coverage denoising model declaration (continuous RVs only; discrete posteriors are assumed
     to be given)."""
-    @pytensor.config.change_flags(compute_test_value="off")
+    @pytensor_compat.change_test_value_flag("off")
     def __init__(self,
                  denoising_model_config: DenoisingModelConfig,
                  shared_workspace: DenoisingCallingWorkspace,
@@ -888,7 +888,7 @@ class CopyNumberEmissionBasicSampler:
         self.denoising_model = denoising_model
         self._simultaneous_log_copy_number_emission_sampler = None
 
-    def update_approximation(self, approx: pm.approximations.MeanField):
+    def update_approximation(self, approx: pm.MeanField):
         """Generates a new compiled sampler based on a given approximation.
         Args:
             approx: an instance of PyMC mean-field approximation
@@ -907,16 +907,16 @@ class CopyNumberEmissionBasicSampler:
         assert self.is_sampler_initialized, "Posterior approximation is not provided yet"
         return self._simultaneous_log_copy_number_emission_sampler()
 
-    @pytensor.config.change_flags(compute_test_value="off")
-    def _get_compiled_simultaneous_log_copy_number_emission_sampler(self, approx: pm.approximations.MeanField):
+    @pytensor_compat.change_test_value_flag("off")
+    def _get_compiled_simultaneous_log_copy_number_emission_sampler(self, approx: pm.MeanField):
         """For a given variational approximation, returns a compiled pytensor function that draws posterior samples
         from log copy number emission probabilities."""
         log_copy_number_emission_stc = commons.stochastic_node_mean_symbolic(
             approx, self.denoising_model['log_copy_number_emission_stc'],
             size=self.inference_params.log_emission_samples_per_round)
         # must use compile_pymc to pass random_seed for reproducible sampling
-        return pm.pytensorf.compile_pymc(inputs=[], outputs=log_copy_number_emission_stc,
-                                         random_seed=approx.rng.randint(2**30, dtype=np.int64))
+        return commons.compile_pymc(inputs=[], outputs=log_copy_number_emission_stc,
+                                    random_seed=approx.rng.randint(2**30, dtype=np.int64))
 
 
 class HHMMClassAndCopyNumberBasicCaller:
@@ -1152,7 +1152,7 @@ class HHMMClassAndCopyNumberBasicCaller:
         self.shared_workspace.update_auxiliary_vars()
 
     @staticmethod
-    @pytensor.config.change_flags(compute_test_value="off")
+    @pytensor_compat.change_test_value_flag("off")
     def get_compiled_copy_number_hmm_specs_pytensor_func() -> pytensor.compile.Function:
         """Returns a compiled function that calculates the interval-class-averaged and probability-sum-normalized
         log copy number transition matrix and log copy number prior for the first interval
@@ -1177,7 +1177,7 @@ class HHMMClassAndCopyNumberBasicCaller:
         pi_jkc = pt.tensor3(name='pi_jkc')
         cnv_stay_prob_t = pt.vector(name='cnv_stay_prob_t')
         log_q_tau_tk = pt.matrix(name='log_q_tau_tk')
-        t_to_j_map = pt.vector(name='t_to_j_map', dtype=pytensor.scalar.uint32)
+        t_to_j_map = pt.vector(name='t_to_j_map', dtype=types.med_uint)
 
 
 
@@ -1206,7 +1206,7 @@ class HHMMClassAndCopyNumberBasicCaller:
 
         return pytensor.function(inputs=inputs, outputs=outputs)
 
-    @pytensor.config.change_flags(compute_test_value="off")
+    @pytensor_compat.change_test_value_flag("off")
     def _get_update_log_class_emission_tk_pytensor_func(self) -> pytensor.compile.Function:
         """Returns a compiled function that calculates the log interval class emission probability and
         directly updates `log_class_emission_tk` in the workspace.
@@ -1266,9 +1266,9 @@ class HHMMClassAndCopyNumberBasicCaller:
                 xi_tab.dimshuffle(0, 'x', 1, 2) * log_trans_tkab, axis=-1), axis=-1)
             return cum_sum_tk + current_log_class_emission_tk
 
-        reduce_output = pytensor.reduce(inc_log_class_emission_tk_except_for_first_interval,
-                                  sequences=[pi_sjkc, q_c_stc],
-                                  outputs_info=[log_class_emission_cum_sum_tk])
+        reduce_output = pytensor_compat.scan_reduce(inc_log_class_emission_tk_except_for_first_interval,
+                                                    sequences=[pi_sjkc, q_c_stc],
+                                                    outputs_info=[log_class_emission_cum_sum_tk])
         log_class_emission_tk_except_for_first_interval = reduce_output[0]
 
         # the first interval

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/model_ploidy.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/model_ploidy.py
@@ -11,7 +11,7 @@ from pymc import Normal, Deterministic, Potential, Exponential, TruncatedNormal,
 
 from . import commons
 from .fancy_model import GeneralizedContinuousModel
-from .. import config, types
+from .. import config, pytensor_compat, types
 from ..structs.metadata import IntervalListMetadata, SampleMetadataCollection
 from ..tasks.inference_task_base import HybridInferenceParameters
 
@@ -195,7 +195,7 @@ class PloidyModel(GeneralizedContinuousModel):
     """Declaration of the germline contig ploidy model (continuous variables only; posterior of discrete
     variables are assumed to be known)."""
 
-    @pytensor.config.change_flags(compute_test_value="off")
+    @pytensor_compat.change_test_value_flag("off")
     def __init__(self,
                  ploidy_config: PloidyModelConfig,
                  ploidy_workspace: PloidyWorkspace):
@@ -283,7 +283,7 @@ class PloidyEmissionBasicSampler:
         self.samples_per_round = samples_per_round
         self._simultaneous_log_ploidy_emission_sampler = None
 
-    def update_approximation(self, approx: pm.approximations.MeanField):
+    def update_approximation(self, approx: pm.MeanField):
         """Generates a new compiled sampler based on a given approximation.
         Args:
             approx: an instance of PyMC mean-field approximation
@@ -300,14 +300,14 @@ class PloidyEmissionBasicSampler:
     def draw(self) -> np.ndarray:
         return self._simultaneous_log_ploidy_emission_sampler()
 
-    @pytensor.config.change_flags(compute_test_value="off")
-    def _get_compiled_simultaneous_log_ploidy_emission_sampler(self, approx: pm.approximations.MeanField):
+    @pytensor_compat.change_test_value_flag("off")
+    def _get_compiled_simultaneous_log_ploidy_emission_sampler(self, approx: pm.MeanField):
         """For a given variational approximation, returns a compiled pytensor function that draws posterior samples
         from the log ploidy emission."""
         log_ploidy_emission_sjk = commons.stochastic_node_mean_symbolic(
             approx, self.ploidy_model['logp_sjk'], size=self.samples_per_round)
-        return pm.pytensorf.compile_pymc(inputs=[], outputs=log_ploidy_emission_sjk,
-                                         random_seed=approx.rng.randint(2**30, dtype=np.int64))
+        return commons.compile_pymc(inputs=[], outputs=log_ploidy_emission_sjk,
+                                    random_seed=approx.rng.randint(2**30, dtype=np.int64))
 
 
 class PloidyBasicCaller:
@@ -319,7 +319,7 @@ class PloidyBasicCaller:
         self.inference_params = inference_params
         self._update_log_q_ploidy_sjk_pytensor_func = self._get_update_log_q_ploidy_sjk_pytensor_func()
 
-    @pytensor.config.change_flags(compute_test_value="off")
+    @pytensor_compat.change_test_value_flag("off")
     def _get_update_log_q_ploidy_sjk_pytensor_func(self) -> pytensor.compile.Function:
         new_log_q_ploidy_sjk = (self.ploidy_workspace.log_p_ploidy_jk.dimshuffle('x', 0, 1)
                                 + self.ploidy_workspace.log_ploidy_emission_sjk)

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/pytensor_hmm.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/models/pytensor_hmm.py
@@ -6,7 +6,7 @@ import pytensor.tensor as pt
 
 from ..models import commons
 from ..models.commons import logsumexp
-from .. import types
+from .. import pytensor_compat, types
 
 
 class PytensorForwardBackward:
@@ -122,7 +122,7 @@ class PytensorForwardBackward:
             arg_idx += 1
         return result
 
-    @pytensor.config.change_flags(compute_test_value="ignore")
+    @pytensor_compat.change_test_value_flag("ignore")
     def _get_compiled_forward_backward_pytensor_func(self) -> pytensor.compile.Function:
         """Returns a compiled pytensor function that computes the posterior probabilities of hidden states using
         the forward-backward algorithm.
@@ -354,7 +354,7 @@ class PytensorViterbi:
                          log_emission_tc: np.ndarray) -> List[int]:
         return self._viterbi_pytensor_func(log_prior_c, log_trans_tcc, log_emission_tc).tolist()
 
-    @pytensor.config.change_flags(compute_test_value="ignore")
+    @pytensor_compat.change_test_value_flag("ignore")
     def _get_compiled_viterbi_pytensor_func(self) -> pytensor.compile.Function:
         """Returns a pytensor function that calculates the Viterbi path."""
         log_prior_c = pt.vector('log_prior_c')

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/postprocess/segment_quality_utils.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/postprocess/segment_quality_utils.py
@@ -8,6 +8,7 @@ from ..models import commons
 from scipy.special import logsumexp
 
 from ..utils.math import logsumexp_double_complement, logp_to_phred
+from .. import pytensor_compat
 
 _logger = logging.getLogger(__name__)
 
@@ -67,7 +68,7 @@ class HMMSegmentationQualityCalculator:
             for left_out_state in range(self.num_states)}
 
     @staticmethod
-    @pytensor.config.change_flags(compute_test_value="ignore")
+    @pytensor_compat.change_test_value_flag("ignore")
     def _get_compiled_constrained_path_logp_pytensor_func() -> pytensor.compile.Function:
         """Returns a pytensor function that calculates the log posterior probability of hidden state paths composed
         from a subset X of all hidden states S.

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/pytensor_compat.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/pytensor_compat.py
@@ -1,0 +1,64 @@
+import pytensor
+
+
+def change_test_value_flag(mode: str):
+    """Returns a decorator that sets PyTensor's `compute_test_value` flag for the decorated callable.
+
+    PyTensor removed test values, along with the `compute_test_value` configuration flag, in 3.0.0.
+    Setting the flag there raises a KeyError, so the decorator is a no-op with those versions.
+
+    Args:
+        mode: value for the `compute_test_value` flag, e.g. "off" or "ignore"
+
+    Returns:
+        a decorator
+    """
+    if hasattr(pytensor.config, "compute_test_value"):
+        return pytensor.config.change_flags(compute_test_value=mode)
+
+    def identity_decorator(func):
+        return func
+
+    return identity_decorator
+
+
+try:
+    from pytensor.tensor.shape import unbroadcast
+except ImportError:
+    def unbroadcast(x, *axes):
+        """Returns `x` unchanged.
+
+        PyTensor removed broadcastable flags, along with `unbroadcast`, in 3.0.0: a dimension of
+        static shape 1 is no longer implicitly broadcastable there, so nothing has to be undone.
+        """
+        return x
+
+
+try:
+    from pytensor.sparse import SparseConstant
+except ImportError:
+    # PyTensor renamed SparseConstant to Constant in 3.0.0.
+    from pytensor.sparse import Constant as SparseConstant
+
+
+try:
+    from pytensor import reduce as scan_reduce
+except ImportError:
+    def scan_reduce(fn, sequences, outputs_info, non_sequences=None, go_backwards=False,
+                    mode=None, name=None):
+        """Constructs a `Scan` `Op` that functions like `reduce`, returning only the last step.
+
+        PyTensor removed the scan views (`reduce`, `foldl`, `foldr`, `map`) in 3.0.0; this is the
+        implementation they had, expressed with `pytensor.scan`.
+        """
+        outputs, updates = pytensor.scan(fn=fn,
+                                         sequences=sequences,
+                                         outputs_info=outputs_info,
+                                         non_sequences=non_sequences,
+                                         go_backwards=go_backwards,
+                                         truncate_gradient=-1,
+                                         mode=mode,
+                                         name=name)
+        if isinstance(outputs, (list, tuple)):
+            return [output[-1] for output in outputs], updates
+        return outputs[-1], updates

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/structs/segment.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/structs/segment.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from .. import config
-from ..io import io_consts
+from ..io import io_commons, io_consts
 
 
 class IntegerCopyNumberSegment:
@@ -60,11 +60,11 @@ class IntegerCopyNumberSegment:
 
     def __repr__(self):
         return '\t'.join([self.contig,
-                          repr(self.start),
-                          repr(self.end),
-                          repr(self.num_points),
-                          repr(self.call_copy_number),
-                          repr(self.baseline_copy_number),
+                          io_commons.scalar_to_str(self.start),
+                          io_commons.scalar_to_str(self.end),
+                          io_commons.scalar_to_str(self.num_points),
+                          io_commons.scalar_to_str(self.call_copy_number),
+                          io_commons.scalar_to_str(self.baseline_copy_number),
                           self._repr_quality(self.quality_some_called),
                           self._repr_quality(self.quality_all_called),
                           self._repr_quality(self.quality_start),

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/tasks/inference_task_base.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/tasks/inference_task_base.py
@@ -36,7 +36,7 @@ class Sampler:
         self.hybrid_inference_params = hybrid_inference_params
 
     @abstractmethod
-    def update_approximation(self, approx: pm.approximations.MeanField) -> None:
+    def update_approximation(self, approx: pm.MeanField) -> None:
         """Take a new mean-field approximation and update the sampler routine accordingly.
 
         Args:

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/tasks/task_cohort_denoising_calling.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/tasks/task_cohort_denoising_calling.py
@@ -111,7 +111,7 @@ class CopyNumberEmissionSampler(Sampler):
         self.copy_number_emission_basic_sampler = CopyNumberEmissionBasicSampler(
             denoising_config, calling_config, hybrid_inference_params, shared_workspace, denoising_model)
 
-    def update_approximation(self, approx: pm.approximations.MeanField):
+    def update_approximation(self, approx: pm.MeanField):
         self.copy_number_emission_basic_sampler.update_approximation(approx)
 
     def draw(self) -> np.ndarray:

--- a/src/main/python/org/broadinstitute/hellbender/gcnvkernel/tasks/task_cohort_ploidy_determination.py
+++ b/src/main/python/org/broadinstitute/hellbender/gcnvkernel/tasks/task_cohort_ploidy_determination.py
@@ -61,7 +61,7 @@ class PloidyEmissionSampler(Sampler):
         self.ploidy_emission_basic_sampler = PloidyEmissionBasicSampler(
             ploidy_model, self.hybrid_inference_params.log_emission_samples_per_round)
 
-    def update_approximation(self, approx: pm.approximations.MeanField):
+    def update_approximation(self, approx: pm.MeanField):
         self.ploidy_emission_basic_sampler.update_approximation(approx)
 
     def draw(self) -> np.ndarray:


### PR DESCRIPTION
gcnvkernel asserts `pymc_version == "5.10.1"` on import and uses a number of APIs that PyMC 6, PyTensor 3 and NumPy 2 have moved or removed. In practice this means the gCNV tools can only run inside an environment pinned to the exact versions in `gatkcondaenv.yml`, which is a problem for anyone packaging GATK outside conda (Linux distributions, conda-forge, Homebrew), where PyMC is a shared dependency that cannot be pinned to a 2023 release.

This makes the same code work on both.

**Version check.** The hard assertion becomes a minimum-version check (`MINIMUM_PYMC_VERSION`), plus a warning when the version is not the tested one (`TESTED_PYMC_VERSION`, still 5.10.1). It also runs before the rest of the package is imported, so a too-old PyMC now produces the intended message instead of an `AttributeError` from a submodule.

**Moved APIs**, reached through their canonical locations, which exist in 5.10.1 as well:

- `pm.operators.Operator`, `pm.approximations.Approximation` / `.MeanField`, `pm.Inference` → `pymc.variational.opvi` / `.approximations` / `.inference`

**Removed APIs**, behind shims in the new `gcnvkernel/pytensor_compat.py`, each falling back to the current implementation when the old name is gone:

- `pytensor.reduce` (the scan views were removed in PyTensor 3) → the same thing expressed with `pytensor.scan`
- `unbroadcast` → a no-op, since PyTensor 3 no longer makes a static shape of 1 implicitly broadcastable
- the `compute_test_value` flag → the decorator becomes a no-op where test values no longer exist
- `pytensor.sparse.SparseConstant` → `pytensor.sparse.Constant`
- `pymc.pytensorf.compile_pymc` → `pymc.pytensorf.compile`
- `pt.vector(dtype=pytensor.scalar.uint32)` → `dtype=types.med_uint`, as PyTensor 3 no longer converts a `ScalarType` to a NumPy dtype

**NumPy 2 output formatting.** The `.tsv` writers used `repr()` on NumPy scalars, which NumPy 2 renders as `np.float64(-29.02)` / `np.uint16(2)`. GATK then rejects its own output, e.g. `format error in copy_number_segments.tsv at line 9: expected int value for column BASELINE_COPY_NUMBER but found np.uint16(2)`. A small `io_commons.scalar_to_str` helper converts NumPy scalars to their Python equivalent first, which reproduces the NumPy 1 formatting exactly.

## Testing

Run on macOS 26.6 arm64, Java 17, with `TEST_TYPE=conda` over `GermlineCNVCallerIntegrationTest`, `DetermineGermlineContigPloidyIntegrationTest` and `PostprocessGermlineCNVCallsIntegrationTest`.

- **PyMC 5.10.1 / PyTensor 2.18.3 / NumPy 1.26.2** (the pinned environment): 37 tests, 37 successes. `testNumericalAccuracy` still matches the committed expected outputs to 1E-6, so the change is a no-op for the environment GATK ships.
- **PyMC 6.3.1 / PyTensor 3.3.0 / NumPy 2.4.6**: 37 tests, 36 successes. Only `testNumericalAccuracy` fails, which compares against expected outputs generated under the pinned environment.

On that one failure, comparing a `GermlineCNVCaller` COHORT run over the 20 simulated samples on `sim_intervals_shard_0` against `gcnv-numerical-accuracy`:

- the copy-number calls are identical on 170/170 intervals, and the posterior probability of the called state differs by at most 1.7E-5
- model parameters agree closely: `mu_W_tu` max |diff| 0.088, `mu_psi_t_log__` 0.032, `mu_denoised_copy_ratio_t` 0.024, `std_*` below 0.004
- the large deltas the test reports are in log space on states with negligible probability (`log_q_tau_tk` max |diff| 1.386, mean 0.080, correlation 0.9996)
- two consecutive runs under the new stack produce byte-identical model files, so the difference is a deterministic consequence of the different PyMC/PyTensor release, not run-to-run noise

I have not regenerated the expected outputs, since they should track whichever environment GATK ships; `UPDATE_EXACT_MATCH_EXPECTED_OUTPUTS` is left disabled. `gatkcondaenv.yml` is unchanged: this PR only lifts the restriction, it does not move the official environment.

Happy to adjust the version constants, split the NumPy 2 formatting fix into its own PR, or add the compatibility shims somewhere other than a new module if you would prefer.