### PR TITLE
Exclude withdrawn and control samples from participant mappings [VS-2000]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,9 +54,11 @@ test*.dot
 venv
 .headroom_data
 .serena
+.claude
 
 # Emacs backup / autosave / lock files
 *~
 \#*\#
 .\#*
 *.save
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,25 @@ The canonical GVS location encoding and decoding logic lives in
 - **`cost_observability`**: Operation cost tracking, written to by the various
   tools that comprise the GVS pipeline.
 
+### Filter table gotchas
+
+**`yng_status` is only ever `G` or `Y`.** `N` is recognized by the extract code
+but is never written by the filter model; on Foxtrot the distribution across
+`filter_set_info` was `G` 1,724,533,270 and `Y` 29,333,911. Any check keyed on
+`yng_status = 'N'` is therefore vacuous, returning zero rows whether or not the
+condition it tests for occurs. `Y` comes from `POSITIVE_TRAIN_SITE`
+(`CreateFilteringFiles.java`), assigned by matching against left-aligned truth
+resources, so input data that is not left aligned cannot be rescued by a `Y` and
+is judged on calibration sensitivity alone.
+
+**Filtering is applied per site and per genotype, with opposite senses.**
+`ExtractCohortEngine#isFailingSite` compares the *maximum* (best) score among
+alleles of a class against that class's threshold, so a poor allele at a site
+whose best allele passes is not excluded; `filter_set_sites` records that
+per-site outcome and is the right table for "did this variant survive
+filtering". `#isFailingGenotype` compares the *minimum* (worst) score across a
+genotype's non-ref alleles, so a `1/2` call is filtered if either allele fails.
+
 ## Key Workflows
 
 ### GvsJointVariantCalling.wdl

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,44 @@ Some of the GVS code in this repo does interact with split multi-allelic non-VDS
 Hail artifacts; see `AOU_MARKETING_STATISTICS.md` for an example that takes a
 split Exome MatrixTable as input.
 
+### Allele representations across GVS artifacts
+
+The same variant is written differently in different GVS artifacts. The
+differences are systematic rather than incidental, and comparing alleles across
+artifacts without accounting for them is a recurring source of bugs.
+
+- **`vet_%` and `alt_allele`** hold minimized (trimmed) alleles that are *not*
+  left-aligned. An indel stays wherever the caller placed it.
+- **The VDS** holds unsplit multi-allelic rows in a common per-site reference
+  context. `alleles[0]` must be long enough to span the longest deletion at the
+  site, and every ALT is expressed relative to it. A VDS allele string is
+  therefore a property of the site's allele set, not of the variant: the same
+  variant is written differently at a site with different neighbours.
+- **The VAT, and therefore vids,** hold alleles that are minimized *and*
+  left-aligned, via `bcftools norm -f` in `GvsCreateVATFromVDS.wdl:731`.
+
+Four consequences worth knowing before writing anything that joins across these:
+
+1. Minimize before comparing. `hl.min_rep`, or trimming by hand, reduces a VDS
+   allele to the intrinsic form that `alt_allele` stores.
+2. Compare the REF/ALT **pair**, never the ALT alone. One string can be the raw
+   ALT of one variant and the minimized ALT of an unrelated one. At
+   chr13:32368001 in Foxtrot, `CTT` is both: the raw ALT of a 24bp deletion
+   against a 27bp REF, and the minimized ALT of a 2bp insertion.
+3. Minimizing is not left-aligning. `hl.min_rep` trims shared prefixes and
+   suffixes but will not walk an indel through a repeat, so it cannot unify a
+   left-aligned vid with a non-left-aligned `alt_allele` row. That needs real
+   normalization against the reference, which is what `GvsMapUnmappedVIDs` and
+   the scripts under
+   `scripts/variantstore/scripts/variant_annotation_table/left_alignment_fixups/`
+   exist to do.
+4. Indel length is invariant under normalization, so it is a safe filter when
+   hunting for equivalent representations; position and allele strings are not.
+   The production synonym search keys on it as bcftools `ILEN` over a 200bp
+   window rightward from the vid's position, left-aligned being the leftmost
+   equivalent form (`generate_bcftools_searches_for_variant_synonyms.py:38-45`).
+
+
 # High-Level Architecture (WDLs, BigQuery, Terra)
 
 ## Java Artifacts
