### PR TITLE
Allow building and packaging GATK outside of a git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,17 @@ For more details on system packages, see the GATK [Base Dockerfile](scripts/dock
 * The version number is automatically derived from the git history using `git describe`, you can override it by setting the `versionOverride` property.
   ( `./gradlew -DversionOverride=my_weird_version printVersion` )
 
+* **Building from a source archive (packagers):** GATK can also be built outside of a git clone, from a source
+  archive such as a GitHub source tarball, which is useful when packaging GATK for a distribution. Since the
+  version can't be derived from the git history in that case, it has to be supplied explicitly, which also tells
+  the build not to require a git clone:
+
+        ./gradlew -DversionOverride=4.7.0.0 -Drelease=true localJar
+
+  The large runtime resource files under `src/main/resources/large` are stored in git-lfs, and a source archive
+  contains only their git-lfs stub files. When git-lfs isn't available to resolve them, the build downloads them
+  from the git-lfs server itself and verifies each one against the sha256 recorded in the stub file it replaces.
+
 ## <a name="running">Running GATK4</a>
 
 * The standard way to run GATK4 tools is via the **`gatk`** wrapper script located in the root directory of a clone of this repository.
@@ -209,6 +220,7 @@ For more details on system packages, see the GATK [Base Dockerfile](scripts/dock
         * By extracting the zip archive produced by `./gradlew bundle` to a directory, and running `gatk` from there
         * Manually putting the `gatk` script within the same directory as fully-packaged GATK jars produced by `./gradlew localJar` and/or `./gradlew sparkJar`
         * Defining the environment variables `GATK_LOCAL_JAR` and `GATK_SPARK_JAR`, and setting them to the paths to the GATK jars produced by `./gradlew localJar` and/or `./gradlew sparkJar` 
+    * By default `gatk` runs packaged jars with `java` from the `PATH`. Setting the `GATK_JAVA` environment variable to the path of a java executable uses that one instead, which lets an installation pin the java it was tested against.
     * `gatk` can run non-Spark tools as well as Spark tools, and can run Spark tools locally, on a Spark cluster, or on Google Cloud Dataproc.
     * ***Note:*** running with `java -jar` directly and bypassing `gatk` causes several important system properties to not get set, including htsjdk compression level!
     

--- a/build.gradle
+++ b/build.gradle
@@ -86,8 +86,9 @@ final gatkCondaYML = "gatkcondaenv.yml"
 final largeResourcesFolder = "src/main/resources/large"
 final buildPrerequisitesMessage = "See https://github.com/broadinstitute/gatk#building for information on how to build GATK."
 
-// Returns true if any files in the target folder are git-lfs stub files.
-def checkForLFSStubFiles(targetFolder) {
+// Returns the git-lfs stub files in the target folder. A stub file is a small text file that
+// stands in for the real content, recording the sha256 ("oid") and the size of that content.
+def findLFSStubFiles(targetFolder) {
     final lfsStubFileHeader = "version https://git-lfs.github.com/spec/v1"  // first line of a git-lfs stub file
     def readBytesFromFile = { largeFile, n ->
         final byte[] bytes = new byte[n]
@@ -95,38 +96,127 @@ def checkForLFSStubFiles(targetFolder) {
         return bytes
     }
     def targetFiles = fileTree(dir: targetFolder)
-    return targetFiles.any() { f ->
+    return targetFiles.findAll() { f ->
         final byte[] actualBytes = readBytesFromFile(f, lfsStubFileHeader.length())
         return new String(actualBytes, "UTF-8") == lfsStubFileHeader
     }
 }
 
-// if any of the large resources are lfs stub files, download them
+// Returns the oid (sha256) and size of the content a git-lfs stub file stands in for.
+def parseLFSStubFile(stubFile) {
+    final stubFileLines = stubFile.readLines("UTF-8")
+    final oidLine = stubFileLines.find { it.startsWith("oid sha256:") }
+    final sizeLine = stubFileLines.find { it.startsWith("size ") }
+    if (oidLine == null || sizeLine == null) {
+        throw new GradleException("$stubFile looks like a git-lfs stub file, but has no oid and/or size line.")
+    }
+    return [ oid : oidLine.substring("oid sha256:".length()).trim(),
+             size: Long.parseLong(sizeLine.substring("size ".length()).trim()) ]
+}
+
+// Returns the sha256 of the contents of a file, as a hex string.
+def sha256OfFile(targetFile) {
+    final digest = java.security.MessageDigest.getInstance("SHA-256")
+    targetFile.withInputStream { stream ->
+        final byte[] buffer = new byte[64 * 1024]
+        int bytesRead
+        while ((bytesRead = stream.read(buffer)) > 0) {
+            digest.update(buffer, 0, bytesRead)
+        }
+    }
+    return digest.digest().encodeHex().toString()
+}
+
+// Download the content the given git-lfs stub files stand in for directly from the git-lfs server,
+// using the git-lfs batch API (https://github.com/git-lfs/git-lfs/blob/main/docs/api/batch.md),
+// and verify each download against the sha256 recorded in the stub file it replaces. This is what
+// allows the build to run from a source archive (i.e. a GitHub source tarball, or the source
+// tarball used by a downstream packager), which contains stub files, but no git repository and
+// no git-lfs to resolve them with.
+def downloadLFSStubFileContents(stubFiles, buildPrerequisitesMessage) {
+    // the lfs server the large resources are fetched from, overridable for forks and mirrors
+    final lfsBatchAPIEndpoint = System.getProperty("lfsBatchAPIEndpoint",
+            "https://github.com/broadinstitute/gatk.git/info/lfs/objects/batch")
+    final stubs = stubFiles.collectEntries { [(it): parseLFSStubFile(it)] }
+    final batchRequest = groovy.json.JsonOutput.toJson([
+            operation: "download",
+            transfers: [ "basic" ],
+            objects  : stubs.values().collect { [oid: it.oid, size: it.size] }
+    ])
+
+    def batchResponse
+    try {
+        final connection = new URL(lfsBatchAPIEndpoint).openConnection()
+        connection.setRequestMethod("POST")
+        connection.setDoOutput(true)
+        connection.setRequestProperty("Accept", "application/vnd.git-lfs+json")
+        connection.setRequestProperty("Content-Type", "application/vnd.git-lfs+json")
+        connection.outputStream.withWriter("UTF-8") { it.write(batchRequest) }
+        if (connection.responseCode != 200) {
+            throw new GradleException("The git-lfs server at $lfsBatchAPIEndpoint responded with"
+                    + " ${connection.responseCode} ${connection.responseMessage}. $buildPrerequisitesMessage")
+        }
+        batchResponse = new groovy.json.JsonSlurper().parseText(connection.inputStream.getText("UTF-8"))
+    } catch (IOException e) {
+        throw new GradleException("An IOException occurred while requesting the large resource files"
+                + " from the git-lfs server at $lfsBatchAPIEndpoint. $buildPrerequisitesMessage", e)
+    }
+
+    final downloadURLs = batchResponse.objects.collectEntries { [(it.oid): it.actions?.download?.href] }
+    stubs.each { stubFile, stub ->
+        final downloadURL = downloadURLs[stub.oid]
+        if (downloadURL == null) {
+            throw new GradleException("The git-lfs server did not return a download URL for $stubFile"
+                    + " (oid ${stub.oid}). $buildPrerequisitesMessage")
+        }
+        println "Downloading git-lfs resource $stubFile (${stub.size} bytes)"
+        final downloadedFile = File.createTempFile(stubFile.name, ".lfsdownload", stubFile.parentFile)
+        try {
+            downloadedFile.withOutputStream { output ->
+                new URL(downloadURL).withInputStream { input -> output << input }
+            }
+            final downloadedOid = sha256OfFile(downloadedFile)
+            if (downloadedOid != stub.oid) {
+                throw new GradleException("The content downloaded for $stubFile has sha256 $downloadedOid,"
+                        + " but the git-lfs stub file it replaces requires ${stub.oid}.")
+            }
+            java.nio.file.Files.move(downloadedFile.toPath(), stubFile.toPath(),
+                    java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+        } finally {
+            downloadedFile.delete()
+        }
+    }
+}
+
+// if any of the large resources are lfs stub files, resolve them: with git-lfs when we're in a git
+// repository, and by downloading them straight from the git-lfs server otherwise, or if git-lfs
+// isn't installed
 def resolveLargeResourceStubFiles(largeResourcesFolder, buildPrerequisitesMessage) {
     def execGitLFSCommand = { gitLFSExecCommand ->
         println "Executing: $gitLFSExecCommand"
         try {
             def retCode = gitLFSExecCommand.execute().waitFor()
             if (retCode.intValue() != 0) {
-                throw new GradleException("Execution of \"$gitLFSExecCommand\" failed with exit code: $retCode. " +
-                        " git-lfs is required to build GATK but may not be installed. $buildPrerequisitesMessage")
+                println "Execution of \"$gitLFSExecCommand\" failed with exit code: $retCode."
             }
             return retCode
         } catch (IOException e) {
-            throw new GradleException(
-                    "An IOException occurred while attempting to execute the command $gitLFSExecCommand."
-                    + " git-lfs is required to build GATK but may not be installed. $buildPrerequisitesMessage", e)
+            println "An IOException occurred while attempting to execute the command $gitLFSExecCommand: ${e.getMessage()}"
+            return -1
         }
     }
 
     // check for stub files, try to pull once if there are any, then check again
-    if (checkForLFSStubFiles(largeResourcesFolder)) {
-        final gitLFSPullLargeResources = "git lfs pull --include $largeResourcesFolder"
-        execGitLFSCommand(gitLFSPullLargeResources)
-        if (checkForLFSStubFiles(largeResourcesFolder)) {
-            throw new GradleException("$largeResourcesFolder contains one or more git-lfs stub files."
-                    + " The resource files in $largeResourcesFolder must be downloaded by running the git-lfs"
-                    + " command \"$gitLFSPullLargeResources\". $buildPrerequisitesMessage")
+    def stubFiles = findLFSStubFiles(largeResourcesFolder)
+    if (!stubFiles.isEmpty()) {
+        if (looksLikeWereInAGitRepository()) {
+            execGitLFSCommand("git lfs pull --include $largeResourcesFolder")
+            stubFiles = findLFSStubFiles(largeResourcesFolder)
+        }
+        // git-lfs is either unavailable, or didn't resolve the stub files (which is always the case
+        // when building from a source archive) - fetch the content from the git-lfs server directly
+        if (!stubFiles.isEmpty()) {
+            downloadLFSStubFileContents(stubFiles, buildPrerequisitesMessage)
         }
     }
 }
@@ -150,7 +240,9 @@ def ensureBuildPrerequisites(largeResourcesFolder, buildPrerequisitesMessage, sk
     }
     if (!skipGitCheck && !looksLikeWereInAGitRepository() ) {
         throw new GradleException("This doesn't appear to be a git folder. " +
-                "The GATK Github repository must be cloned using \"git clone\" to run the build. " +
+                "The GATK Github repository must be cloned using \"git clone\" to run the build, " +
+                "or, to build from a source archive, the version must be supplied explicitly using " +
+                "\"-DversionOverride=<version>\". " +
                 "\n$buildPrerequisitesMessage")
     }
     // Large runtime resource files must be present at build time to be compiled into the jar, so

--- a/gatk
+++ b/gatk
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Launcher script for GATK tools. Delegates to java -jar, spark-submit, or gcloud as appropriate,
 # and sets many important Spark and htsjdk properties before launch.
@@ -14,6 +14,9 @@
 #     -If the GATK_SPARK_JAR environment variable is set, uses that jar
 #     -Otherwise uses the newest Spark jar in the same directory as the script or the BIN_PATH
 #      (in that order of precedence)
+#
+# The java executable used to run a packaged jar is "java" from the PATH, unless the GATK_JAVA
+# environment variable is set, in which case it names the java executable to use.
 #
 
 import sys
@@ -31,6 +34,7 @@ BUILD_LOCATION = script +"/build/install/" + projectName + "/bin/"
 GATK_RUN_SCRIPT = BUILD_LOCATION + projectName
 GATK_LOCAL_JAR_ENV_VARIABLE = "GATK_LOCAL_JAR"
 GATK_SPARK_JAR_ENV_VARIABLE = "GATK_SPARK_JAR"
+GATK_JAVA_ENV_VARIABLE = "GATK_JAVA"
 BIN_PATH = script + "/build/libs"
 
 EXTRA_JAVA_OPTIONS_SPARK= "-DGATK_STACKTRACE_ON_USER_EXCEPTION=true " \
@@ -237,7 +241,13 @@ def getLocalGatkRunCommand(javaOptions, debugPort, debugSuspend):
 
 
 def formatLocalJarCommand(localJar):
-    return ["java"] + PACKAGED_LOCAL_JAR_OPTIONS + [ "-jar", localJar]
+    return [getJavaCommand()] + PACKAGED_LOCAL_JAR_OPTIONS + [ "-jar", localJar]
+
+# The java executable to launch a packaged jar with. Defaults to "java" from the PATH, which the
+# GATK_JAVA environment variable overrides, so that an installation can pin the java it was built
+# and tested against without relying on the PATH.
+def getJavaCommand():
+    return os.environ.get(GATK_JAVA_ENV_VARIABLE, "java")
 
 def getGatkWrapperScript(throwIfNotFound=True):
     if not os.path.exists(GATK_RUN_SCRIPT):


### PR DESCRIPTION
## Why

GATK can't currently be built outside of a git clone, which is what every downstream packager works from (Homebrew, conda-forge, Debian/Ubuntu, Nix, Spack, and anyone building GATK inside a network-restricted build system from a vendored source tarball). Two things get in the way:

1. `build.gradle` requires a git repository.
2. The large runtime resources under `src/main/resources/large` (the NVScoreVariants models) are stored in git-lfs. A source archive, including the GitHub source tarball for a release tag, contains only their git-lfs stub files, and there is no git repository and no git-lfs there to resolve them with.

The practical result is that packagers repackage the prebuilt release zip instead of building GATK, which is exactly what most distribution policies do not allow. This PR makes the documented, supported path work.

## What changed

**`build.gradle`: resolve git-lfs stub files without git-lfs.**
When large resources are still stub files (always the case in a source archive), the build fetches the content they stand in for straight from the git-lfs server using the [git-lfs batch API](https://github.com/git-lfs/git-lfs/blob/main/docs/api/batch.md), and verifies each download against the sha256 (`oid`) recorded in the stub file it replaces. That check is what git-lfs itself does, so this is no weaker than a `git lfs pull`.

- Behavior inside a git clone is unchanged: `git lfs pull --include src/main/resources/large` is still tried first, and the direct download only runs if git-lfs is missing or left stub files behind.
- A failing `git lfs pull` no longer aborts the build outright, since the download path can still resolve the files. A genuine failure (server error, checksum mismatch, missing object) still fails the build with a specific message.
- The endpoint is overridable with `-DlfsBatchAPIEndpoint=...` for forks and mirrors.

**Building from an archive.** `-DversionOverride` already skips the git-clone requirement (the version can't come from `git describe` in an archive), so a source-archive build is just:

```
./gradlew -DversionOverride=4.7.0.0 -Drelease=true localJar
```

That is now documented in the Building section of the README, along with how the large resources are resolved.

**`gatk` launcher: two changes that make it usable as an installed program.**

- Shebang is `python3` instead of `python`. The launcher already documents "Requires Python 3.9 or greater", and `python` no longer exists on macOS (removed in 12.3) or on several Linux distributions, so the current shebang fails on a stock system.
- New optional `GATK_JAVA` environment variable naming the java executable used to run a packaged jar. This lets an installation pin the java GATK was built and tested against rather than depending on whatever `java` the `PATH` happens to resolve to. Unset, behavior is exactly as before (`java` from the `PATH`). Packagers currently patch the string `"java"` in the launcher to achieve this.

No changes to tool behavior, dependencies, or outputs.

## Testing

Exported the repository to a source archive, replaced the three files under `src/main/resources/large` with their git-lfs stub files (reproducing a GitHub source tarball), removed the git metadata, and built with JDK 17:

```
./gradlew -DversionOverride=4.7.0.0 -Drelease=true localJar
```

- All three large resources are downloaded and are byte-for-byte identical (sha256) to the ones in the clone.
- `BUILD SUCCESSFUL`, producing `gatk-package-4.7.0.0-local.jar`.
- `./gatk PrintReads --version` reports `v4.7.0.0` / HTSJDK 5.0.0 / Picard 3.5.0, both with `GATK_JAVA` unset and with it pointing at a specific JDK 17. A bogus `GATK_JAVA` fails on that path, confirming it is honored.
- The normal in-clone build path is untouched and still resolves resources through git-lfs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