@@ -261,11 +299,15 @@ is derived from its alleles by the max-over-class rule below and is not recorded
 in either table.
 
 **The filter model is applied per site and per genotype, with opposite senses.**
-`ExtractCohortEngine#isFailingSite` compares the *maximum* (best) score among
-alleles of a class against that class's threshold, so a poor allele at a site
-whose best allele passes is not excluded. `#isFailingGenotype` compares the
-*minimum* (worst) score across a genotype's non-ref alleles, so a `1/2` call is
-filtered if either allele fails.
+A site is judged by its *best* allele of a class, so a poor allele at a site
+whose best allele passes is not excluded; a genotype is judged by its *worst*
+non-ref allele, so a `1/2` call is filtered if either allele fails. Note that
+which arithmetic expresses "best" depends on the model, and the two are
+inverted. For VQSR, `vqslod` is higher-is-better, so `ExtractCohortEngine`
+fails a site when `max(score) < threshold` and a genotype when
+`min(score) < threshold`. For VETS — the default — `calibration_sensitivity` is
+lower-is-better, so `ExtractCohortVETSEngine` overrides both and fails a site
+when `min(score) > threshold` and a genotype when `max(score) > threshold`.
 
 ## Key Workflows
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,13 +243,29 @@ condition it tests for occurs. `Y` comes from `POSITIVE_TRAIN_SITE`
 resources, so input data that is not left aligned cannot be rescued by a `Y` and
 is judged on calibration sensitivity alone.
 
-**Filtering is applied per site and per genotype, with opposite senses.**
+**`filter_set_sites` records only sites that have filters, and does not cover
+the filter model.** There is no PASS or null row; absence from the table means
+the site was not filtered. On Foxtrot it held 71,032,776 rows across
+`EXCESS_ALLELES`, `ExcessHet`, `LowQual`, `NO_HQ_GENOTYPES` and combinations.
+Calibration sensitivity failures are *not* among them: VETS and VQSR site
+failures are computed at extract time from `filter_set_info` scores, never
+stored here. So this table records which sites carry site-level filter values.
+Whether carrying one actually excludes the variant depends on the artifact: per
+"Hard filtered versus soft filtered variants" above, the VAT is hard filtered and
+drops them, while the VCF, VDS and PGEN artifacts are soft filtered and emit
+every variant with its filter information attached.
+`filter_set_info` answers a different question again: keyed by
+`(location, ref, alt)`, it gives the calibration sensitivity score and
+`yng_status` of an individual *allele*. Whether a *site* passes the filter model
+is derived from its alleles by the max-over-class rule below and is not recorded
+in either table.
+
+**The filter model is applied per site and per genotype, with opposite senses.**
 `ExtractCohortEngine#isFailingSite` compares the *maximum* (best) score among
 alleles of a class against that class's threshold, so a poor allele at a site
-whose best allele passes is not excluded; `filter_set_sites` records that
-per-site outcome and is the right table for "did this variant survive
-filtering". `#isFailingGenotype` compares the *minimum* (worst) score across a
-genotype's non-ref alleles, so a `1/2` call is filtered if either allele fails.
+whose best allele passes is not excluded. `#isFailingGenotype` compares the
+*minimum* (worst) score across a genotype's non-ref alleles, so a `1/2` call is
+filtered if either allele fails.
 
 ## Key Workflows
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -405,6 +405,30 @@ patch this table for a set of VIDs that did not have corresponding Participant
 IDs. See the directory `pseudo_vids_only_in_vat` for more information on
 unmatched VIDs that were discovered in the VATs of the Delta and Echo callsets.
 
+# Data Handling
+
+## Redact participant IDs from anything committed to this repo
+
+The GATK repository is public, and AoU is highly sensitive about participant
+data appearing in public places. Any AoU participant ID must be redacted before
+a file containing it is committed, replaced with a placeholder such as
+`<PERSON_A>`. This applies everywhere, not just to data files: SQL scripts with
+real IDs in an `IN` list, Python fixtures, pasted query output in a Markdown
+write-up, an example invocation in a docstring, and a commit message all count.
+
+Attach the unredacted data to the JIRA ticket for the work instead, and refer to
+it from the repo by ticket number.
+
+Redact before committing rather than afterwards. A commit is not undone by a
+later one — the ID stays reachable in the history, so a slip has to be fixed by
+rewriting history, which is disruptive and easy to do incompletely. Prefer
+placeholders in the working file from the outset, so there is no version of it
+that can be committed by accident.
+
+Note that a redacted file and its working counterpart tend to drift apart. Where
+both are needed, keep the redacted one as the file that is edited, and treat any
+real-ID version as a throwaway.
+
 # Documentation Conventions
 
 ## Markdown tables must be rectangular

--- a/scripts/variantstore/variant-annotations-table/GvsCreateParticipantMappingTable.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsCreateParticipantMappingTable.wdl
@@ -61,6 +61,13 @@ task CreateParticipantMappingTable {
         FROM `~{project_id}.~{dataset}.alt_allele` AS aa
                 JOIN `~{project_id}.~{dataset}.sample_info` AS si
                     ON aa.sample_id = si.sample_id
+                        -- `alt_allele` is append-only and is only ever extended for sample ids greater than the
+                        -- maximum already present, so it still contains rows for samples that were withdrawn
+                        -- after those rows were written. Those samples are excluded from the VDS, so they must
+                        -- be excluded here too. Controls are likewise absent from the VDS; the SAFE_CAST below
+                        -- happens to drop non-numeric control sample names, but do not rely on that.
+                        AND si.withdrawn IS NULL
+                        AND si.is_control = false
                 JOIN
             (SELECT vid,
                 vidToLocation(vid) AS location,

--- a/scripts/variantstore/variant-annotations-table/GvsMapDroppedDuplicateVIDs.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsMapDroppedDuplicateVIDs.wdl
@@ -159,6 +159,13 @@ task MapDroppedDuplicateVIDs {
           `~{dataset}.sample_info` si
         ON
           aa.sample_id = si.sample_id
+          -- `alt_allele` is append-only and is only ever extended for sample ids greater than the maximum
+          -- already present, so it still contains rows for samples that were withdrawn after those rows were
+          -- written. Those samples are excluded from the VDS, so they must be excluded here too. Controls are
+          -- likewise absent from the VDS; the SAFE_CAST above happens to drop non-numeric control sample names,
+          -- but do not rely on that.
+          AND si.withdrawn IS NULL
+          AND si.is_control = false
           ~{if defined(range_filter) then "WHERE aa.location >= ~{select_first([range_filter]).startLocation} AND aa.location < ~{select_first([range_filter]).endLocation}" else ""}
         GROUP BY
           vid

--- a/scripts/variantstore/variant-annotations-table/GvsMapUnmappedVIDs.wdl
+++ b/scripts/variantstore/variant-annotations-table/GvsMapUnmappedVIDs.wdl
@@ -147,6 +147,13 @@ task MapUnmappedVIDs {
           `~{dataset}.sample_info` si
         ON
           aa.sample_id = si.sample_id
+          -- `alt_allele` is append-only and is only ever extended for sample ids greater than the maximum
+          -- already present, so it still contains rows for samples that were withdrawn after those rows were
+          -- written. Those samples are excluded from the VDS, so they must be excluded here too. Controls are
+          -- likewise absent from the VDS; the SAFE_CAST above happens to drop non-numeric control sample names,
+          -- but do not rely on that.
+          AND si.withdrawn IS NULL
+          AND si.is_control = false
           ~{if defined(range_filter) then "where aa.location >= ~{select_first([range_filter]).startLocation} AND aa.location < ~{select_first([range_filter]).endLocation}" else ""}
         GROUP BY
           vid


### PR DESCRIPTION
Filter out withdrawn and control samples when creating and updating the participant mapping table. Full details in the JIRA ticket [here](https://broadworkbench.atlassian.net/browse/VS-2000).