### PR TITLE
Parquet ingest verification independent from the loader [VS-1989]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -209,6 +209,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - ng_vs_1989_parquet_ingest_verification
          tags:
              - /.*/
    - name: GvsBulkIngestGenomes

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -219,6 +219,7 @@ workflows:
        branches:
          - master
          - ah_var_store
+         - ng_vs_1989_parquet_ingest_verification
        tags:
          - /.*/
    - name: GvsPrepareRangesCallset

--- a/scripts/variantstore/scripts/test/test_verify_all_loaded.py
+++ b/scripts/variantstore/scripts/test/test_verify_all_loaded.py
@@ -1,0 +1,153 @@
+"""
+Unit tests for verify_all_loaded.py, focused on the VS-1989 composition change: the independent
+structural checks must be able to block Parquet deletion (all_loaded=False) even when the
+shared-predicate presence check is fully satisfied, and the results JSON must carry both the new
+structural booleans and the pre-existing keys the WDL already reads.
+
+The BigQuery-touching helpers (get_already_loaded_tables_and_sample_ids, run_structural_checks) are
+patched; the real GCS-path parser runs against realistic fixture paths.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import verify_all_loaded
+
+# Six fixture files: two samples (1, 2) across vet, ref_ranges, and sample_chromosome_ploidy.
+FIXTURE_FILES = [
+    "gs://b/vet/vet_001_1_input_vcf_0_S1.vcf.gz.parquet",
+    "gs://b/vet/vet_001_2_input_vcf_0_S2.vcf.gz.parquet",
+    "gs://b/ref_ranges/ref_ranges_001_1_input_vcf_0_S1.vcf.gz.parquet",
+    "gs://b/ref_ranges/ref_ranges_001_2_input_vcf_0_S2.vcf.gz.parquet",
+    "gs://b/sample_chromosome_ploidy/sample_chromosome_ploidy_1_S1.parquet",
+    "gs://b/sample_chromosome_ploidy/sample_chromosome_ploidy_2_S2.parquet",
+]
+
+ALL_PAIRS = {
+    ("vet_001", 1), ("vet_001", 2),
+    ("ref_ranges_001", 1), ("ref_ranges_001", 2),
+    ("sample_chromosome_ploidy", 1), ("sample_chromosome_ploidy", 2),
+}
+
+
+def _structural(completeness_ok=True, cardinality_ok=True, duplication_flagged=False,
+                strict_vet_screen=False):
+    """A run_structural_checks return value with the keys verify_all_loaded consumes."""
+    return {
+        "completeness_ok": completeness_ok,
+        "cardinality_ok": cardinality_ok,
+        "duplication_flagged": duplication_flagged,
+        "strict_vet_screen": strict_vet_screen,
+        "details": {
+            "family_completeness": {"ok": completeness_ok, "per_family": {}},
+            "cardinality": {},
+            "duplication_screen": {},
+            "duplication_unscreened": {"families": ["ref_ranges"], "reason": "not screened"},
+        },
+    }
+
+
+class VerifyAllLoadedTestBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.gcs_list = os.path.join(self.tmp, "gcs_files.txt")
+        with open(self.gcs_list, "w") as f:
+            f.write("\n".join(FIXTURE_FILES) + "\n")
+        self.out_dir = os.path.join(self.tmp, "out")
+
+    def _run(self, loaded_pairs, structural, strict_vet_screen=False):
+        with patch("verify_all_loaded.get_already_loaded_tables_and_sample_ids",
+                   return_value=loaded_pairs), \
+             patch("verify_all_loaded.run_structural_checks",
+                   return_value=structural) as mock_struct:
+            self.mock_struct = mock_struct
+            return verify_all_loaded.verify_all_loaded(
+                project_id="proj",
+                dataset_name="ds",
+                gcs_files_list=self.gcs_list,
+                output_dir=self.out_dir,
+                strict_vet_screen=strict_vet_screen,
+            )
+
+    def _written_json(self):
+        with open(os.path.join(self.out_dir, "verification_results.json")) as f:
+            return json.load(f)
+
+
+class TestHappyPath(VerifyAllLoadedTestBase):
+    def test_all_loaded_and_json_keys(self):
+        r = self._run(set(ALL_PAIRS), _structural())
+
+        self.assertTrue(r["all_loaded"])
+        # Pre-existing keys the WDL already reads must be preserved.
+        self.assertEqual(r["total_files"], 6)
+        self.assertEqual(r["loaded_files"], 6)
+        self.assertEqual(r["missing_files"], 0)
+        self.assertEqual(r["unmatched_files"], 0)
+        self.assertIsNone(r["missing_files_list"])
+        # New structural booleans (read shallowly by the WDL).
+        self.assertTrue(r["structural_checks_ok"])
+        self.assertTrue(r["family_completeness_ok"])
+        self.assertTrue(r["ploidy_cardinality_ok"])
+        self.assertFalse(r["vet_duplication_flagged"])
+        self.assertIn("structural_checks", r)
+        # The JSON on disk matches the returned dict.
+        self.assertEqual(self._written_json(), r)
+
+    def test_expected_by_family_passed_to_structural_checks(self):
+        self._run(set(ALL_PAIRS), _structural())
+        expected_by_family = self.mock_struct.call_args[0][2]
+        self.assertEqual(set(expected_by_family["vet"]), {1, 2})
+        self.assertEqual(set(expected_by_family["ref_ranges"]), {1, 2})
+        self.assertEqual(set(expected_by_family["sample_chromosome_ploidy"]), {1, 2})
+
+
+class TestStructuralChecksGate(VerifyAllLoadedTestBase):
+    def test_cardinality_failure_blocks_deletion(self):
+        # Every pair is present to the shared predicate, but a partial load fails cardinality.
+        r = self._run(set(ALL_PAIRS), _structural(cardinality_ok=False))
+        self.assertFalse(r["all_loaded"])
+        self.assertFalse(r["structural_checks_ok"])
+        self.assertFalse(r["ploidy_cardinality_ok"])
+        self.assertEqual(r["missing_files"], 0)
+
+    def test_completeness_failure_blocks_deletion(self):
+        r = self._run(set(ALL_PAIRS), _structural(completeness_ok=False))
+        self.assertFalse(r["all_loaded"])
+        self.assertFalse(r["family_completeness_ok"])
+
+    def test_vet_duplication_warns_by_default(self):
+        r = self._run(set(ALL_PAIRS), _structural(duplication_flagged=True))
+        self.assertTrue(r["all_loaded"])
+        self.assertTrue(r["structural_checks_ok"])
+        self.assertTrue(r["vet_duplication_flagged"])
+
+    def test_vet_duplication_gates_under_strict(self):
+        r = self._run(
+            set(ALL_PAIRS),
+            _structural(duplication_flagged=True, strict_vet_screen=True),
+            strict_vet_screen=True,
+        )
+        self.assertFalse(r["all_loaded"])
+        self.assertFalse(r["structural_checks_ok"])
+        self.assertTrue(r["vet_duplication_flagged"])
+
+
+class TestSharedPredicateStillGates(VerifyAllLoadedTestBase):
+    def test_missing_pair_blocks_even_when_structural_ok(self):
+        loaded = set(ALL_PAIRS) - {("vet_001", 2)}
+        r = self._run(loaded, _structural())
+        self.assertFalse(r["all_loaded"])
+        self.assertEqual(r["missing_files"], 1)
+        self.assertTrue(r["structural_checks_ok"])
+        self.assertTrue(os.path.exists(r["missing_files_list"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/variantstore/scripts/test/test_verify_all_loaded.py
+++ b/scripts/variantstore/scripts/test/test_verify_all_loaded.py
@@ -61,7 +61,8 @@ class VerifyAllLoadedTestBase(unittest.TestCase):
             f.write("\n".join(FIXTURE_FILES) + "\n")
         self.out_dir = os.path.join(self.tmp, "out")
 
-    def _run(self, loaded_pairs, structural, strict_vet_screen=False):
+    def _run(self, loaded_pairs, structural, strict_vet_screen=False,
+             expected_ploidy_rows_per_sample=None):
         with patch("verify_all_loaded.get_already_loaded_tables_and_sample_ids",
                    return_value=loaded_pairs), \
              patch("verify_all_loaded.run_structural_checks",
@@ -73,6 +74,7 @@ class VerifyAllLoadedTestBase(unittest.TestCase):
                 gcs_files_list=self.gcs_list,
                 output_dir=self.out_dir,
                 strict_vet_screen=strict_vet_screen,
+                expected_ploidy_rows_per_sample=expected_ploidy_rows_per_sample,
             )
 
     def _written_json(self):
@@ -106,6 +108,14 @@ class TestHappyPath(VerifyAllLoadedTestBase):
         self.assertEqual(set(expected_by_family["vet"]), {1, 2})
         self.assertEqual(set(expected_by_family["ref_ranges"]), {1, 2})
         self.assertEqual(set(expected_by_family["sample_chromosome_ploidy"]), {1, 2})
+
+    def test_expected_ploidy_override_threaded_to_structural_checks(self):
+        self._run(set(ALL_PAIRS), _structural(), expected_ploidy_rows_per_sample=24)
+        self.assertEqual(self.mock_struct.call_args.kwargs["expected_ploidy_rows_per_sample"], 24)
+
+    def test_expected_ploidy_override_defaults_to_none(self):
+        self._run(set(ALL_PAIRS), _structural())
+        self.assertIsNone(self.mock_struct.call_args.kwargs["expected_ploidy_rows_per_sample"])
 
 
 class TestStructuralChecksGate(VerifyAllLoadedTestBase):

--- a/scripts/variantstore/scripts/test/test_verify_all_loaded.py
+++ b/scripts/variantstore/scripts/test/test_verify_all_loaded.py
@@ -202,6 +202,46 @@ class TestStructuralDetailCapped(VerifyAllLoadedTestBase):
         self.assertNotIn("missing_samples_total", vet)
 
 
+class TestComputeStructuralChecksOk(unittest.TestCase):
+    """The structural half of the deletion gate, isolated: exact checks gate, heuristics warn unless strict."""
+
+    def _ok(self, structural, strict):
+        return verify_all_loaded.compute_structural_checks_ok(structural, strict)
+
+    def test_all_ok_passes(self):
+        self.assertTrue(self._ok(_structural(), False))
+
+    def test_completeness_failure_gates_unconditionally(self):
+        self.assertFalse(self._ok(_structural(completeness_ok=False), False))
+
+    def test_cardinality_failure_gates_unconditionally(self):
+        self.assertFalse(self._ok(_structural(cardinality_ok=False), False))
+
+    def test_duplication_warns_by_default_gates_under_strict(self):
+        self.assertTrue(self._ok(_structural(duplication_flagged=True), False))
+        self.assertFalse(self._ok(_structural(duplication_flagged=True), True))
+
+    def test_truncation_warns_by_default_gates_under_strict(self):
+        self.assertTrue(self._ok(_structural(truncation_flagged=True), False))
+        self.assertFalse(self._ok(_structural(truncation_flagged=True), True))
+
+
+class TestComputeAllLoaded(unittest.TestCase):
+    """The deletion gate proper: safe to delete only when nothing is missing/unmatched and structural checks pass."""
+
+    def test_true_when_everything_clean(self):
+        self.assertTrue(verify_all_loaded.compute_all_loaded(set(), [], True))
+
+    def test_missing_pair_blocks(self):
+        self.assertFalse(verify_all_loaded.compute_all_loaded({("vet_001", 2)}, [], True))
+
+    def test_unmatched_file_blocks(self):
+        self.assertFalse(verify_all_loaded.compute_all_loaded(set(), ["gs://b/weird.parquet"], True))
+
+    def test_structural_failure_blocks_even_when_files_all_present(self):
+        self.assertFalse(verify_all_loaded.compute_all_loaded(set(), [], False))
+
+
 class TestSharedPredicateStillGates(VerifyAllLoadedTestBase):
     def test_missing_pair_blocks_even_when_structural_ok(self):
         loaded = set(ALL_PAIRS) - {("vet_001", 2)}

--- a/scripts/variantstore/scripts/test/test_verify_all_loaded.py
+++ b/scripts/variantstore/scripts/test/test_verify_all_loaded.py
@@ -1,8 +1,11 @@
 """
-Unit tests for verify_all_loaded.py, focused on the VS-1989 composition change: the independent
-structural checks must be able to block Parquet deletion (all_loaded=False) even when the
-shared-predicate presence check is fully satisfied, and the results JSON must carry both the new
-structural booleans and the pre-existing keys the WDL already reads.
+Unit tests for verify_all_loaded.py, focused on the VS-1989 composition change and its Part-2 split of
+the deletion gate: the exact structural checks (family completeness, ploidy cardinality) block
+all_loaded -- the factual "is the load complete?" signal fail-loud aborts on -- even when the
+shared-predicate presence check is fully satisfied; while the heuristic vet duplication/truncation
+screens never touch all_loaded and instead gate the separate safe_to_delete_parquet predicate, blocking
+deletion by default and waived only under allow_flagged_vet_loads. The results JSON must carry both
+predicates plus the structural booleans and the pre-existing keys the WDL already reads.
 
 The BigQuery-touching helpers (get_already_loaded_tables_and_sample_ids, run_structural_checks) are
 patched; the real GCS-path parser runs against realistic fixture paths.
@@ -37,14 +40,14 @@ ALL_PAIRS = {
 
 
 def _structural(completeness_ok=True, cardinality_ok=True, duplication_flagged=False,
-                truncation_flagged=False, strict_vet_screen=False):
+                truncation_flagged=False, allow_flagged_vet_loads=False):
     """A run_structural_checks return value with the keys verify_all_loaded consumes."""
     return {
         "completeness_ok": completeness_ok,
         "cardinality_ok": cardinality_ok,
         "duplication_flagged": duplication_flagged,
         "truncation_flagged": truncation_flagged,
-        "strict_vet_screen": strict_vet_screen,
+        "allow_flagged_vet_loads": allow_flagged_vet_loads,
         "details": {
             "family_completeness": {"ok": completeness_ok, "per_family": {}},
             "cardinality": {},
@@ -63,7 +66,7 @@ class VerifyAllLoadedTestBase(unittest.TestCase):
             f.write("\n".join(FIXTURE_FILES) + "\n")
         self.out_dir = os.path.join(self.tmp, "out")
 
-    def _run(self, loaded_pairs, structural, strict_vet_screen=False,
+    def _run(self, loaded_pairs, structural, allow_flagged_vet_loads=False,
              expected_ploidy_rows_per_sample=None):
         with patch("verify_all_loaded.get_already_loaded_tables_and_sample_ids",
                    return_value=loaded_pairs), \
@@ -75,7 +78,7 @@ class VerifyAllLoadedTestBase(unittest.TestCase):
                 dataset_name="ds",
                 gcs_files_list=self.gcs_list,
                 output_dir=self.out_dir,
-                strict_vet_screen=strict_vet_screen,
+                allow_flagged_vet_loads=allow_flagged_vet_loads,
                 expected_ploidy_rows_per_sample=expected_ploidy_rows_per_sample,
             )
 
@@ -89,6 +92,7 @@ class TestHappyPath(VerifyAllLoadedTestBase):
         r = self._run(set(ALL_PAIRS), _structural())
 
         self.assertTrue(r["all_loaded"])
+        self.assertTrue(r["safe_to_delete_parquet"])
         # Pre-existing keys the WDL already reads must be preserved.
         self.assertEqual(r["total_files"], 6)
         self.assertEqual(r["loaded_files"], 6)
@@ -121,51 +125,63 @@ class TestHappyPath(VerifyAllLoadedTestBase):
         self.assertIsNone(self.mock_struct.call_args.kwargs["expected_ploidy_rows_per_sample"])
 
 
-class TestStructuralChecksGate(VerifyAllLoadedTestBase):
-    def test_cardinality_failure_blocks_deletion(self):
-        # Every pair is present to the shared predicate, but a partial load fails cardinality.
+class TestExactChecksGateAllLoaded(VerifyAllLoadedTestBase):
+    """The exact checks fail all_loaded (and so safe_to_delete_parquet) even when the shared predicate
+    sees every pair present."""
+
+    def test_cardinality_failure_blocks_all_loaded(self):
         r = self._run(set(ALL_PAIRS), _structural(cardinality_ok=False))
         self.assertFalse(r["all_loaded"])
+        self.assertFalse(r["safe_to_delete_parquet"])
         self.assertFalse(r["structural_checks_ok"])
         self.assertFalse(r["ploidy_cardinality_ok"])
         self.assertEqual(r["missing_files"], 0)
 
-    def test_completeness_failure_blocks_deletion(self):
+    def test_completeness_failure_blocks_all_loaded(self):
         r = self._run(set(ALL_PAIRS), _structural(completeness_ok=False))
         self.assertFalse(r["all_loaded"])
+        self.assertFalse(r["safe_to_delete_parquet"])
         self.assertFalse(r["family_completeness_ok"])
 
-    def test_vet_duplication_warns_by_default(self):
+
+class TestVetScreensGateDeletionNotAllLoaded(VerifyAllLoadedTestBase):
+    """A vet-screen flag is orthogonal to load completeness: all_loaded stays True (so the task
+    succeeds), but the flag blocks Parquet deletion by default and is waived only under
+    allow_flagged_vet_loads."""
+
+    def test_duplication_flag_blocks_deletion_but_not_all_loaded(self):
         r = self._run(set(ALL_PAIRS), _structural(duplication_flagged=True))
         self.assertTrue(r["all_loaded"])
         self.assertTrue(r["structural_checks_ok"])
         self.assertTrue(r["vet_duplication_flagged"])
+        self.assertFalse(r["safe_to_delete_parquet"])
 
-    def test_vet_duplication_gates_under_strict(self):
+    def test_duplication_flag_waived_allows_deletion(self):
         r = self._run(
             set(ALL_PAIRS),
-            _structural(duplication_flagged=True, strict_vet_screen=True),
-            strict_vet_screen=True,
+            _structural(duplication_flagged=True, allow_flagged_vet_loads=True),
+            allow_flagged_vet_loads=True,
         )
-        self.assertFalse(r["all_loaded"])
-        self.assertFalse(r["structural_checks_ok"])
+        self.assertTrue(r["all_loaded"])
         self.assertTrue(r["vet_duplication_flagged"])
+        self.assertTrue(r["safe_to_delete_parquet"])
 
-    def test_vet_truncation_warns_by_default(self):
+    def test_truncation_flag_blocks_deletion_but_not_all_loaded(self):
         r = self._run(set(ALL_PAIRS), _structural(truncation_flagged=True))
         self.assertTrue(r["all_loaded"])
         self.assertTrue(r["structural_checks_ok"])
         self.assertTrue(r["vet_truncation_flagged"])
+        self.assertFalse(r["safe_to_delete_parquet"])
 
-    def test_vet_truncation_gates_under_strict(self):
+    def test_truncation_flag_waived_allows_deletion(self):
         r = self._run(
             set(ALL_PAIRS),
-            _structural(truncation_flagged=True, strict_vet_screen=True),
-            strict_vet_screen=True,
+            _structural(truncation_flagged=True, allow_flagged_vet_loads=True),
+            allow_flagged_vet_loads=True,
         )
-        self.assertFalse(r["all_loaded"])
-        self.assertFalse(r["structural_checks_ok"])
+        self.assertTrue(r["all_loaded"])
         self.assertTrue(r["vet_truncation_flagged"])
+        self.assertTrue(r["safe_to_delete_parquet"])
 
 
 class TestStructuralDetailCapped(VerifyAllLoadedTestBase):
@@ -203,31 +219,29 @@ class TestStructuralDetailCapped(VerifyAllLoadedTestBase):
 
 
 class TestComputeStructuralChecksOk(unittest.TestCase):
-    """The structural half of the deletion gate, isolated: exact checks gate, heuristics warn unless strict."""
+    """The exact structural signal that feeds all_loaded: completeness and cardinality only. The vet
+    screens are deliberately excluded -- they gate safe_to_delete_parquet, not all_loaded."""
 
-    def _ok(self, structural, strict):
-        return verify_all_loaded.compute_structural_checks_ok(structural, strict)
+    def _ok(self, structural):
+        return verify_all_loaded.compute_structural_checks_ok(structural)
 
     def test_all_ok_passes(self):
-        self.assertTrue(self._ok(_structural(), False))
+        self.assertTrue(self._ok(_structural()))
 
-    def test_completeness_failure_gates_unconditionally(self):
-        self.assertFalse(self._ok(_structural(completeness_ok=False), False))
+    def test_completeness_failure_gates(self):
+        self.assertFalse(self._ok(_structural(completeness_ok=False)))
 
-    def test_cardinality_failure_gates_unconditionally(self):
-        self.assertFalse(self._ok(_structural(cardinality_ok=False), False))
+    def test_cardinality_failure_gates(self):
+        self.assertFalse(self._ok(_structural(cardinality_ok=False)))
 
-    def test_duplication_warns_by_default_gates_under_strict(self):
-        self.assertTrue(self._ok(_structural(duplication_flagged=True), False))
-        self.assertFalse(self._ok(_structural(duplication_flagged=True), True))
-
-    def test_truncation_warns_by_default_gates_under_strict(self):
-        self.assertTrue(self._ok(_structural(truncation_flagged=True), False))
-        self.assertFalse(self._ok(_structural(truncation_flagged=True), True))
+    def test_screen_flags_do_not_affect_exact_signal(self):
+        self.assertTrue(self._ok(_structural(duplication_flagged=True)))
+        self.assertTrue(self._ok(_structural(truncation_flagged=True)))
 
 
 class TestComputeAllLoaded(unittest.TestCase):
-    """The deletion gate proper: safe to delete only when nothing is missing/unmatched and structural checks pass."""
+    """The factual load-complete gate (what fail-loud aborts on): True only when nothing is
+    missing/unmatched and the exact structural checks pass. The vet screens never enter here."""
 
     def test_true_when_everything_clean(self):
         self.assertTrue(verify_all_loaded.compute_all_loaded(set(), [], True))
@@ -242,18 +256,47 @@ class TestComputeAllLoaded(unittest.TestCase):
         self.assertFalse(verify_all_loaded.compute_all_loaded(set(), [], False))
 
 
+class TestComputeSafeToDeleteParquet(unittest.TestCase):
+    """The deletion gate proper: all_loaded AND no unwaived vet-screen flag."""
+
+    def _safe(self, all_loaded, structural, allow):
+        return verify_all_loaded.compute_safe_to_delete_parquet(all_loaded, structural, allow)
+
+    def test_requires_all_loaded(self):
+        # Even with no flags and the screens waived, an incomplete load is never safe to delete.
+        self.assertFalse(self._safe(False, _structural(), False))
+        self.assertFalse(self._safe(False, _structural(), True))
+
+    def test_clean_load_is_safe(self):
+        self.assertTrue(self._safe(True, _structural(), False))
+
+    def test_duplication_flag_blocks_by_default(self):
+        self.assertFalse(self._safe(True, _structural(duplication_flagged=True), False))
+
+    def test_truncation_flag_blocks_by_default(self):
+        self.assertFalse(self._safe(True, _structural(truncation_flagged=True), False))
+
+    def test_flags_waived_when_allowed(self):
+        self.assertTrue(self._safe(True, _structural(duplication_flagged=True), True))
+        self.assertTrue(self._safe(True, _structural(truncation_flagged=True), True))
+        self.assertTrue(self._safe(
+            True, _structural(duplication_flagged=True, truncation_flagged=True), True))
+
+
 class TestSharedPredicateStillGates(VerifyAllLoadedTestBase):
     def test_missing_pair_blocks_even_when_structural_ok(self):
         loaded = set(ALL_PAIRS) - {("vet_001", 2)}
         r = self._run(loaded, _structural())
         self.assertFalse(r["all_loaded"])
+        self.assertFalse(r["safe_to_delete_parquet"])
         self.assertEqual(r["missing_files"], 1)
         self.assertTrue(r["structural_checks_ok"])
         self.assertTrue(os.path.exists(r["missing_files_list"]))
 
 
 class TestDescribeIncompleteReasons(unittest.TestCase):
-    """The fail-loud operator message names every not-all-loaded cause, including a strict truncation-only failure."""
+    """The fail-loud operator message names every not-all-loaded cause. Only the exact checks appear;
+    a vet-screen flag never fails all_loaded, so it must not surface here."""
 
     def _reasons(self, **over):
         base = {
@@ -261,9 +304,6 @@ class TestDescribeIncompleteReasons(unittest.TestCase):
             "unmatched_files": 0,
             "family_completeness_ok": True,
             "ploidy_cardinality_ok": True,
-            "structural_checks_ok": True,
-            "vet_duplication_flagged": False,
-            "vet_truncation_flagged": False,
         }
         base.update(over)
         return verify_all_loaded.describe_incomplete_reasons(base)
@@ -281,21 +321,10 @@ class TestDescribeIncompleteReasons(unittest.TestCase):
         self.assertTrue(any("family completeness" in r for r in reasons))
         self.assertTrue(any("ploidy cardinality" in r for r in reasons))
 
-    def test_strict_duplication_only_named(self):
-        reasons = self._reasons(structural_checks_ok=False, vet_duplication_flagged=True)
-        self.assertEqual(reasons, ["vet duplication screen flagged samples (--strict-vet-screen)"])
-
-    def test_strict_truncation_only_named(self):
-        # The regression: a truncation-only strict failure must not fall through to "unknown reasons".
-        reasons = self._reasons(structural_checks_ok=False, vet_truncation_flagged=True)
-        self.assertEqual(reasons, ["vet truncation screen flagged samples (--strict-vet-screen)"])
-
-    def test_strict_both_screens_named(self):
-        reasons = self._reasons(structural_checks_ok=False,
-                                vet_duplication_flagged=True, vet_truncation_flagged=True)
-        self.assertEqual(len(reasons), 2)
-        self.assertTrue(any("duplication" in r for r in reasons))
-        self.assertTrue(any("truncation" in r for r in reasons))
+    def test_screen_flags_do_not_appear(self):
+        # Screens gate safe_to_delete_parquet, never all_loaded, so they must not appear as a
+        # fail-loud reason even when flagged.
+        self.assertEqual(self._reasons(vet_duplication_flagged=True, vet_truncation_flagged=True), [])
 
 
 if __name__ == "__main__":

--- a/scripts/variantstore/scripts/test/test_verify_all_loaded.py
+++ b/scripts/variantstore/scripts/test/test_verify_all_loaded.py
@@ -39,17 +39,19 @@ ALL_PAIRS = {
 }
 
 
-def _structural(completeness_ok=True, cardinality_ok=True, duplication_flagged=False,
-                truncation_flagged=False, allow_flagged_vet_loads=False):
+def _structural(completeness_ok=True, cardinality_ok=True, cross_family_ok=True,
+                duplication_flagged=False, truncation_flagged=False, allow_flagged_vet_loads=False):
     """A run_structural_checks return value with the keys verify_all_loaded consumes."""
     return {
         "completeness_ok": completeness_ok,
         "cardinality_ok": cardinality_ok,
+        "cross_family_ok": cross_family_ok,
         "duplication_flagged": duplication_flagged,
         "truncation_flagged": truncation_flagged,
         "allow_flagged_vet_loads": allow_flagged_vet_loads,
         "details": {
             "family_completeness": {"ok": completeness_ok, "per_family": {}},
+            "cross_family_consistency": {"ok": cross_family_ok, "union_size": 0, "per_family": {}},
             "cardinality": {},
             "duplication_screen": {},
             "truncation_screen": {},
@@ -103,6 +105,7 @@ class TestHappyPath(VerifyAllLoadedTestBase):
         self.assertTrue(r["structural_checks_ok"])
         self.assertTrue(r["family_completeness_ok"])
         self.assertTrue(r["ploidy_cardinality_ok"])
+        self.assertTrue(r["cross_family_consistency_ok"])
         self.assertFalse(r["vet_duplication_flagged"])
         self.assertFalse(r["vet_truncation_flagged"])
         self.assertIn("structural_checks", r)
@@ -142,6 +145,17 @@ class TestExactChecksGateAllLoaded(VerifyAllLoadedTestBase):
         self.assertFalse(r["all_loaded"])
         self.assertFalse(r["safe_to_delete_parquet"])
         self.assertFalse(r["family_completeness_ok"])
+
+    def test_cross_family_failure_blocks_all_loaded(self):
+        # A sample present in some families but absent from another (a partial upload) fails all_loaded
+        # even though every listed pair is present in BigQuery -- the cross-family gap completeness
+        # judges vacuously.
+        r = self._run(set(ALL_PAIRS), _structural(cross_family_ok=False))
+        self.assertFalse(r["all_loaded"])
+        self.assertFalse(r["safe_to_delete_parquet"])
+        self.assertFalse(r["structural_checks_ok"])
+        self.assertFalse(r["cross_family_consistency_ok"])
+        self.assertEqual(r["missing_files"], 0)
 
 
 class TestVetScreensGateDeletionNotAllLoaded(VerifyAllLoadedTestBase):
@@ -219,8 +233,9 @@ class TestStructuralDetailCapped(VerifyAllLoadedTestBase):
 
 
 class TestComputeStructuralChecksOk(unittest.TestCase):
-    """The exact structural signal that feeds all_loaded: completeness and cardinality only. The vet
-    screens are deliberately excluded -- they gate safe_to_delete_parquet, not all_loaded."""
+    """The exact structural signal that feeds all_loaded: completeness, cardinality and cross-family
+    consistency only. The vet screens are deliberately excluded -- they gate safe_to_delete_parquet,
+    not all_loaded."""
 
     def _ok(self, structural):
         return verify_all_loaded.compute_structural_checks_ok(structural)
@@ -233,6 +248,9 @@ class TestComputeStructuralChecksOk(unittest.TestCase):
 
     def test_cardinality_failure_gates(self):
         self.assertFalse(self._ok(_structural(cardinality_ok=False)))
+
+    def test_cross_family_failure_gates(self):
+        self.assertFalse(self._ok(_structural(cross_family_ok=False)))
 
     def test_screen_flags_do_not_affect_exact_signal(self):
         self.assertTrue(self._ok(_structural(duplication_flagged=True)))
@@ -304,6 +322,7 @@ class TestDescribeIncompleteReasons(unittest.TestCase):
             "unmatched_files": 0,
             "family_completeness_ok": True,
             "ploidy_cardinality_ok": True,
+            "cross_family_consistency_ok": True,
         }
         base.update(over)
         return verify_all_loaded.describe_incomplete_reasons(base)
@@ -320,6 +339,10 @@ class TestDescribeIncompleteReasons(unittest.TestCase):
         reasons = self._reasons(family_completeness_ok=False, ploidy_cardinality_ok=False)
         self.assertTrue(any("family completeness" in r for r in reasons))
         self.assertTrue(any("ploidy cardinality" in r for r in reasons))
+
+    def test_cross_family_named(self):
+        reasons = self._reasons(cross_family_consistency_ok=False)
+        self.assertTrue(any("cross-family consistency" in r for r in reasons))
 
     def test_screen_flags_do_not_appear(self):
         # Screens gate safe_to_delete_parquet, never all_loaded, so they must not appear as a

--- a/scripts/variantstore/scripts/test/test_verify_all_loaded.py
+++ b/scripts/variantstore/scripts/test/test_verify_all_loaded.py
@@ -37,17 +37,19 @@ ALL_PAIRS = {
 
 
 def _structural(completeness_ok=True, cardinality_ok=True, duplication_flagged=False,
-                strict_vet_screen=False):
+                truncation_flagged=False, strict_vet_screen=False):
     """A run_structural_checks return value with the keys verify_all_loaded consumes."""
     return {
         "completeness_ok": completeness_ok,
         "cardinality_ok": cardinality_ok,
         "duplication_flagged": duplication_flagged,
+        "truncation_flagged": truncation_flagged,
         "strict_vet_screen": strict_vet_screen,
         "details": {
             "family_completeness": {"ok": completeness_ok, "per_family": {}},
             "cardinality": {},
             "duplication_screen": {},
+            "truncation_screen": {},
             "duplication_unscreened": {"families": ["ref_ranges"], "reason": "not screened"},
         },
     }
@@ -98,6 +100,7 @@ class TestHappyPath(VerifyAllLoadedTestBase):
         self.assertTrue(r["family_completeness_ok"])
         self.assertTrue(r["ploidy_cardinality_ok"])
         self.assertFalse(r["vet_duplication_flagged"])
+        self.assertFalse(r["vet_truncation_flagged"])
         self.assertIn("structural_checks", r)
         # The JSON on disk matches the returned dict.
         self.assertEqual(self._written_json(), r)
@@ -147,6 +150,22 @@ class TestStructuralChecksGate(VerifyAllLoadedTestBase):
         self.assertFalse(r["all_loaded"])
         self.assertFalse(r["structural_checks_ok"])
         self.assertTrue(r["vet_duplication_flagged"])
+
+    def test_vet_truncation_warns_by_default(self):
+        r = self._run(set(ALL_PAIRS), _structural(truncation_flagged=True))
+        self.assertTrue(r["all_loaded"])
+        self.assertTrue(r["structural_checks_ok"])
+        self.assertTrue(r["vet_truncation_flagged"])
+
+    def test_vet_truncation_gates_under_strict(self):
+        r = self._run(
+            set(ALL_PAIRS),
+            _structural(truncation_flagged=True, strict_vet_screen=True),
+            strict_vet_screen=True,
+        )
+        self.assertFalse(r["all_loaded"])
+        self.assertFalse(r["structural_checks_ok"])
+        self.assertTrue(r["vet_truncation_flagged"])
 
 
 class TestStructuralDetailCapped(VerifyAllLoadedTestBase):

--- a/scripts/variantstore/scripts/test/test_verify_all_loaded.py
+++ b/scripts/variantstore/scripts/test/test_verify_all_loaded.py
@@ -252,5 +252,51 @@ class TestSharedPredicateStillGates(VerifyAllLoadedTestBase):
         self.assertTrue(os.path.exists(r["missing_files_list"]))
 
 
+class TestDescribeIncompleteReasons(unittest.TestCase):
+    """The fail-loud operator message names every not-all-loaded cause, including a strict truncation-only failure."""
+
+    def _reasons(self, **over):
+        base = {
+            "missing_files": 0,
+            "unmatched_files": 0,
+            "family_completeness_ok": True,
+            "ploidy_cardinality_ok": True,
+            "structural_checks_ok": True,
+            "vet_duplication_flagged": False,
+            "vet_truncation_flagged": False,
+        }
+        base.update(over)
+        return verify_all_loaded.describe_incomplete_reasons(base)
+
+    def test_clean_results_yield_no_reasons(self):
+        self.assertEqual(self._reasons(), [])
+
+    def test_missing_and_unmatched_named(self):
+        reasons = self._reasons(missing_files=3, unmatched_files=2)
+        self.assertIn("3 file(s) not yet loaded", reasons)
+        self.assertTrue(any("2 file(s) could not be parsed" in r for r in reasons))
+
+    def test_completeness_and_cardinality_named(self):
+        reasons = self._reasons(family_completeness_ok=False, ploidy_cardinality_ok=False)
+        self.assertTrue(any("family completeness" in r for r in reasons))
+        self.assertTrue(any("ploidy cardinality" in r for r in reasons))
+
+    def test_strict_duplication_only_named(self):
+        reasons = self._reasons(structural_checks_ok=False, vet_duplication_flagged=True)
+        self.assertEqual(reasons, ["vet duplication screen flagged samples (--strict-vet-screen)"])
+
+    def test_strict_truncation_only_named(self):
+        # The regression: a truncation-only strict failure must not fall through to "unknown reasons".
+        reasons = self._reasons(structural_checks_ok=False, vet_truncation_flagged=True)
+        self.assertEqual(reasons, ["vet truncation screen flagged samples (--strict-vet-screen)"])
+
+    def test_strict_both_screens_named(self):
+        reasons = self._reasons(structural_checks_ok=False,
+                                vet_duplication_flagged=True, vet_truncation_flagged=True)
+        self.assertEqual(len(reasons), 2)
+        self.assertTrue(any("duplication" in r for r in reasons))
+        self.assertTrue(any("truncation" in r for r in reasons))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/variantstore/scripts/test/test_verify_all_loaded.py
+++ b/scripts/variantstore/scripts/test/test_verify_all_loaded.py
@@ -149,6 +149,40 @@ class TestStructuralChecksGate(VerifyAllLoadedTestBase):
         self.assertTrue(r["vet_duplication_flagged"])
 
 
+class TestStructuralDetailCapped(VerifyAllLoadedTestBase):
+    def test_large_lists_capped_in_json(self):
+        # A failure that produces a huge per-sample list must not bloat the results JSON: the embedded
+        # list is capped and a sibling *_total records the true length.
+        cap = verify_all_loaded.STRUCTURAL_DETAIL_LIST_CAP
+        huge = list(range(cap + 500))
+        structural = _structural(completeness_ok=False)
+        structural["details"]["family_completeness"]["per_family"]["vet"] = {
+            "ok": False, "expected": len(huge), "present": 0,
+            "missing_samples": huge, "empty_partition_samples": [],
+        }
+
+        r = self._run(set(ALL_PAIRS), structural)
+
+        vet = r["structural_checks"]["family_completeness"]["per_family"]["vet"]
+        self.assertEqual(len(vet["missing_samples"]), cap)
+        self.assertEqual(vet["missing_samples_total"], len(huge))
+        # The on-disk JSON carries the same bounded copy.
+        self.assertEqual(self._written_json(), r)
+
+    def test_small_lists_untouched(self):
+        structural = _structural(completeness_ok=False)
+        structural["details"]["family_completeness"]["per_family"]["vet"] = {
+            "ok": False, "expected": 3, "present": 1,
+            "missing_samples": [4], "empty_partition_samples": [3],
+        }
+
+        r = self._run(set(ALL_PAIRS), structural)
+
+        vet = r["structural_checks"]["family_completeness"]["per_family"]["vet"]
+        self.assertEqual(vet["missing_samples"], [4])
+        self.assertNotIn("missing_samples_total", vet)
+
+
 class TestSharedPredicateStillGates(VerifyAllLoadedTestBase):
     def test_missing_pair_blocks_even_when_structural_ok(self):
         loaded = set(ALL_PAIRS) - {("vet_001", 2)}

--- a/scripts/variantstore/scripts/test/test_verify_structural_checks.py
+++ b/scripts/variantstore/scripts/test/test_verify_structural_checks.py
@@ -159,6 +159,40 @@ class TestAssessCardinality(unittest.TestCase):
         self.assertTrue(r["ok"])
         self.assertIsNone(r["mode"])
 
+    def test_reference_source_is_mode_by_default(self):
+        r = assess_cardinality({1: 24, 2: 24}, {1, 2})
+        self.assertEqual(r["reference_source"], "mode")
+        self.assertEqual(r["reference_count"], 24)
+
+    def test_override_matching_constant_passes(self):
+        r = assess_cardinality({1: 24, 2: 24, 3: 24}, {1, 2, 3}, expected_count=24)
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["reference_source"], "override")
+        self.assertEqual(r["reference_count"], 24)
+        self.assertEqual(r["deviating_samples"], [])
+
+    def test_override_flags_uniform_wrong_count(self):
+        # The case mode-based detection misses: every sample shares the *wrong* count. Mode would make
+        # 25 the reference and pass; the override pins 24 and flags all three, reporting observed mode.
+        counts = {1: 25, 2: 25, 3: 25}
+        self.assertTrue(assess_cardinality(counts, {1, 2, 3})["ok"])  # mode-based: passes
+        r = assess_cardinality(counts, {1, 2, 3}, expected_count=24)
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["mode"], 25)
+        self.assertEqual(r["reference_count"], 24)
+        self.assertEqual([d["sample_id"] for d in r["deviating_samples"]], [1, 2, 3])
+
+    def test_override_still_catches_missing(self):
+        r = assess_cardinality({1: 24, 2: 24}, {1, 2, 3}, expected_count=24)
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["missing_samples"], [3])
+
+    def test_override_empty_records_reference(self):
+        r = assess_cardinality({}, {1, 2}, expected_count=24)
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["reference_count"], 24)
+        self.assertEqual(r["reference_source"], "override")
+
 
 class TestAssessFamilyCompleteness(unittest.TestCase):
     def _run(self, part, reg, exp):
@@ -273,6 +307,21 @@ class TestRunStructuralChecks(unittest.TestCase):
         self.assertTrue(r["completeness_ok"])
         self.assertTrue(r["cardinality_ok"])
         self.assertFalse(r["strict_vet_screen"])
+
+    def test_expected_ploidy_override_gates_uniform_wrong_count(self):
+        # Every sample uniformly carries 25 ploidy rows. Mode-based inference passes (25 is the mode);
+        # the explicit override pins 24 and fails cardinality, gating deletion.
+        part = [("vet_001", i, 100) for i in (1, 2)] + [("ref_ranges_001", i, 50) for i in (1, 2)]
+        self._patch(part, {1: 25, 2: 25})
+        exp = {"vet": {1, 2}, "ref_ranges": {1, 2}, "sample_chromosome_ploidy": {1, 2}}
+
+        self.assertTrue(run_structural_checks("proj", "ds", exp)["cardinality_ok"])  # mode: passes
+        r = run_structural_checks("proj", "ds", exp, expected_ploidy_rows_per_sample=24)
+        self.assertFalse(r["cardinality_ok"])
+        card = r["details"]["cardinality"]["sample_chromosome_ploidy"]
+        self.assertEqual(card["reference_source"], "override")
+        self.assertEqual(card["reference_count"], 24)
+        self.assertEqual(card["mode"], 25)
 
 
 if __name__ == "__main__":

--- a/scripts/variantstore/scripts/test/test_verify_structural_checks.py
+++ b/scripts/variantstore/scripts/test/test_verify_structural_checks.py
@@ -1,0 +1,279 @@
+"""
+Unit tests for verify_structural_checks.py -- the independent, row-count-based checks added for
+VS-1989.
+
+The BigQuery-reading functions are tested by patching verify_structural_checks.bigquery and asserting
+on the generated SQL (mirroring the style in test_parquet_loading.py). The assessment functions are
+pure and are tested directly. run_structural_checks is tested with the two query helpers patched so no
+BigQuery is touched.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Add parent directory to path for imports (matches test_parquet_loading.py).
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import verify_structural_checks as vsc
+from verify_structural_checks import (
+    family_for_table,
+    get_partition_row_counts,
+    get_ploidy_row_counts,
+    assess_family_completeness,
+    assess_cardinality,
+    assess_duplication_screen,
+    run_structural_checks,
+)
+
+
+def _row(**kwargs):
+    """A stand-in BigQuery Row: attribute access returns the given values."""
+    row = MagicMock()
+    for k, val in kwargs.items():
+        setattr(row, k, val)
+    return row
+
+
+class TestFamilyForTable(unittest.TestCase):
+    def test_matches_superpartitioned_names(self):
+        self.assertEqual(family_for_table("vet_001", ["vet", "ref_ranges"]), "vet")
+        self.assertEqual(family_for_table("ref_ranges_042", ["vet", "ref_ranges"]), "ref_ranges")
+
+    def test_requires_digits_after_prefix(self):
+        self.assertIsNone(family_for_table("vet_x", ["vet"]))
+        self.assertIsNone(family_for_table("vet_", ["vet"]))
+
+    def test_does_not_match_longer_name_with_shared_start(self):
+        # "vet" must not swallow a differently-named table that merely starts with the letters.
+        self.assertIsNone(family_for_table("vetting_1", ["vet"]))
+
+    def test_returns_none_for_unknown(self):
+        self.assertIsNone(family_for_table("sample_chromosome_ploidy", ["vet", "ref_ranges"]))
+
+
+class TestGetPartitionRowCounts(unittest.TestCase):
+    @patch("verify_structural_checks.bigquery")
+    def test_query_reads_total_rows_and_not_bytes(self, mock_bq):
+        mock_client = MagicMock()
+        mock_bq.Client.return_value = mock_client
+        mock_client.query.return_value = []
+
+        get_partition_row_counts("proj", "ds", ["vet", "ref_ranges"])
+
+        query = mock_client.query.call_args[0][0]
+        self.assertIn("INFORMATION_SCHEMA.PARTITIONS", query)
+        self.assertIn("total_rows", query)
+        self.assertIn("^vet_[0-9]+$", query)
+        self.assertIn("^ref_ranges_[0-9]+$", query)
+        # Independence from the loader predicate: it must NOT gate on bytes.
+        self.assertNotIn("total_logical_bytes", query)
+
+    @patch("verify_structural_checks.bigquery")
+    def test_returns_tuples(self, mock_bq):
+        mock_client = MagicMock()
+        mock_bq.Client.return_value = mock_client
+        mock_client.query.return_value = [
+            _row(table_name="vet_001", sample_id=1, total_rows=100),
+            _row(table_name="ref_ranges_001", sample_id=1, total_rows=50),
+        ]
+
+        result = get_partition_row_counts("proj", "ds", ["vet", "ref_ranges"])
+
+        self.assertEqual(result, [("vet_001", 1, 100), ("ref_ranges_001", 1, 50)])
+
+    @patch("verify_structural_checks.bigquery")
+    def test_empty_prefixes_skips_query(self, mock_bq):
+        mock_client = MagicMock()
+        mock_bq.Client.return_value = mock_client
+
+        self.assertEqual(get_partition_row_counts("proj", "ds", []), [])
+        mock_client.query.assert_not_called()
+
+    def test_invalid_prefix_raises(self):
+        with self.assertRaises(ValueError):
+            get_partition_row_counts("proj", "ds", ["vet; DROP TABLE x--"])
+
+
+class TestGetPloidyRowCounts(unittest.TestCase):
+    @patch("verify_structural_checks.bigquery")
+    def test_query_groups_by_sample(self, mock_bq):
+        mock_client = MagicMock()
+        mock_bq.Client.return_value = mock_client
+        mock_client.query.return_value = [_row(sample_id=1, n=24), _row(sample_id=2, n=24)]
+
+        result = get_ploidy_row_counts("proj", "ds", "sample_chromosome_ploidy")
+
+        query = mock_client.query.call_args[0][0]
+        self.assertIn("sample_chromosome_ploidy", query)
+        self.assertIn("GROUP BY sample_id", query)
+        self.assertIn("COUNT(*)", query)
+        self.assertEqual(result, {1: 24, 2: 24})
+
+    def test_invalid_table_raises(self):
+        with self.assertRaises(ValueError):
+            get_ploidy_row_counts("proj", "ds", "bad table")
+
+
+class TestAssessCardinality(unittest.TestCase):
+    def test_uniform_counts_pass(self):
+        r = assess_cardinality({i: 24 for i in range(1, 6)}, set(range(1, 6)))
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["mode"], 24)
+        self.assertEqual(r["distinct_samples"], 5)
+        self.assertEqual(r["deviating_samples"], [])
+
+    def test_does_not_assume_24(self):
+        # A callset whose modal count is 25 (e.g. chrM ingested) still passes when uniform.
+        r = assess_cardinality({i: 25 for i in range(1, 4)}, set(range(1, 4)))
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["mode"], 25)
+
+    def test_missing_sample_fails(self):
+        r = assess_cardinality({1: 24, 2: 24}, {1, 2, 3})
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["missing_samples"], [3])
+
+    def test_partial_and_duplicate_flagged(self):
+        # sample 3 short (partial load), sample 4 doubled (duplication).
+        r = assess_cardinality({1: 24, 2: 24, 3: 20, 4: 48, 5: 24}, set(range(1, 6)))
+        self.assertFalse(r["ok"])
+        self.assertEqual({d["sample_id"] for d in r["deviating_samples"]}, {3, 4})
+        self.assertEqual(r["min"], 20)
+        self.assertEqual(r["max"], 48)
+
+    def test_extra_samples_in_table_ignored(self):
+        # A sample already in the table from a prior load (99) is not expected this run: ignored.
+        r = assess_cardinality({1: 24, 2: 24, 99: 24}, {1, 2})
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["distinct_samples"], 2)
+
+    def test_zero_count_treated_as_missing(self):
+        r = assess_cardinality({1: 24, 2: 0}, {1, 2})
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["missing_samples"], [2])
+
+    def test_no_expected_is_ok(self):
+        r = assess_cardinality({}, set())
+        self.assertTrue(r["ok"])
+        self.assertIsNone(r["mode"])
+
+
+class TestAssessFamilyCompleteness(unittest.TestCase):
+    def _run(self, part, reg, exp):
+        return assess_family_completeness(
+            part, reg, exp, ["vet", "ref_ranges"], ["sample_chromosome_ploidy"]
+        )
+
+    def test_all_present_passes(self):
+        part = [("vet_001", 1, 100), ("vet_001", 2, 100),
+                ("ref_ranges_001", 1, 50), ("ref_ranges_001", 2, 50)]
+        reg = {"sample_chromosome_ploidy": {1: 24, 2: 24}}
+        exp = {"vet": {1, 2}, "ref_ranges": {1, 2}, "sample_chromosome_ploidy": {1, 2}}
+        r = self._run(part, reg, exp)
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["per_family"]["vet"]["present"], 2)
+
+    def test_empty_partition_is_partial_load(self):
+        # sample 2 has a vet partition with 0 rows -> present to a bytes-based check, empty in fact.
+        part = [("vet_001", 1, 100), ("vet_001", 2, 0),
+                ("ref_ranges_001", 1, 50), ("ref_ranges_001", 2, 50)]
+        reg = {"sample_chromosome_ploidy": {1: 24, 2: 24}}
+        exp = {"vet": {1, 2}, "ref_ranges": {1, 2}, "sample_chromosome_ploidy": {1, 2}}
+        r = self._run(part, reg, exp)
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["per_family"]["vet"]["empty_partition_samples"], [2])
+
+    def test_missing_sample_in_one_family(self):
+        part = [("vet_001", 1, 100), ("ref_ranges_001", 1, 50)]  # sample 2 absent everywhere
+        reg = {"sample_chromosome_ploidy": {1: 24}}
+        exp = {"vet": {1, 2}, "ref_ranges": {1, 2}, "sample_chromosome_ploidy": {1, 2}}
+        r = self._run(part, reg, exp)
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["per_family"]["vet"]["missing_samples"], [2])
+        self.assertEqual(r["per_family"]["sample_chromosome_ploidy"]["missing_samples"], [2])
+
+    def test_empty_partition_for_unexpected_sample_ignored(self):
+        # A 0-row partition for a sample not expected this run must not fail completeness.
+        part = [("vet_001", 1, 100), ("vet_001", 9, 0), ("ref_ranges_001", 1, 50)]
+        reg = {"sample_chromosome_ploidy": {1: 24}}
+        exp = {"vet": {1}, "ref_ranges": {1}, "sample_chromosome_ploidy": {1}}
+        r = self._run(part, reg, exp)
+        self.assertTrue(r["ok"])
+
+
+class TestAssessDuplicationScreen(unittest.TestCase):
+    def test_flags_high_outlier(self):
+        part = [("vet_001", i, 100) for i in range(1, 9)] + [("vet_001", 9, 220)]
+        r = assess_duplication_screen(part, "vet", set(range(1, 10)), ["vet", "ref_ranges"], 1.6)
+        self.assertEqual(r["median"], 100)
+        self.assertEqual([o["sample_id"] for o in r["outliers"]], [9])
+        self.assertAlmostEqual(r["outliers"][0]["ratio"], 2.2)
+
+    def test_uniform_no_outliers(self):
+        part = [("vet_001", i, 100) for i in range(1, 6)]
+        r = assess_duplication_screen(part, "vet", set(range(1, 6)), ["vet", "ref_ranges"], 1.6)
+        self.assertEqual(r["outliers"], [])
+
+    def test_other_family_not_screened(self):
+        part = [("vet_001", i, 100) for i in range(1, 6)]
+        r = assess_duplication_screen(part, "ref_ranges", set(range(1, 6)), ["vet", "ref_ranges"], 1.6)
+        self.assertEqual(r["samples_screened"], 0)
+        self.assertEqual(r["outliers"], [])
+
+    def test_only_expected_samples_screened(self):
+        part = [("vet_001", i, 100) for i in range(1, 6)] + [("vet_001", 99, 1000)]
+        r = assess_duplication_screen(part, "vet", set(range(1, 6)), ["vet", "ref_ranges"], 1.6)
+        self.assertEqual(r["samples_screened"], 5)
+        self.assertEqual(r["outliers"], [])
+
+
+class TestRunStructuralChecks(unittest.TestCase):
+    """run_structural_checks with the two BigQuery helpers patched (no BQ touched)."""
+
+    def _patch(self, partition_rows, ploidy_counts):
+        p1 = patch("verify_structural_checks.get_partition_row_counts", return_value=partition_rows)
+        p2 = patch("verify_structural_checks.get_ploidy_row_counts", return_value=ploidy_counts)
+        p1.start()
+        p2.start()
+        self.addCleanup(p1.stop)
+        self.addCleanup(p2.stop)
+
+    def test_all_good(self):
+        part = [("vet_001", i, 100) for i in (1, 2)] + [("ref_ranges_001", i, 50) for i in (1, 2)]
+        self._patch(part, {1: 24, 2: 24})
+        exp = {"vet": {1, 2}, "ref_ranges": {1, 2}, "sample_chromosome_ploidy": {1, 2}}
+        r = run_structural_checks("proj", "ds", exp)
+        self.assertTrue(r["completeness_ok"])
+        self.assertTrue(r["cardinality_ok"])
+        self.assertFalse(r["duplication_flagged"])
+        self.assertIn("ref_ranges", r["details"]["duplication_unscreened"]["families"])
+        self.assertNotIn("vet", r["details"]["duplication_unscreened"]["families"])
+        self.assertIn("backfill_caveat", r["details"]["cardinality"]["sample_chromosome_ploidy"])
+
+    def test_partial_ploidy_load_fails_cardinality(self):
+        part = [("vet_001", i, 100) for i in (1, 2)] + [("ref_ranges_001", i, 50) for i in (1, 2)]
+        self._patch(part, {1: 24, 2: 20})  # sample 2 short
+        exp = {"vet": {1, 2}, "ref_ranges": {1, 2}, "sample_chromosome_ploidy": {1, 2}}
+        r = run_structural_checks("proj", "ds", exp)
+        self.assertTrue(r["completeness_ok"])
+        self.assertFalse(r["cardinality_ok"])
+
+    def test_vet_duplication_flag_warns_not_gates_by_default(self):
+        part = [("vet_001", i, 100) for i in range(1, 9)] + [("vet_001", 9, 300)]
+        part += [("ref_ranges_001", i, 50) for i in range(1, 10)]
+        self._patch(part, {i: 24 for i in range(1, 10)})
+        exp = {"vet": set(range(1, 10)), "ref_ranges": set(range(1, 10)),
+               "sample_chromosome_ploidy": set(range(1, 10))}
+
+        r = run_structural_checks("proj", "ds", exp, strict_vet_screen=False)
+        self.assertTrue(r["duplication_flagged"])
+        # Completeness and cardinality (the hard gates) are unaffected by a warn-only screen.
+        self.assertTrue(r["completeness_ok"])
+        self.assertTrue(r["cardinality_ok"])
+        self.assertFalse(r["strict_vet_screen"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/variantstore/scripts/test/test_verify_structural_checks.py
+++ b/scripts/variantstore/scripts/test/test_verify_structural_checks.py
@@ -480,5 +480,35 @@ class TestRunStructuralChecks(unittest.TestCase):
         self.assertTrue(r["cardinality_ok"])  # ploidy still uniform
 
 
+class TestThresholdValidation(unittest.TestCase):
+    """run_structural_checks rejects a nonsensical duplication/truncation ratio before any BigQuery read."""
+
+    def _call(self, threshold):
+        # An invalid threshold must raise before get_partition_row_counts is reached, so no patching is
+        # needed; if the guard were removed the call would instead try to touch BigQuery and error with
+        # a different type, failing these assertRaisesRegex checks.
+        run_structural_checks("proj", "ds", {"vet": {1}}, vet_duplication_threshold=threshold)
+
+    def test_zero_rejected(self):
+        with self.assertRaisesRegex(ValueError, "vet_duplication_threshold"):
+            self._call(0)
+
+    def test_one_rejected(self):
+        with self.assertRaisesRegex(ValueError, "vet_duplication_threshold"):
+            self._call(1)
+
+    def test_below_one_rejected(self):
+        with self.assertRaisesRegex(ValueError, "vet_duplication_threshold"):
+            self._call(0.5)
+
+    def test_infinite_rejected(self):
+        with self.assertRaisesRegex(ValueError, "vet_duplication_threshold"):
+            self._call(float("inf"))
+
+    def test_nan_rejected(self):
+        with self.assertRaisesRegex(ValueError, "vet_duplication_threshold"):
+            self._call(float("nan"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/variantstore/scripts/test/test_verify_structural_checks.py
+++ b/scripts/variantstore/scripts/test/test_verify_structural_checks.py
@@ -257,36 +257,46 @@ class TestAssessFamilyCompleteness(unittest.TestCase):
 
 
 class TestAssessCrossFamilyConsistency(unittest.TestCase):
-    """The cross-family gap assess_family_completeness judges vacuously: a sample present in some
-    families' GCS listing but absent from another's."""
+    """The cross-family gaps assess_family_completeness judges vacuously: a sample present in some
+    required families but absent from another, and an entirely absent required family."""
+
+    REQUIRED = ["vet", "ref_ranges", "sample_chromosome_ploidy"]
 
     def test_identical_family_sets_pass(self):
         exp = {"vet": {1, 2}, "ref_ranges": {1, 2}, "sample_chromosome_ploidy": {1, 2}}
-        r = assess_cross_family_consistency(exp)
+        r = assess_cross_family_consistency(exp, self.REQUIRED)
         self.assertTrue(r["ok"])
         self.assertEqual(r["union_size"], 2)
 
     def test_sample_missing_from_one_family_flagged(self):
-        # sample 2 was produced for vet and ploidy but its ref_ranges file never landed -- the exact
+        # sample 2 was produced for vet and ploidy but its ref_ranges file never landed -- the per-sample
         # cross-family gap. completeness would pass ref_ranges vacuously (it only expects {1}); this
         # catches it.
         exp = {"vet": {1, 2}, "ref_ranges": {1}, "sample_chromosome_ploidy": {1, 2}}
-        r = assess_cross_family_consistency(exp)
+        r = assess_cross_family_consistency(exp, self.REQUIRED)
         self.assertFalse(r["ok"])
         self.assertEqual(r["union_size"], 2)
         self.assertEqual(r["per_family"]["ref_ranges"]["missing_samples"], [2])
         self.assertTrue(r["per_family"]["vet"]["ok"])
         self.assertTrue(r["per_family"]["sample_chromosome_ploidy"]["ok"])
 
-    def test_single_family_run_passes_trivially(self):
-        # A run that legitimately lists only one family has a union equal to that family, so nothing is
-        # missing -- the check must not fire (that would be the whole-family case, VS-2016 territory).
-        r = assess_cross_family_consistency({"ref_ranges": {1, 2, 3}})
-        self.assertTrue(r["ok"])
+    def test_entirely_absent_required_family_flagged(self):
+        # No vet file was produced for any sample, so vet has no key in expected_by_family -- but it is a
+        # required family, so it is compared as the empty set and flagged missing every sample the other
+        # families carry. (Regression for the whole-family hole: a union over only present families would
+        # drop vet and pass, authorizing deletion of Parquet that lacks all variant data.)
+        exp = {"ref_ranges": {1, 2, 3}, "sample_chromosome_ploidy": {1, 2, 3}}
+        r = assess_cross_family_consistency(exp, self.REQUIRED)
+        self.assertFalse(r["ok"])
         self.assertEqual(r["union_size"], 3)
+        self.assertEqual(r["per_family"]["vet"]["missing_samples"], [1, 2, 3])
+        self.assertTrue(r["per_family"]["ref_ranges"]["ok"])
+        self.assertTrue(r["per_family"]["sample_chromosome_ploidy"]["ok"])
 
-    def test_empty_input_passes(self):
-        r = assess_cross_family_consistency({})
+    def test_headers_only_run_passes(self):
+        # A run that produced none of the required data families has an empty union, so no required family
+        # is missing anything -- a legitimate headers-only ingest must not be flagged.
+        r = assess_cross_family_consistency({}, self.REQUIRED)
         self.assertTrue(r["ok"])
         self.assertEqual(r["union_size"], 0)
 
@@ -408,6 +418,21 @@ class TestRunStructuralChecks(unittest.TestCase):
         self.assertFalse(r["cross_family_ok"])
         self.assertEqual(
             r["details"]["cross_family_consistency"]["per_family"]["ref_ranges"]["missing_samples"], [2]
+        )
+
+    def test_entirely_absent_family_fails(self):
+        # No vet files at all; ref_ranges + ploidy present for every sample. Completeness passes (nothing
+        # is "expected" for vet, so it is never iterated), but vet is a required family (from the default
+        # prefixes), so the cross-family check compares it as empty and fails all_loaded -- blocking
+        # deletion of Parquet that lacks all variant data.
+        part = [("ref_ranges_001", i, 50) for i in (1, 2)]
+        self._patch(part, {1: 24, 2: 24})
+        exp = {"ref_ranges": {1, 2}, "sample_chromosome_ploidy": {1, 2}}
+        r = run_structural_checks("proj", "ds", exp)
+        self.assertTrue(r["completeness_ok"])
+        self.assertFalse(r["cross_family_ok"])
+        self.assertEqual(
+            r["details"]["cross_family_consistency"]["per_family"]["vet"]["missing_samples"], [1, 2]
         )
 
     def test_partial_ploidy_load_fails_cardinality(self):

--- a/scripts/variantstore/scripts/test/test_verify_structural_checks.py
+++ b/scripts/variantstore/scripts/test/test_verify_structural_checks.py
@@ -257,14 +257,16 @@ class TestAssessFamilyCompleteness(unittest.TestCase):
 
 
 class TestAssessCrossFamilyConsistency(unittest.TestCase):
-    """The cross-family gaps assess_family_completeness judges vacuously: a sample present in some
-    required families but absent from another, and an entirely absent required family."""
+    """The cross-family gaps assess_family_completeness judges vacuously: within the co-produced data
+    group (vet / ref_ranges / ploidy, emitted together per sample), a sample present in some members but
+    absent from another, and an entirely absent member. The check is presence-activated -- dormant unless
+    a group member has files this run -- so a headers-only ingest, which produces none of these, passes."""
 
-    REQUIRED = ["vet", "ref_ranges", "sample_chromosome_ploidy"]
+    CO_PRODUCED = ["vet", "ref_ranges", "sample_chromosome_ploidy"]
 
     def test_identical_family_sets_pass(self):
         exp = {"vet": {1, 2}, "ref_ranges": {1, 2}, "sample_chromosome_ploidy": {1, 2}}
-        r = assess_cross_family_consistency(exp, self.REQUIRED)
+        r = assess_cross_family_consistency(exp, self.CO_PRODUCED)
         self.assertTrue(r["ok"])
         self.assertEqual(r["union_size"], 2)
 
@@ -273,30 +275,42 @@ class TestAssessCrossFamilyConsistency(unittest.TestCase):
         # cross-family gap. completeness would pass ref_ranges vacuously (it only expects {1}); this
         # catches it.
         exp = {"vet": {1, 2}, "ref_ranges": {1}, "sample_chromosome_ploidy": {1, 2}}
-        r = assess_cross_family_consistency(exp, self.REQUIRED)
+        r = assess_cross_family_consistency(exp, self.CO_PRODUCED)
         self.assertFalse(r["ok"])
         self.assertEqual(r["union_size"], 2)
         self.assertEqual(r["per_family"]["ref_ranges"]["missing_samples"], [2])
         self.assertTrue(r["per_family"]["vet"]["ok"])
         self.assertTrue(r["per_family"]["sample_chromosome_ploidy"]["ok"])
 
-    def test_entirely_absent_required_family_flagged(self):
-        # No vet file was produced for any sample, so vet has no key in expected_by_family -- but it is a
-        # required family, so it is compared as the empty set and flagged missing every sample the other
-        # families carry. (Regression for the whole-family hole: a union over only present families would
-        # drop vet and pass, authorizing deletion of Parquet that lacks all variant data.)
+    def test_entirely_absent_member_flagged(self):
+        # No vet file was produced for any sample, so vet has no key in expected_by_family -- but a sibling
+        # member (ref_ranges / ploidy) is present, so the check activates and vet is compared as the empty
+        # set and flagged missing every sample the other members carry. (Regression for the whole-family
+        # hole: a union over only present families would drop vet and pass, authorizing deletion of Parquet
+        # that lacks all variant data.)
         exp = {"ref_ranges": {1, 2, 3}, "sample_chromosome_ploidy": {1, 2, 3}}
-        r = assess_cross_family_consistency(exp, self.REQUIRED)
+        r = assess_cross_family_consistency(exp, self.CO_PRODUCED)
         self.assertFalse(r["ok"])
         self.assertEqual(r["union_size"], 3)
         self.assertEqual(r["per_family"]["vet"]["missing_samples"], [1, 2, 3])
         self.assertTrue(r["per_family"]["ref_ranges"]["ok"])
         self.assertTrue(r["per_family"]["sample_chromosome_ploidy"]["ok"])
 
-    def test_headers_only_run_passes(self):
-        # A run that produced none of the required data families has an empty union, so no required family
-        # is missing anything -- a legitimate headers-only ingest must not be flagged.
-        r = assess_cross_family_consistency({}, self.REQUIRED)
+    def test_headers_only_run_with_scratch_samples_passes(self):
+        # A supported headers-only ingest lists only vcf_header_lines_scratch in GCS -- with real samples --
+        # while the data prefixes are configured but produce nothing. vcf_header_lines_scratch is not a
+        # co-produced member, so no member is present, the check is dormant, and the run passes. (Regression
+        # for the R10 whole-family fix rejecting the headers-only path: taking the union over every
+        # configured prefix reported every header sample missing from all three data families.)
+        exp = {"vcf_header_lines_scratch": {1, 2, 3}}
+        r = assess_cross_family_consistency(exp, self.CO_PRODUCED)
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["union_size"], 0)
+        self.assertEqual(r["per_family"], {})
+
+    def test_empty_run_passes(self):
+        # No family produced anything at all: no member present, dormant, passes.
+        r = assess_cross_family_consistency({}, self.CO_PRODUCED)
         self.assertTrue(r["ok"])
         self.assertEqual(r["union_size"], 0)
 
@@ -422,8 +436,8 @@ class TestRunStructuralChecks(unittest.TestCase):
 
     def test_entirely_absent_family_fails(self):
         # No vet files at all; ref_ranges + ploidy present for every sample. Completeness passes (nothing
-        # is "expected" for vet, so it is never iterated), but vet is a required family (from the default
-        # prefixes), so the cross-family check compares it as empty and fails all_loaded -- blocking
+        # is "expected" for vet, so it is never iterated), but its co-produced siblings are present, so the
+        # cross-family check activates, compares vet as the empty set, and fails all_loaded -- blocking
         # deletion of Parquet that lacks all variant data.
         part = [("ref_ranges_001", i, 50) for i in (1, 2)]
         self._patch(part, {1: 24, 2: 24})
@@ -434,6 +448,33 @@ class TestRunStructuralChecks(unittest.TestCase):
         self.assertEqual(
             r["details"]["cross_family_consistency"]["per_family"]["vet"]["missing_samples"], [1, 2]
         )
+
+    def test_headers_only_run_passes(self):
+        # A supported headers-only ingest: the WDL configures the data prefixes (vet / ref_ranges /
+        # sample_chromosome_ploidy) alongside vcf_header_lines_scratch, but only header files land, so GCS
+        # lists samples for vcf_header_lines_scratch alone. Completeness passes (only that family is
+        # expected and every sample has header rows), cardinality skips it (variable per-sample counts),
+        # and the cross-family check stays dormant because no co-produced member is present -- so the run
+        # is not falsely reported incomplete. (Regression for the R10 whole-family fix, which took the
+        # union over every configured prefix and reported every header sample missing from all three data
+        # families.)
+        self._patch_regular(
+            [],
+            {
+                "vcf_header_lines_scratch": {1: 10, 2: 12, 3: 8},
+                "sample_chromosome_ploidy": {},
+            },
+        )
+        exp = {"vcf_header_lines_scratch": {1, 2, 3}}
+        r = run_structural_checks(
+            "proj", "ds", exp,
+            superpartitioned_table_prefixes=["vet", "ref_ranges"],
+            regular_table_prefixes=["sample_chromosome_ploidy", "vcf_header_lines_scratch"],
+        )
+        self.assertTrue(r["completeness_ok"])
+        self.assertTrue(r["cardinality_ok"])
+        self.assertTrue(r["cross_family_ok"])
+        self.assertEqual(r["details"]["cross_family_consistency"]["per_family"], {})
 
     def test_partial_ploidy_load_fails_cardinality(self):
         part = [("vet_001", i, 100) for i in (1, 2)] + [("ref_ranges_001", i, 50) for i in (1, 2)]

--- a/scripts/variantstore/scripts/test/test_verify_structural_checks.py
+++ b/scripts/variantstore/scripts/test/test_verify_structural_checks.py
@@ -24,6 +24,7 @@ from verify_structural_checks import (
     assess_family_completeness,
     assess_cardinality,
     assess_duplication_screen,
+    assess_truncation_screen,
     run_structural_checks,
 )
 
@@ -280,6 +281,49 @@ class TestAssessDuplicationScreen(unittest.TestCase):
         self.assertEqual(r["outliers"], [])
 
 
+class TestAssessTruncationScreen(unittest.TestCase):
+    """Low-side mirror of the duplication screen: flags a grossly under-rowed vet partition."""
+
+    def test_flags_low_outlier(self):
+        # sample 9 has 1 row where its peers have 100 -- a truncated partition. floor = 100/1.6 = 62.5.
+        part = [("vet_001", i, 100) for i in range(1, 9)] + [("vet_001", 9, 1)]
+        r = assess_truncation_screen(part, "vet", set(range(1, 10)), ["vet", "ref_ranges"], 1.6)
+        self.assertEqual(r["median"], 100)
+        self.assertEqual([o["sample_id"] for o in r["outliers"]], [9])
+        self.assertAlmostEqual(r["outliers"][0]["ratio"], 0.01)
+
+    def test_uniform_no_outliers(self):
+        part = [("vet_001", i, 100) for i in range(1, 6)]
+        r = assess_truncation_screen(part, "vet", set(range(1, 6)), ["vet", "ref_ranges"], 1.6)
+        self.assertEqual(r["outliers"], [])
+
+    def test_mild_dip_within_threshold_not_flagged(self):
+        # A sample at 70% of the median is above the floor (median/1.6 = 62.5%) and must not flag.
+        part = [("vet_001", i, 100) for i in range(1, 9)] + [("vet_001", 9, 70)]
+        r = assess_truncation_screen(part, "vet", set(range(1, 10)), ["vet", "ref_ranges"], 1.6)
+        self.assertEqual(r["outliers"], [])
+
+    def test_zero_row_partition_not_screened(self):
+        # A 0-row partition is the completeness check's empty case, not truncation's: it is excluded
+        # here (only present, non-empty partitions are judged) so it is not double-reported.
+        part = [("vet_001", i, 100) for i in range(1, 6)] + [("vet_001", 6, 0)]
+        r = assess_truncation_screen(part, "vet", set(range(1, 7)), ["vet", "ref_ranges"], 1.6)
+        self.assertEqual(r["samples_screened"], 5)
+        self.assertEqual(r["outliers"], [])
+
+    def test_other_family_not_screened(self):
+        part = [("vet_001", i, 100) for i in range(1, 6)]
+        r = assess_truncation_screen(part, "ref_ranges", set(range(1, 6)), ["vet", "ref_ranges"], 1.6)
+        self.assertEqual(r["samples_screened"], 0)
+        self.assertEqual(r["outliers"], [])
+
+    def test_only_expected_samples_screened(self):
+        part = [("vet_001", i, 100) for i in range(1, 6)] + [("vet_001", 99, 1)]
+        r = assess_truncation_screen(part, "vet", set(range(1, 6)), ["vet", "ref_ranges"], 1.6)
+        self.assertEqual(r["samples_screened"], 5)
+        self.assertEqual(r["outliers"], [])
+
+
 class TestRunStructuralChecks(unittest.TestCase):
     """run_structural_checks with the two BigQuery helpers patched (no BQ touched)."""
 
@@ -336,6 +380,38 @@ class TestRunStructuralChecks(unittest.TestCase):
         self.assertTrue(r["completeness_ok"])
         self.assertTrue(r["cardinality_ok"])
         self.assertFalse(r["strict_vet_screen"])
+
+    def test_nonzero_truncated_vet_partition_flagged_not_gated_by_default(self):
+        # Regression for the Copilot finding: a vet partition present with a *nonzero* but grossly
+        # truncated row count (1 where peers have 100) passes completeness (it is not empty) and is not
+        # a high-side duplicate, yet the low-side truncation screen surfaces it. Warn-only by default,
+        # so the hard gates stay green and deletion is not blocked unless --strict-vet-screen is set.
+        part = [("vet_001", i, 100) for i in range(1, 9)] + [("vet_001", 9, 1)]
+        part += [("ref_ranges_001", i, 50) for i in range(1, 10)]
+        self._patch(part, {i: 24 for i in range(1, 10)})
+        exp = {"vet": set(range(1, 10)), "ref_ranges": set(range(1, 10)),
+               "sample_chromosome_ploidy": set(range(1, 10))}
+
+        r = run_structural_checks("proj", "ds", exp, strict_vet_screen=False)
+        self.assertTrue(r["truncation_flagged"])
+        self.assertFalse(r["duplication_flagged"])
+        # The hard gates do not see it -- present and non-empty, uniform ploidy.
+        self.assertTrue(r["completeness_ok"])
+        self.assertTrue(r["cardinality_ok"])
+        truncation = r["details"]["truncation_screen"]["vet"]
+        self.assertEqual([o["sample_id"] for o in truncation["outliers"]], [9])
+
+    def test_truncation_screen_covers_vet_only(self):
+        # ref_ranges is deliberately unscreened (wide per-sample distribution), so its detail is a
+        # zero-sample screen even when a ref_ranges partition is tiny.
+        part = ([("vet_001", i, 100) for i in (1, 2)]
+                + [("ref_ranges_001", 1, 50), ("ref_ranges_001", 2, 1)])
+        self._patch(part, {1: 24, 2: 24})
+        exp = {"vet": {1, 2}, "ref_ranges": {1, 2}, "sample_chromosome_ploidy": {1, 2}}
+        r = run_structural_checks("proj", "ds", exp)
+        self.assertFalse(r["truncation_flagged"])
+        self.assertIn("vet", r["details"]["truncation_screen"])
+        self.assertNotIn("ref_ranges", r["details"]["truncation_screen"])
 
     def test_expected_ploidy_override_gates_uniform_wrong_count(self):
         # Every sample uniformly carries 25 ploidy rows. Mode-based inference passes (25 is the mode);

--- a/scripts/variantstore/scripts/test/test_verify_structural_checks.py
+++ b/scripts/variantstore/scripts/test/test_verify_structural_checks.py
@@ -22,6 +22,7 @@ from verify_structural_checks import (
     get_partition_row_counts,
     get_ploidy_row_counts,
     assess_family_completeness,
+    assess_cross_family_consistency,
     assess_cardinality,
     assess_duplication_screen,
     assess_truncation_screen,
@@ -255,6 +256,41 @@ class TestAssessFamilyCompleteness(unittest.TestCase):
         self.assertTrue(r["ok"])
 
 
+class TestAssessCrossFamilyConsistency(unittest.TestCase):
+    """The cross-family gap assess_family_completeness judges vacuously: a sample present in some
+    families' GCS listing but absent from another's."""
+
+    def test_identical_family_sets_pass(self):
+        exp = {"vet": {1, 2}, "ref_ranges": {1, 2}, "sample_chromosome_ploidy": {1, 2}}
+        r = assess_cross_family_consistency(exp)
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["union_size"], 2)
+
+    def test_sample_missing_from_one_family_flagged(self):
+        # sample 2 was produced for vet and ploidy but its ref_ranges file never landed -- the exact
+        # cross-family gap. completeness would pass ref_ranges vacuously (it only expects {1}); this
+        # catches it.
+        exp = {"vet": {1, 2}, "ref_ranges": {1}, "sample_chromosome_ploidy": {1, 2}}
+        r = assess_cross_family_consistency(exp)
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["union_size"], 2)
+        self.assertEqual(r["per_family"]["ref_ranges"]["missing_samples"], [2])
+        self.assertTrue(r["per_family"]["vet"]["ok"])
+        self.assertTrue(r["per_family"]["sample_chromosome_ploidy"]["ok"])
+
+    def test_single_family_run_passes_trivially(self):
+        # A run that legitimately lists only one family has a union equal to that family, so nothing is
+        # missing -- the check must not fire (that would be the whole-family case, VS-2016 territory).
+        r = assess_cross_family_consistency({"ref_ranges": {1, 2, 3}})
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["union_size"], 3)
+
+    def test_empty_input_passes(self):
+        r = assess_cross_family_consistency({})
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["union_size"], 0)
+
+
 class TestAssessDuplicationScreen(unittest.TestCase):
     def test_flags_high_outlier(self):
         part = [("vet_001", i, 100) for i in range(1, 9)] + [("vet_001", 9, 220)]
@@ -354,10 +390,25 @@ class TestRunStructuralChecks(unittest.TestCase):
         r = run_structural_checks("proj", "ds", exp)
         self.assertTrue(r["completeness_ok"])
         self.assertTrue(r["cardinality_ok"])
+        self.assertTrue(r["cross_family_ok"])
         self.assertFalse(r["duplication_flagged"])
         self.assertIn("ref_ranges", r["details"]["duplication_unscreened"]["families"])
         self.assertNotIn("vet", r["details"]["duplication_unscreened"]["families"])
         self.assertIn("backfill_caveat", r["details"]["cardinality"]["sample_chromosome_ploidy"])
+
+    def test_cross_family_gap_fails(self):
+        # sample 2's ref_ranges file was never produced, so GCS lists it only for vet/ploidy. Every
+        # listed pair is present in BigQuery, so completeness passes (ref_ranges only expected {1});
+        # the cross-family check catches the gap.
+        part = [("vet_001", i, 100) for i in (1, 2)] + [("ref_ranges_001", 1, 50)]
+        self._patch(part, {1: 24, 2: 24})
+        exp = {"vet": {1, 2}, "ref_ranges": {1}, "sample_chromosome_ploidy": {1, 2}}
+        r = run_structural_checks("proj", "ds", exp)
+        self.assertTrue(r["completeness_ok"])
+        self.assertFalse(r["cross_family_ok"])
+        self.assertEqual(
+            r["details"]["cross_family_consistency"]["per_family"]["ref_ranges"]["missing_samples"], [2]
+        )
 
     def test_partial_ploidy_load_fails_cardinality(self):
         part = [("vet_001", i, 100) for i in (1, 2)] + [("ref_ranges_001", i, 50) for i in (1, 2)]

--- a/scripts/variantstore/scripts/test/test_verify_structural_checks.py
+++ b/scripts/variantstore/scripts/test/test_verify_structural_checks.py
@@ -374,25 +374,27 @@ class TestRunStructuralChecks(unittest.TestCase):
         exp = {"vet": set(range(1, 10)), "ref_ranges": set(range(1, 10)),
                "sample_chromosome_ploidy": set(range(1, 10))}
 
-        r = run_structural_checks("proj", "ds", exp, strict_vet_screen=False)
+        r = run_structural_checks("proj", "ds", exp, allow_flagged_vet_loads=False)
         self.assertTrue(r["duplication_flagged"])
-        # Completeness and cardinality (the hard gates) are unaffected by a warn-only screen.
+        # Completeness and cardinality (the exact checks that gate all_loaded) are unaffected by a
+        # screen flag; the screen only bears on safe_to_delete_parquet.
         self.assertTrue(r["completeness_ok"])
         self.assertTrue(r["cardinality_ok"])
-        self.assertFalse(r["strict_vet_screen"])
+        self.assertFalse(r["allow_flagged_vet_loads"])
 
     def test_nonzero_truncated_vet_partition_flagged_not_gated_by_default(self):
         # Regression for the Copilot finding: a vet partition present with a *nonzero* but grossly
         # truncated row count (1 where peers have 100) passes completeness (it is not empty) and is not
-        # a high-side duplicate, yet the low-side truncation screen surfaces it. Warn-only by default,
-        # so the hard gates stay green and deletion is not blocked unless --strict-vet-screen is set.
+        # a high-side duplicate, yet the low-side truncation screen surfaces it. The exact checks stay
+        # green (so all_loaded stays true); the flag bears only on safe_to_delete_parquet, which blocks
+        # deletion by default unless --allow-flagged-vet-loads is set.
         part = [("vet_001", i, 100) for i in range(1, 9)] + [("vet_001", 9, 1)]
         part += [("ref_ranges_001", i, 50) for i in range(1, 10)]
         self._patch(part, {i: 24 for i in range(1, 10)})
         exp = {"vet": set(range(1, 10)), "ref_ranges": set(range(1, 10)),
                "sample_chromosome_ploidy": set(range(1, 10))}
 
-        r = run_structural_checks("proj", "ds", exp, strict_vet_screen=False)
+        r = run_structural_checks("proj", "ds", exp, allow_flagged_vet_loads=False)
         self.assertTrue(r["truncation_flagged"])
         self.assertFalse(r["duplication_flagged"])
         # The hard gates do not see it -- present and non-empty, uniform ploidy.

--- a/scripts/variantstore/scripts/test/test_verify_structural_checks.py
+++ b/scripts/variantstore/scripts/test/test_verify_structural_checks.py
@@ -218,6 +218,23 @@ class TestAssessFamilyCompleteness(unittest.TestCase):
         r = self._run(part, reg, exp)
         self.assertFalse(r["ok"])
         self.assertEqual(r["per_family"]["vet"]["empty_partition_samples"], [2])
+        # A present-but-empty partition is a partial load, not an absence: it must not also be
+        # double-counted as missing (regression guard for the double-count fix).
+        self.assertEqual(r["per_family"]["vet"]["missing_samples"], [])
+        self.assertEqual(r["per_family"]["vet"]["present"], 1)
+
+    def test_missing_and_empty_are_disjoint(self):
+        # sample 2 present (100 rows), sample 3 empty (0 rows), sample 4 absent entirely. Each must
+        # land in exactly one bucket.
+        part = [("vet_001", 2, 100), ("vet_001", 3, 0)]
+        reg = {"sample_chromosome_ploidy": {2: 24, 3: 24, 4: 24}}
+        exp = {"vet": {2, 3, 4}, "ref_ranges": set(), "sample_chromosome_ploidy": {2, 3, 4}}
+        r = self._run(part, reg, exp)
+        vet = r["per_family"]["vet"]
+        self.assertFalse(vet["ok"])
+        self.assertEqual(vet["missing_samples"], [4])
+        self.assertEqual(vet["empty_partition_samples"], [3])
+        self.assertEqual(vet["present"], 1)
 
     def test_missing_sample_in_one_family(self):
         part = [("vet_001", 1, 100), ("ref_ranges_001", 1, 50)]  # sample 2 absent everywhere

--- a/scripts/variantstore/scripts/test/test_verify_structural_checks.py
+++ b/scripts/variantstore/scripts/test/test_verify_structural_checks.py
@@ -291,6 +291,18 @@ class TestRunStructuralChecks(unittest.TestCase):
         self.addCleanup(p1.stop)
         self.addCleanup(p2.stop)
 
+    def _patch_regular(self, partition_rows, counts_by_table):
+        """Like _patch but returns per-table regular counts, keyed on the table-name argument."""
+        p1 = patch("verify_structural_checks.get_partition_row_counts", return_value=partition_rows)
+        p2 = patch(
+            "verify_structural_checks.get_ploidy_row_counts",
+            side_effect=lambda project_id, dataset_name, table: counts_by_table.get(table, {}),
+        )
+        p1.start()
+        p2.start()
+        self.addCleanup(p1.stop)
+        self.addCleanup(p2.stop)
+
     def test_all_good(self):
         part = [("vet_001", i, 100) for i in (1, 2)] + [("ref_ranges_001", i, 50) for i in (1, 2)]
         self._patch(part, {1: 24, 2: 24})
@@ -339,6 +351,57 @@ class TestRunStructuralChecks(unittest.TestCase):
         self.assertEqual(card["reference_source"], "override")
         self.assertEqual(card["reference_count"], 24)
         self.assertEqual(card["mode"], 25)
+
+    def test_variable_cardinality_regular_table_not_gated(self):
+        # With VCF-header loading, the WDL passes vcf_header_lines_scratch alongside ploidy as a
+        # regular table. Its per-sample row count legitimately varies (one row per header line), so it
+        # must be completeness-checked but NOT held to the uniform-cardinality mode -- otherwise a valid
+        # headers ingest fails. Regression guard for the header-enabled prefix list.
+        part = ([("vet_001", i, 100) for i in (1, 2, 3)]
+                + [("ref_ranges_001", i, 50) for i in (1, 2, 3)])
+        counts_by_table = {
+            "sample_chromosome_ploidy": {1: 24, 2: 24, 3: 24},   # uniform
+            "vcf_header_lines_scratch": {1: 30, 2: 45, 3: 12},   # legitimately non-uniform
+        }
+        self._patch_regular(part, counts_by_table)
+        exp = {"vet": {1, 2, 3}, "ref_ranges": {1, 2, 3},
+               "sample_chromosome_ploidy": {1, 2, 3}, "vcf_header_lines_scratch": {1, 2, 3}}
+
+        r = run_structural_checks(
+            "proj", "ds", exp,
+            regular_table_prefixes=["sample_chromosome_ploidy", "vcf_header_lines_scratch"],
+        )
+
+        # The varying header counts must not fail cardinality, because the header table is never
+        # cardinality-checked -- only ploidy is.
+        self.assertTrue(r["cardinality_ok"])
+        self.assertIn("sample_chromosome_ploidy", r["details"]["cardinality"])
+        self.assertNotIn("vcf_header_lines_scratch", r["details"]["cardinality"])
+        # Completeness still covers the header table (all three samples present).
+        self.assertTrue(r["completeness_ok"])
+        self.assertIn("vcf_header_lines_scratch", r["details"]["family_completeness"]["per_family"])
+
+    def test_missing_header_sample_still_fails_completeness(self):
+        # Dropping the header table from the cardinality check must not blind us to a lost header load:
+        # a sample present in ploidy but absent from headers still fails completeness.
+        part = [("vet_001", i, 100) for i in (1, 2)] + [("ref_ranges_001", i, 50) for i in (1, 2)]
+        counts_by_table = {
+            "sample_chromosome_ploidy": {1: 24, 2: 24},
+            "vcf_header_lines_scratch": {1: 30},   # sample 2 missing
+        }
+        self._patch_regular(part, counts_by_table)
+        exp = {"vet": {1, 2}, "ref_ranges": {1, 2},
+               "sample_chromosome_ploidy": {1, 2}, "vcf_header_lines_scratch": {1, 2}}
+
+        r = run_structural_checks(
+            "proj", "ds", exp,
+            regular_table_prefixes=["sample_chromosome_ploidy", "vcf_header_lines_scratch"],
+        )
+
+        self.assertFalse(r["completeness_ok"])
+        header = r["details"]["family_completeness"]["per_family"]["vcf_header_lines_scratch"]
+        self.assertEqual(header["missing_samples"], [2])
+        self.assertTrue(r["cardinality_ok"])  # ploidy still uniform
 
 
 if __name__ == "__main__":

--- a/scripts/variantstore/scripts/verify_all_loaded.py
+++ b/scripts/variantstore/scripts/verify_all_loaded.py
@@ -173,6 +173,14 @@ def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
     # --- Independent structural checks (VS-1989) --------------------------------------------------
     # Derive, per family, the sample_ids GCS says should be loaded, then run row-count-based checks
     # that share no code with the loader's get_already_loaded_tables_and_sample_ids predicate.
+    #
+    # This independence has a boundary: expected_by_family is sourced from all_gcs_pairs, which is
+    # the same GCS file listing (gcs_files_list, produced upstream by DiscoverParquetFiles) that the
+    # loader itself scatters over. A sample for which Parquet generation never produced output files
+    # at all -- as opposed to a sample whose files were produced but never loaded into BigQuery -- was
+    # never "expected" by this listing in the first place, so it is invisible to every check below,
+    # not just to the missing_pairs check above. Closing that would need an expected-sample source
+    # independent of GCS, e.g. sample_info/external_sample_names. See VS-1989.
     expected_by_family = defaultdict(set)
     for table_name, sample_id in all_gcs_pairs:
         family = family_for_table(table_name, superpartitioned_table_prefixes)

--- a/scripts/variantstore/scripts/verify_all_loaded.py
+++ b/scripts/variantstore/scripts/verify_all_loaded.py
@@ -2,11 +2,21 @@
 """
 Verify that all Parquet files in GCS have been loaded to BigQuery.
 
-Idempotency is determined by inspecting BigQuery directly:
-- For vet_% and ref_ranges_% tables: checks INFORMATION_SCHEMA.PARTITIONS for non-empty partitions.
-- For sample_chromosome_ploidy: checks for the sample_id in the table itself.
+Two layers of verification run here, and only together do they gate deletion of the source Parquet:
 
-This approach does not require or consult a parquet_load_status tracking table.
+1. Shared-predicate presence check. Parses every GCS path into a (table_name, sample_id) pair and
+   compares against get_already_loaded_tables_and_sample_ids -- the same predicate the loader uses to
+   decide what to skip. This is cheap and catches whole-sample absence, but because it asks the
+   loader's own question it can never contradict the loader: it is blind to a partition that is
+   present-but-partial or present-but-duplicated (VS-1989).
+
+2. Independent structural checks (verify_structural_checks.py). These ask "how many rows?" via
+   INFORMATION_SCHEMA.PARTITIONS.total_rows and a per-sample COUNT(*) on the ploidy table -- signals
+   the loader predicate never consults -- so they can catch partial loads and duplication. Family
+   completeness and ploidy cardinality gate deletion; the vet duplication screen warns by default and
+   only gates under --strict-vet-screen.
+
+Neither layer requires or consults a parquet_load_status tracking table.
 """
 
 import argparse
@@ -14,20 +24,70 @@ import json
 import logging
 import os
 import sys
+from collections import defaultdict
 
 from parse_and_group_files import (
     parse_table_and_sample_id_from_file_path,
     get_already_loaded_tables_and_sample_ids,
 )
+from verify_structural_checks import (
+    family_for_table,
+    run_structural_checks,
+    DEFAULT_VET_DUPLICATION_THRESHOLD,
+)
 
 log = logging.getLogger(__name__)
 
 
+def _log_structural_summary(structural):
+    """Log a human-readable summary of the independent structural checks."""
+    details = structural["details"]
+
+    for family, fam in sorted(details["family_completeness"]["per_family"].items()):
+        if fam["ok"]:
+            log.info(f"  [completeness] {family}: {fam['present']}/{fam['expected']} expected samples present")
+        else:
+            log.error(
+                f"  [completeness] {family}: {len(fam['missing_samples'])} missing, "
+                f"{len(fam['empty_partition_samples'])} present-but-empty "
+                f"(expected {fam['expected']})"
+            )
+
+    for table, card in sorted(details["cardinality"].items()):
+        if card["ok"]:
+            log.info(
+                f"  [cardinality] {table}: {card['distinct_samples']} samples, "
+                f"all with {card['mode']} rows"
+            )
+        else:
+            log.error(
+                f"  [cardinality] {table}: mode={card['mode']} min={card['min']} max={card['max']}; "
+                f"{len(card['missing_samples'])} missing, {len(card['deviating_samples'])} off-mode"
+            )
+
+    for family, screen in sorted(details["duplication_screen"].items()):
+        outliers = screen["outliers"]
+        level = "  [duplication]"
+        if not outliers:
+            log.info(f"{level} {family}: no samples >= {screen['threshold']}x median ({screen['median']})")
+        elif structural["strict_vet_screen"]:
+            log.error(f"{level} {family}: {len(outliers)} sample(s) >= {screen['threshold']}x median (STRICT: gating)")
+        else:
+            log.warning(f"{level} {family}: {len(outliers)} sample(s) >= {screen['threshold']}x median (warning only)")
+
+    unscreened = details["duplication_unscreened"]
+    if unscreened["families"]:
+        log.info(f"  [duplication] not screened for {unscreened['families']}: {unscreened['reason']}")
+
+
 def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
-                      superpartitioned_table_prefixes=None, regular_table_prefixes=None):
+                      superpartitioned_table_prefixes=None, regular_table_prefixes=None,
+                      vet_duplication_threshold=DEFAULT_VET_DUPLICATION_THRESHOLD,
+                      strict_vet_screen=False):
     """
     Compare GCS-derived (table_name, sample_id) pairs against what is actually
-    present in BigQuery to find loads that are missing.
+    present in BigQuery to find loads that are missing, then run independent
+    row-count-based structural checks that the loader-shared predicate cannot make.
 
     Args:
         project_id: BigQuery project ID
@@ -36,6 +96,9 @@ def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
         output_dir: Directory to write results
         superpartitioned_table_prefixes: Prefixes for superpartitioned tables (default: ["vet", "ref_ranges"])
         regular_table_prefixes: Prefixes for regular tables (default: ["sample_chromosome_ploidy"])
+        vet_duplication_threshold: Ratio-to-median above which a vet sample is flagged (default 1.6)
+        strict_vet_screen: If True, a vet duplication flag fails verification (blocking deletion);
+            if False (default) it only warns.
 
     Returns:
         Dictionary with verification results
@@ -103,7 +166,40 @@ def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
     log.info(f"  Files with missing pairs: {missing_files_count}")
     log.info(f"  Missing (table, sample_id) pairs: {len(missing_pairs)}")
 
-    all_loaded = (len(missing_pairs) == 0 and len(unmatched_files) == 0)
+    # --- Independent structural checks (VS-1989) --------------------------------------------------
+    # Derive, per family, the sample_ids GCS says should be loaded, then run row-count-based checks
+    # that share no code with the loader's get_already_loaded_tables_and_sample_ids predicate.
+    expected_by_family = defaultdict(set)
+    for table_name, sample_id in all_gcs_pairs:
+        family = family_for_table(table_name, superpartitioned_table_prefixes)
+        if family is not None:
+            expected_by_family[family].add(sample_id)
+        elif table_name in regular_table_prefixes:
+            expected_by_family[table_name].add(sample_id)
+
+    log.info("Running independent structural checks...")
+    structural = run_structural_checks(
+        project_id, dataset_name, expected_by_family,
+        superpartitioned_table_prefixes=superpartitioned_table_prefixes,
+        regular_table_prefixes=regular_table_prefixes,
+        vet_duplication_threshold=vet_duplication_threshold,
+        strict_vet_screen=strict_vet_screen,
+    )
+    _log_structural_summary(structural)
+
+    # Family completeness and per-sample cardinality are hard gates; the vet duplication screen only
+    # gates when strict mode is requested (otherwise it warns).
+    structural_checks_ok = (
+        structural["completeness_ok"]
+        and structural["cardinality_ok"]
+        and not (strict_vet_screen and structural["duplication_flagged"])
+    )
+
+    all_loaded = (
+        len(missing_pairs) == 0
+        and len(unmatched_files) == 0
+        and structural_checks_ok
+    )
 
     # Write list of missing file paths if there are any
     missing_files_list_path = None
@@ -131,6 +227,13 @@ def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
         "missing_files": missing_files_count,
         "missing_files_list": missing_files_list_path,
         "unmatched_files": len(unmatched_files),
+        # Flat structural-check booleans, read shallowly by the WDL (VS-1989).
+        "structural_checks_ok": structural_checks_ok,
+        "family_completeness_ok": structural["completeness_ok"],
+        "ploidy_cardinality_ok": structural["cardinality_ok"],
+        "vet_duplication_flagged": structural["duplication_flagged"],
+        # Full per-check detail for humans and logs.
+        "structural_checks": structural["details"],
     }
 
     results_file = f"{output_dir}/verification_results.json"
@@ -169,6 +272,23 @@ def main():
         default=["sample_chromosome_ploidy"],
         help="Table prefixes for regular (non-superpartitioned) tables (default: sample_chromosome_ploidy)"
     )
+    parser.add_argument(
+        "--vet-duplication-threshold",
+        type=float,
+        default=DEFAULT_VET_DUPLICATION_THRESHOLD,
+        help=(
+            "Ratio-to-median above which a vet sample is flagged as a possible duplicate "
+            f"(default: {DEFAULT_VET_DUPLICATION_THRESHOLD})"
+        )
+    )
+    parser.add_argument(
+        "--strict-vet-screen",
+        action="store_true",
+        help=(
+            "Treat vet duplication-screen flags as a failure (blocking Parquet deletion). "
+            "By default the screen only warns."
+        )
+    )
 
     args = parser.parse_args()
 
@@ -179,6 +299,8 @@ def main():
         output_dir=args.output_dir,
         superpartitioned_table_prefixes=args.superpartitioned_table_prefixes,
         regular_table_prefixes=args.regular_table_prefixes,
+        vet_duplication_threshold=args.vet_duplication_threshold,
+        strict_vet_screen=args.strict_vet_screen,
     )
 
     if results["all_loaded"]:
@@ -194,6 +316,15 @@ def main():
             reasons.append(
                 f"{unmatched_count} file(s) could not be parsed or matched to a table/sample_id"
             )
+        if not results.get("family_completeness_ok", True):
+            reasons.append("family completeness check failed (missing or empty partitions)")
+        if not results.get("ploidy_cardinality_ok", True):
+            reasons.append("ploidy cardinality check failed (missing or off-mode samples)")
+        if (results.get("vet_duplication_flagged")
+                and results.get("family_completeness_ok", True)
+                and results.get("ploidy_cardinality_ok", True)
+                and not results.get("structural_checks_ok", True)):
+            reasons.append("vet duplication screen flagged samples (--strict-vet-screen)")
 
         if reasons:
             log.error("✗ INCOMPLETE: " + "; ".join(reasons))

--- a/scripts/variantstore/scripts/verify_all_loaded.py
+++ b/scripts/variantstore/scripts/verify_all_loaded.py
@@ -54,15 +54,16 @@ def _log_structural_summary(structural):
             )
 
     for table, card in sorted(details["cardinality"].items()):
+        ref_desc = f"{card.get('reference_count')} rows/sample ({card.get('reference_source', 'mode')})"
         if card["ok"]:
             log.info(
-                f"  [cardinality] {table}: {card['distinct_samples']} samples, "
-                f"all with {card['mode']} rows"
+                f"  [cardinality] {table}: {card['distinct_samples']} samples, all with {ref_desc}"
             )
         else:
             log.error(
-                f"  [cardinality] {table}: mode={card['mode']} min={card['min']} max={card['max']}; "
-                f"{len(card['missing_samples'])} missing, {len(card['deviating_samples'])} off-mode"
+                f"  [cardinality] {table}: expected {ref_desc}, observed mode={card['mode']} "
+                f"min={card['min']} max={card['max']}; "
+                f"{len(card['missing_samples'])} missing, {len(card['deviating_samples'])} off-reference"
             )
 
     for family, screen in sorted(details["duplication_screen"].items()):
@@ -83,7 +84,8 @@ def _log_structural_summary(structural):
 def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
                       superpartitioned_table_prefixes=None, regular_table_prefixes=None,
                       vet_duplication_threshold=DEFAULT_VET_DUPLICATION_THRESHOLD,
-                      strict_vet_screen=False):
+                      strict_vet_screen=False,
+                      expected_ploidy_rows_per_sample=None):
     """
     Compare GCS-derived (table_name, sample_id) pairs against what is actually
     present in BigQuery to find loads that are missing, then run independent
@@ -99,6 +101,8 @@ def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
         vet_duplication_threshold: Ratio-to-median above which a vet sample is flagged (default 1.6)
         strict_vet_screen: If True, a vet duplication flag fails verification (blocking deletion);
             if False (default) it only warns.
+        expected_ploidy_rows_per_sample: If set, the exact per-sample ploidy row count to validate
+            against (e.g. 24 for WGS) instead of the callset mode; leave unset to infer from the data.
 
     Returns:
         Dictionary with verification results
@@ -184,6 +188,7 @@ def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
         regular_table_prefixes=regular_table_prefixes,
         vet_duplication_threshold=vet_duplication_threshold,
         strict_vet_screen=strict_vet_screen,
+        expected_ploidy_rows_per_sample=expected_ploidy_rows_per_sample,
     )
     _log_structural_summary(structural)
 
@@ -289,6 +294,15 @@ def main():
             "By default the screen only warns."
         )
     )
+    parser.add_argument(
+        "--expected-ploidy-rows-per-sample",
+        type=int,
+        default=None,
+        help=(
+            "Exact per-sample ploidy row count to validate against (e.g. 24 for WGS) instead of the "
+            "callset mode. Leave unset to infer the reference from the data."
+        )
+    )
 
     args = parser.parse_args()
 
@@ -301,6 +315,7 @@ def main():
         regular_table_prefixes=args.regular_table_prefixes,
         vet_duplication_threshold=args.vet_duplication_threshold,
         strict_vet_screen=args.strict_vet_screen,
+        expected_ploidy_rows_per_sample=args.expected_ploidy_rows_per_sample,
     )
 
     if results["all_loaded"]:
@@ -319,7 +334,7 @@ def main():
         if not results.get("family_completeness_ok", True):
             reasons.append("family completeness check failed (missing or empty partitions)")
         if not results.get("ploidy_cardinality_ok", True):
-            reasons.append("ploidy cardinality check failed (missing or off-mode samples)")
+            reasons.append("ploidy cardinality check failed (missing or off-reference samples)")
         if (results.get("vet_duplication_flagged")
                 and results.get("family_completeness_ok", True)
                 and results.get("ploidy_cardinality_ok", True)

--- a/scripts/variantstore/scripts/verify_all_loaded.py
+++ b/scripts/variantstore/scripts/verify_all_loaded.py
@@ -318,17 +318,19 @@ def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
     # This independence has a boundary: expected_by_family is sourced from all_gcs_pairs, which is the
     # same GCS file listing (gcs_files_list, produced upstream by DiscoverParquetFiles) that the loader
     # itself scatters over. Within that listing the checks are now cross-family consistent: a sample
-    # present in some required families but absent from another, AND an entirely absent required family,
-    # are both caught by assess_cross_family_consistency -- it takes the required family set from this
-    # invocation's configured prefixes, so a family with no files is compared as an empty set rather than
-    # silently dropped, and since all families are produced together per sample either gap is a partial
-    # upload -- rather than passing vacuously in the family that lacks the data. What remains outside the
-    # listing is the whole-sample gap: a sample for which Parquet generation never produced output for
-    # ANY family was never in the listing at all, so it is in no family's expected set and no
-    # cross-family union, and stays invisible to every check here -- as opposed to a sample whose files
-    # were produced but never loaded into BigQuery, which the checks do catch. Unlike a whole family,
-    # whose identity is known from the configured prefixes, a never-produced sample's identity is
-    # unknowable without a non-GCS source. Closing that residual gap needs an expected-sample source that
+    # present in some co-produced data families but absent from another, AND an entirely absent
+    # co-produced family, are both caught by assess_cross_family_consistency. It ranges over the group the
+    # Java ingest emits together per sample (vet / ref_ranges / ploidy) rather than over every configured
+    # prefix, so an absent group member is compared as an empty set -- either gap is a partial upload
+    # rather than passing vacuously in the family that lacks the data -- while the check stays presence-
+    # activated: it is dormant unless a group member has files this run, so a supported headers-only ingest
+    # (which produces only vcf_header_lines_scratch, deliberately not a group member) is not falsely
+    # reported incomplete. What remains outside the listing is the whole-sample gap: a sample for which
+    # Parquet generation never produced output for ANY family was never in the listing at all, so it is in
+    # no family's expected set and no cross-family union, and stays invisible to every check here -- as
+    # opposed to a sample whose files were produced but never loaded into BigQuery, which the checks do
+    # catch. Unlike a whole family, whose identity is known from the co-produced group, a never-produced
+    # sample's identity is unknowable without a non-GCS source. Closing that residual gap needs an expected-sample source that
     # does not derive from GCS: specifically this run's input sample set (the ingest FOFN). Note that
     # sample_info cannot serve this wholesale -- it accumulates every sample ever ingested, including
     # ones since withdrawn or deleted, so comparing against it in bulk would false-positive samples that

--- a/scripts/variantstore/scripts/verify_all_loaded.py
+++ b/scripts/variantstore/scripts/verify_all_loaded.py
@@ -317,20 +317,23 @@ def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
     #
     # This independence has a boundary: expected_by_family is sourced from all_gcs_pairs, which is the
     # same GCS file listing (gcs_files_list, produced upstream by DiscoverParquetFiles) that the loader
-    # itself scatters over. Within that listing the checks are now cross-family consistent -- a sample
-    # present in some families but absent from another is caught by assess_cross_family_consistency (all
-    # families are produced together per sample, so such a gap is a partial upload) rather than passing
-    # vacuously in the family that lacks it. What remains outside the listing is the whole-sample gap: a
-    # sample for which Parquet generation never produced output for ANY family was never in the listing
-    # at all, so it is in no family's expected set and no cross-family union, and stays invisible to
-    # every check here -- as opposed to a sample whose files were produced but never loaded into
-    # BigQuery, which the checks do catch. Closing that residual gap needs an expected-sample source
-    # that does not derive from GCS: specifically this run's input sample set (the ingest FOFN). Note
-    # that sample_info cannot serve this wholesale -- it accumulates every sample ever ingested,
-    # including ones since withdrawn or deleted, so comparing against it in bulk would false-positive
-    # samples that are legitimately absent from this run; the expected set has to be scoped to the FOFN
-    # for this run. Tracked as a follow-up in VS-2016 (family-completeness independence); see also
-    # VS-1989.
+    # itself scatters over. Within that listing the checks are now cross-family consistent: a sample
+    # present in some required families but absent from another, AND an entirely absent required family,
+    # are both caught by assess_cross_family_consistency -- it takes the required family set from this
+    # invocation's configured prefixes, so a family with no files is compared as an empty set rather than
+    # silently dropped, and since all families are produced together per sample either gap is a partial
+    # upload -- rather than passing vacuously in the family that lacks the data. What remains outside the
+    # listing is the whole-sample gap: a sample for which Parquet generation never produced output for
+    # ANY family was never in the listing at all, so it is in no family's expected set and no
+    # cross-family union, and stays invisible to every check here -- as opposed to a sample whose files
+    # were produced but never loaded into BigQuery, which the checks do catch. Unlike a whole family,
+    # whose identity is known from the configured prefixes, a never-produced sample's identity is
+    # unknowable without a non-GCS source. Closing that residual gap needs an expected-sample source that
+    # does not derive from GCS: specifically this run's input sample set (the ingest FOFN). Note that
+    # sample_info cannot serve this wholesale -- it accumulates every sample ever ingested, including
+    # ones since withdrawn or deleted, so comparing against it in bulk would false-positive samples that
+    # are legitimately absent from this run; the expected set has to be scoped to the FOFN for this run.
+    # Tracked as a follow-up in VS-2016 (family-completeness independence); see also VS-1989.
     expected_by_family = defaultdict(set)
     for table_name, sample_id in all_gcs_pairs:
         family = family_for_table(table_name, superpartitioned_table_prefixes)

--- a/scripts/variantstore/scripts/verify_all_loaded.py
+++ b/scripts/variantstore/scripts/verify_all_loaded.py
@@ -13,8 +13,12 @@ Two layers of verification run here, and only together do they gate deletion of 
 2. Independent structural checks (verify_structural_checks.py). These ask "how many rows?" via
    INFORMATION_SCHEMA.PARTITIONS.total_rows and a per-sample COUNT(*) on the ploidy table -- signals
    the loader predicate never consults -- so they can catch partial loads and duplication. Family
-   completeness and ploidy cardinality gate deletion; the vet duplication screen warns by default and
-   only gates under --strict-vet-screen.
+   completeness and ploidy cardinality are exact checks: they gate all_loaded, the factual "is the
+   load complete?" signal that fail-loud aborts on. The vet duplication and truncation screens are
+   heuristics -- they never affect all_loaded, and instead gate the separate safe_to_delete_parquet
+   predicate, which is what authorizes deleting the source Parquet. A screen flag blocks that deletion
+   by default and is waived only with --allow-flagged-vet-loads, so a flagged-but-complete load
+   succeeds and simply retains its Parquet rather than failing the import.
 
 Neither layer requires or consults a parquet_load_status tracking table.
 """
@@ -100,55 +104,51 @@ def _log_structural_summary(structural):
         level = "  [duplication]"
         if not outliers:
             log.info(f"{level} {family}: no samples >= {screen['threshold']}x median ({screen['median']})")
-        elif structural["strict_vet_screen"]:
-            log.error(f"{level} {family}: {len(outliers)} sample(s) >= {screen['threshold']}x median (STRICT: gating)")
+        elif structural["allow_flagged_vet_loads"]:
+            log.warning(f"{level} {family}: {len(outliers)} sample(s) >= {screen['threshold']}x median (warning only; --allow-flagged-vet-loads set)")
         else:
-            log.warning(f"{level} {family}: {len(outliers)} sample(s) >= {screen['threshold']}x median (warning only)")
+            log.error(f"{level} {family}: {len(outliers)} sample(s) >= {screen['threshold']}x median (blocks Parquet deletion)")
 
     for family, screen in sorted(details.get("truncation_screen", {}).items()):
         outliers = screen["outliers"]
         level = "  [truncation]"
         if not outliers:
             log.info(f"{level} {family}: no samples <= median/{screen['threshold']} ({screen['median']})")
-        elif structural["strict_vet_screen"]:
-            log.error(f"{level} {family}: {len(outliers)} sample(s) <= median/{screen['threshold']} (STRICT: gating)")
+        elif structural["allow_flagged_vet_loads"]:
+            log.warning(f"{level} {family}: {len(outliers)} sample(s) <= median/{screen['threshold']} (warning only; --allow-flagged-vet-loads set)")
         else:
-            log.warning(f"{level} {family}: {len(outliers)} sample(s) <= median/{screen['threshold']} (warning only)")
+            log.error(f"{level} {family}: {len(outliers)} sample(s) <= median/{screen['threshold']} (blocks Parquet deletion)")
 
     unscreened = details["duplication_unscreened"]
     if unscreened["families"]:
         log.info(f"  [duplication] not screened for {unscreened['families']}: {unscreened['reason']}")
 
 
-def compute_structural_checks_ok(structural, strict_vet_screen):
+def compute_structural_checks_ok(structural):
     """
-    Reduce a run_structural_checks result to the single structural boolean that feeds the deletion gate.
+    Reduce a run_structural_checks result to the exact structural boolean that feeds all_loaded.
 
-    Only the exact checks gate unconditionally: family completeness (every expected sample present and
+    Only the exact checks contribute: family completeness (every expected sample present and
     non-empty) and per-sample ploidy cardinality. The duplication and truncation screens are
-    heuristics and gate only when ``strict_vet_screen`` is set; otherwise they warn. Keeping a
-    heuristic off the default gate is deliberate -- a heuristic's false negatives would lend false
-    confidence before an irreversible delete, whereas a false positive only over-retains Parquet, which
-    is safe.
+    heuristics and deliberately do NOT gate all_loaded -- all_loaded is the factual "is the load
+    complete?" signal that fail-loud aborts on, and a heuristic flag does not make a complete load
+    incomplete. The screens instead gate the separate safe_to_delete_parquet predicate (see
+    compute_safe_to_delete_parquet).
     """
-    return (
-        structural["completeness_ok"]
-        and structural["cardinality_ok"]
-        and not (strict_vet_screen
-                 and (structural["duplication_flagged"] or structural["truncation_flagged"]))
-    )
+    return structural["completeness_ok"] and structural["cardinality_ok"]
 
 
 def compute_all_loaded(missing_pairs, unmatched_files, structural_checks_ok):
     """
-    The deletion gate. Returns True only when it is safe to delete the source Parquet: no
-    (table, sample_id) pair the loader should have produced is missing from BigQuery, no GCS file was
-    left unmatched, and the independent structural checks pass (see compute_structural_checks_ok).
+    The factual "is the load complete?" gate, and the signal fail-loud aborts on. Returns True only
+    when no (table, sample_id) pair the loader should have produced is missing from BigQuery, no GCS
+    file was left unmatched, and the exact structural checks pass (see compute_structural_checks_ok).
 
-    This is the single predicate DeleteParquetFiles is downstream of. It is kept a pure function of its
-    inputs so the deletion-authorizing logic stays trivially testable in isolation -- a regression here
-    authorizes an irreversible delete, so it is the one place in this module that most warrants direct
-    unit tests.
+    all_loaded is deliberately NOT the deletion gate: the heuristic vet screens are excluded here so a
+    flagged-but-complete load still reads as loaded and its task succeeds (retaining its Parquet)
+    rather than aborting the import. Whether it is safe to delete the source Parquet is the separate
+    compute_safe_to_delete_parquet predicate, which layers the screen policy on top of this. Kept a
+    pure function of its inputs so both predicates stay trivially testable in isolation.
     """
     return (
         len(missing_pairs) == 0
@@ -157,16 +157,35 @@ def compute_all_loaded(missing_pairs, unmatched_files, structural_checks_ok):
     )
 
 
+def compute_safe_to_delete_parquet(all_loaded, structural, allow_flagged_vet_loads):
+    """
+    The deletion gate -- the single predicate DeleteParquetFiles is downstream of. Returns True only
+    when the load is factually complete (all_loaded) AND no heuristic vet screen objects, unless the
+    operator has explicitly waived the screens with allow_flagged_vet_loads.
+
+    Gating the irreversible delete on a screen flag by default is the safe direction: a screen false
+    positive here only over-retains Parquet (cheap and reversible), whereas trusting a flagged load and
+    deleting its source is not. Waiving the screens is therefore an opt-out (--allow-flagged-vet-loads),
+    so the default never deletes anything a screen objected to. Kept a pure function so the
+    deletion-authorizing logic is unit-tested in isolation -- a regression here authorizes an
+    irreversible delete.
+    """
+    if not all_loaded:
+        return False
+    if allow_flagged_vet_loads:
+        return True
+    return not (structural["duplication_flagged"] or structural["truncation_flagged"])
+
+
 def describe_incomplete_reasons(results):
     """
     Human-readable reasons a verification came back not-all-loaded, for the fail-loud error line.
 
     Kept a pure function of the results dict so the operator-facing diagnosis is unit-tested: this line
-    is what an operator reads when a run has aborted, and a strict-screen failure that named the wrong
-    screen -- or fell through to "unknown reasons" -- would misdirect them. The duplication and
-    truncation screens only block deletion under --strict-vet-screen, in which case structural_checks_ok
-    is False while the exact checks (completeness, cardinality) still pass; report whichever screen(s)
-    actually flagged.
+    is what an operator reads when a run has aborted. Only the exact checks can make all_loaded false
+    (missing/unmatched files, family completeness, ploidy cardinality); the vet duplication and
+    truncation screens never fail all_loaded -- they gate safe_to_delete_parquet instead -- so they are
+    deliberately absent here.
     """
     reasons = []
     missing_count = results.get("missing_files", 0) or 0
@@ -179,20 +198,13 @@ def describe_incomplete_reasons(results):
         reasons.append("family completeness check failed (missing or empty partitions)")
     if not results.get("ploidy_cardinality_ok", True):
         reasons.append("ploidy cardinality check failed (missing or off-reference samples)")
-    if (not results.get("structural_checks_ok", True)
-            and results.get("family_completeness_ok", True)
-            and results.get("ploidy_cardinality_ok", True)):
-        if results.get("vet_duplication_flagged"):
-            reasons.append("vet duplication screen flagged samples (--strict-vet-screen)")
-        if results.get("vet_truncation_flagged"):
-            reasons.append("vet truncation screen flagged samples (--strict-vet-screen)")
     return reasons
 
 
 def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
                       superpartitioned_table_prefixes=None, regular_table_prefixes=None,
                       vet_duplication_threshold=DEFAULT_VET_DUPLICATION_THRESHOLD,
-                      strict_vet_screen=False,
+                      allow_flagged_vet_loads=False,
                       expected_ploidy_rows_per_sample=None):
     """
     Compare GCS-derived (table_name, sample_id) pairs against what is actually
@@ -207,8 +219,10 @@ def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
         superpartitioned_table_prefixes: Prefixes for superpartitioned tables (default: ["vet", "ref_ranges"])
         regular_table_prefixes: Prefixes for regular tables (default: ["sample_chromosome_ploidy"])
         vet_duplication_threshold: Ratio-to-median above which a vet sample is flagged (default 1.6)
-        strict_vet_screen: If True, a vet duplication flag fails verification (blocking deletion);
-            if False (default) it only warns.
+        allow_flagged_vet_loads: If False (default), a vet duplication- or truncation-screen flag
+            blocks deletion of the source Parquet (the load still succeeds -- all_loaded stays factual
+            -- and the Parquet is retained). If True, the screens are waived and deletion may proceed
+            despite a flag.
         expected_ploidy_rows_per_sample: If set, the exact per-sample ploidy row count to validate
             against (e.g. 24 for WGS) instead of the callset mode; leave unset to infer from the data.
 
@@ -287,8 +301,12 @@ def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
     # loader itself scatters over. A sample for which Parquet generation never produced output files
     # at all -- as opposed to a sample whose files were produced but never loaded into BigQuery -- was
     # never "expected" by this listing in the first place, so it is invisible to every check below,
-    # not just to the missing_pairs check above. Closing that would need an expected-sample source
-    # independent of GCS, e.g. sample_info/external_sample_names. See VS-1989.
+    # not just to the missing_pairs check above. Closing this needs an expected-sample source that
+    # does not derive from GCS: specifically this run's input sample set (the ingest FOFN). Note that
+    # sample_info cannot serve this wholesale -- it accumulates every sample ever ingested, including
+    # ones since withdrawn or deleted, so comparing against it in bulk would false-positive samples
+    # that are legitimately absent from this run; the expected set has to be scoped to the FOFN for
+    # this run. Tracked as a follow-up in VS-2016 (family-completeness independence); see also VS-1989.
     expected_by_family = defaultdict(set)
     for table_name, sample_id in all_gcs_pairs:
         family = family_for_table(table_name, superpartitioned_table_prefixes)
@@ -303,15 +321,21 @@ def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
         superpartitioned_table_prefixes=superpartitioned_table_prefixes,
         regular_table_prefixes=regular_table_prefixes,
         vet_duplication_threshold=vet_duplication_threshold,
-        strict_vet_screen=strict_vet_screen,
+        allow_flagged_vet_loads=allow_flagged_vet_loads,
         expected_ploidy_rows_per_sample=expected_ploidy_rows_per_sample,
     )
     _log_structural_summary(structural)
 
-    # The structural half of the deletion gate (exact checks gate; heuristics warn unless strict) and
-    # the full gate itself are pure helpers, so the deletion-authorizing logic is tested in isolation.
-    structural_checks_ok = compute_structural_checks_ok(structural, strict_vet_screen)
+    # Two separate predicates, both pure helpers so the logic is unit-tested in isolation:
+    #  * all_loaded -- factual "is the load complete?", from the exact checks only; fail-loud aborts on
+    #    it, so a heuristic screen flag must NOT enter here or a complete load would wrongly abort.
+    #  * safe_to_delete_parquet -- the deletion gate, which layers the vet screen policy on top of
+    #    all_loaded: a flag blocks deletion unless allow_flagged_vet_loads waives the screens.
+    structural_checks_ok = compute_structural_checks_ok(structural)
     all_loaded = compute_all_loaded(missing_pairs, unmatched_files, structural_checks_ok)
+    safe_to_delete_parquet = compute_safe_to_delete_parquet(
+        all_loaded, structural, allow_flagged_vet_loads
+    )
 
     # Write list of missing file paths if there are any
     missing_files_list_path = None
@@ -334,6 +358,9 @@ def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
 
     results_dict = {
         "all_loaded": all_loaded,
+        # The deletion gate DeleteParquetFiles is downstream of: all_loaded AND no unwaived vet-screen
+        # flag. Distinct from all_loaded so a flagged-but-complete load succeeds yet retains Parquet.
+        "safe_to_delete_parquet": safe_to_delete_parquet,
         "total_files": total_files,
         "loaded_files": loaded_files_count,
         "missing_files": missing_files_count,
@@ -396,11 +423,12 @@ def main():
         )
     )
     parser.add_argument(
-        "--strict-vet-screen",
+        "--allow-flagged-vet-loads",
         action="store_true",
         help=(
-            "Treat vet duplication- or truncation-screen flags as a failure (blocking Parquet "
-            "deletion). By default both screens only warn."
+            "Permit deleting the source Parquet even when the vet duplication or truncation screen "
+            "flags a sample. By default a screen flag blocks deletion (the load still succeeds and its "
+            "Parquet is retained); pass this to waive the screens and allow deletion anyway."
         )
     )
     parser.add_argument(
@@ -423,7 +451,7 @@ def main():
         superpartitioned_table_prefixes=args.superpartitioned_table_prefixes,
         regular_table_prefixes=args.regular_table_prefixes,
         vet_duplication_threshold=args.vet_duplication_threshold,
-        strict_vet_screen=args.strict_vet_screen,
+        allow_flagged_vet_loads=args.allow_flagged_vet_loads,
         expected_ploidy_rows_per_sample=args.expected_ploidy_rows_per_sample,
     )
 

--- a/scripts/variantstore/scripts/verify_all_loaded.py
+++ b/scripts/variantstore/scripts/verify_all_loaded.py
@@ -157,6 +157,38 @@ def compute_all_loaded(missing_pairs, unmatched_files, structural_checks_ok):
     )
 
 
+def describe_incomplete_reasons(results):
+    """
+    Human-readable reasons a verification came back not-all-loaded, for the fail-loud error line.
+
+    Kept a pure function of the results dict so the operator-facing diagnosis is unit-tested: this line
+    is what an operator reads when a run has aborted, and a strict-screen failure that named the wrong
+    screen -- or fell through to "unknown reasons" -- would misdirect them. The duplication and
+    truncation screens only block deletion under --strict-vet-screen, in which case structural_checks_ok
+    is False while the exact checks (completeness, cardinality) still pass; report whichever screen(s)
+    actually flagged.
+    """
+    reasons = []
+    missing_count = results.get("missing_files", 0) or 0
+    unmatched_count = results.get("unmatched_files", 0) or 0
+    if missing_count:
+        reasons.append(f"{missing_count} file(s) not yet loaded")
+    if unmatched_count:
+        reasons.append(f"{unmatched_count} file(s) could not be parsed or matched to a table/sample_id")
+    if not results.get("family_completeness_ok", True):
+        reasons.append("family completeness check failed (missing or empty partitions)")
+    if not results.get("ploidy_cardinality_ok", True):
+        reasons.append("ploidy cardinality check failed (missing or off-reference samples)")
+    if (not results.get("structural_checks_ok", True)
+            and results.get("family_completeness_ok", True)
+            and results.get("ploidy_cardinality_ok", True)):
+        if results.get("vet_duplication_flagged"):
+            reasons.append("vet duplication screen flagged samples (--strict-vet-screen)")
+        if results.get("vet_truncation_flagged"):
+            reasons.append("vet truncation screen flagged samples (--strict-vet-screen)")
+    return reasons
+
+
 def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
                       superpartitioned_table_prefixes=None, regular_table_prefixes=None,
                       vet_duplication_threshold=DEFAULT_VET_DUPLICATION_THRESHOLD,
@@ -367,8 +399,8 @@ def main():
         "--strict-vet-screen",
         action="store_true",
         help=(
-            "Treat vet duplication-screen flags as a failure (blocking Parquet deletion). "
-            "By default the screen only warns."
+            "Treat vet duplication- or truncation-screen flags as a failure (blocking Parquet "
+            "deletion). By default both screens only warn."
         )
     )
     parser.add_argument(
@@ -398,26 +430,7 @@ def main():
     if results["all_loaded"]:
         log.info("✓ SUCCESS: All files have been loaded!")
     else:
-        missing_count = results.get("missing_files", 0) or 0
-        unmatched_count = results.get("unmatched_files", 0) or 0
-
-        reasons = []
-        if missing_count:
-            reasons.append(f"{missing_count} file(s) not yet loaded")
-        if unmatched_count:
-            reasons.append(
-                f"{unmatched_count} file(s) could not be parsed or matched to a table/sample_id"
-            )
-        if not results.get("family_completeness_ok", True):
-            reasons.append("family completeness check failed (missing or empty partitions)")
-        if not results.get("ploidy_cardinality_ok", True):
-            reasons.append("ploidy cardinality check failed (missing or off-reference samples)")
-        if (results.get("vet_duplication_flagged")
-                and results.get("family_completeness_ok", True)
-                and results.get("ploidy_cardinality_ok", True)
-                and not results.get("structural_checks_ok", True)):
-            reasons.append("vet duplication screen flagged samples (--strict-vet-screen)")
-
+        reasons = describe_incomplete_reasons(results)
         if reasons:
             log.error("✗ INCOMPLETE: " + "; ".join(reasons))
         else:

--- a/scripts/variantstore/scripts/verify_all_loaded.py
+++ b/scripts/variantstore/scripts/verify_all_loaded.py
@@ -120,6 +120,43 @@ def _log_structural_summary(structural):
         log.info(f"  [duplication] not screened for {unscreened['families']}: {unscreened['reason']}")
 
 
+def compute_structural_checks_ok(structural, strict_vet_screen):
+    """
+    Reduce a run_structural_checks result to the single structural boolean that feeds the deletion gate.
+
+    Only the exact checks gate unconditionally: family completeness (every expected sample present and
+    non-empty) and per-sample ploidy cardinality. The duplication and truncation screens are
+    heuristics and gate only when ``strict_vet_screen`` is set; otherwise they warn. Keeping a
+    heuristic off the default gate is deliberate -- a heuristic's false negatives would lend false
+    confidence before an irreversible delete, whereas a false positive only over-retains Parquet, which
+    is safe.
+    """
+    return (
+        structural["completeness_ok"]
+        and structural["cardinality_ok"]
+        and not (strict_vet_screen
+                 and (structural["duplication_flagged"] or structural["truncation_flagged"]))
+    )
+
+
+def compute_all_loaded(missing_pairs, unmatched_files, structural_checks_ok):
+    """
+    The deletion gate. Returns True only when it is safe to delete the source Parquet: no
+    (table, sample_id) pair the loader should have produced is missing from BigQuery, no GCS file was
+    left unmatched, and the independent structural checks pass (see compute_structural_checks_ok).
+
+    This is the single predicate DeleteParquetFiles is downstream of. It is kept a pure function of its
+    inputs so the deletion-authorizing logic stays trivially testable in isolation -- a regression here
+    authorizes an irreversible delete, so it is the one place in this module that most warrants direct
+    unit tests.
+    """
+    return (
+        len(missing_pairs) == 0
+        and len(unmatched_files) == 0
+        and structural_checks_ok
+    )
+
+
 def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
                       superpartitioned_table_prefixes=None, regular_table_prefixes=None,
                       vet_duplication_threshold=DEFAULT_VET_DUPLICATION_THRESHOLD,
@@ -239,20 +276,10 @@ def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
     )
     _log_structural_summary(structural)
 
-    # Family completeness and per-sample cardinality are hard gates; the vet duplication and truncation
-    # screens only gate when strict mode is requested (otherwise they warn).
-    structural_checks_ok = (
-        structural["completeness_ok"]
-        and structural["cardinality_ok"]
-        and not (strict_vet_screen
-                 and (structural["duplication_flagged"] or structural["truncation_flagged"]))
-    )
-
-    all_loaded = (
-        len(missing_pairs) == 0
-        and len(unmatched_files) == 0
-        and structural_checks_ok
-    )
+    # The structural half of the deletion gate (exact checks gate; heuristics warn unless strict) and
+    # the full gate itself are pure helpers, so the deletion-authorizing logic is tested in isolation.
+    structural_checks_ok = compute_structural_checks_ok(structural, strict_vet_screen)
+    all_loaded = compute_all_loaded(missing_pairs, unmatched_files, structural_checks_ok)
 
     # Write list of missing file paths if there are any
     missing_files_list_path = None

--- a/scripts/variantstore/scripts/verify_all_loaded.py
+++ b/scripts/variantstore/scripts/verify_all_loaded.py
@@ -38,6 +38,35 @@ from verify_structural_checks import (
 
 log = logging.getLogger(__name__)
 
+# Cap on the per-sample ID lists embedded in the results JSON. On a large-callset failure these lists
+# (missing / empty / deviating samples, duplication outliers) could otherwise hold hundreds of
+# thousands of entries, bloating verification_results.json -- which the WDL re-parses in full on every
+# one of its read_json calls -- and the Cromwell logs. The gating booleans and the human-readable
+# counts logged by _log_structural_summary are computed from the full, uncapped structural result;
+# only the copy written to disk is bounded.
+STRUCTURAL_DETAIL_LIST_CAP = 1000
+
+
+def _cap_structural_detail_lists(obj, cap=STRUCTURAL_DETAIL_LIST_CAP):
+    """
+    Return a copy of the structural-checks detail block with any per-sample list longer than ``cap``
+    truncated to its first ``cap`` entries. Where a list is truncated a sibling ``<key>_total`` key
+    records its true length, so the count survives even though the full enumeration does not (the
+    authoritative set lives in BigQuery). Recurses through the nested dicts (per_family, cardinality,
+    duplication_screen); list elements themselves (ints or small ``{sample_id, ...}`` dicts) are left
+    untouched.
+    """
+    if isinstance(obj, dict):
+        capped = {}
+        for key, value in obj.items():
+            if isinstance(value, list) and len(value) > cap:
+                capped[key] = value[:cap]
+                capped[f"{key}_total"] = len(value)
+            else:
+                capped[key] = _cap_structural_detail_lists(value, cap)
+        return capped
+    return obj
+
 
 def _log_structural_summary(structural):
     """Log a human-readable summary of the independent structural checks."""
@@ -245,8 +274,9 @@ def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
         "family_completeness_ok": structural["completeness_ok"],
         "ploidy_cardinality_ok": structural["cardinality_ok"],
         "vet_duplication_flagged": structural["duplication_flagged"],
-        # Full per-check detail for humans and logs.
-        "structural_checks": structural["details"],
+        # Full per-check detail for humans and logs, with per-sample lists bounded so a large-callset
+        # failure cannot bloat this file (which the WDL re-parses on every read_json call).
+        "structural_checks": _cap_structural_detail_lists(structural["details"]),
     }
 
     results_file = f"{output_dir}/verification_results.json"

--- a/scripts/variantstore/scripts/verify_all_loaded.py
+++ b/scripts/variantstore/scripts/verify_all_loaded.py
@@ -105,6 +105,16 @@ def _log_structural_summary(structural):
         else:
             log.warning(f"{level} {family}: {len(outliers)} sample(s) >= {screen['threshold']}x median (warning only)")
 
+    for family, screen in sorted(details.get("truncation_screen", {}).items()):
+        outliers = screen["outliers"]
+        level = "  [truncation]"
+        if not outliers:
+            log.info(f"{level} {family}: no samples <= median/{screen['threshold']} ({screen['median']})")
+        elif structural["strict_vet_screen"]:
+            log.error(f"{level} {family}: {len(outliers)} sample(s) <= median/{screen['threshold']} (STRICT: gating)")
+        else:
+            log.warning(f"{level} {family}: {len(outliers)} sample(s) <= median/{screen['threshold']} (warning only)")
+
     unscreened = details["duplication_unscreened"]
     if unscreened["families"]:
         log.info(f"  [duplication] not screened for {unscreened['families']}: {unscreened['reason']}")
@@ -229,12 +239,13 @@ def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
     )
     _log_structural_summary(structural)
 
-    # Family completeness and per-sample cardinality are hard gates; the vet duplication screen only
-    # gates when strict mode is requested (otherwise it warns).
+    # Family completeness and per-sample cardinality are hard gates; the vet duplication and truncation
+    # screens only gate when strict mode is requested (otherwise they warn).
     structural_checks_ok = (
         structural["completeness_ok"]
         and structural["cardinality_ok"]
-        and not (strict_vet_screen and structural["duplication_flagged"])
+        and not (strict_vet_screen
+                 and (structural["duplication_flagged"] or structural["truncation_flagged"]))
     )
 
     all_loaded = (
@@ -274,6 +285,7 @@ def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
         "family_completeness_ok": structural["completeness_ok"],
         "ploidy_cardinality_ok": structural["cardinality_ok"],
         "vet_duplication_flagged": structural["duplication_flagged"],
+        "vet_truncation_flagged": structural["truncation_flagged"],
         # Full per-check detail for humans and logs, with per-sample lists bounded so a large-callset
         # failure cannot bloat this file (which the WDL re-parses on every read_json call).
         "structural_checks": _cap_structural_detail_lists(structural["details"]),

--- a/scripts/variantstore/scripts/verify_all_loaded.py
+++ b/scripts/variantstore/scripts/verify_all_loaded.py
@@ -86,6 +86,18 @@ def _log_structural_summary(structural):
                 f"(expected {fam['expected']})"
             )
 
+    cross = details.get("cross_family_consistency")
+    if cross is not None:
+        if cross["ok"]:
+            log.info(f"  [cross-family] all families share the same {cross['union_size']} expected sample(s)")
+        else:
+            for family, fam in sorted(cross["per_family"].items()):
+                if fam["missing_samples"]:
+                    log.error(
+                        f"  [cross-family] {family}: {len(fam['missing_samples'])} sample(s) present in "
+                        f"other families but absent here (of {cross['union_size']} across all families)"
+                    )
+
     for table, card in sorted(details["cardinality"].items()):
         ref_desc = f"{card.get('reference_count')} rows/sample ({card.get('reference_source', 'mode')})"
         if card["ok"]:
@@ -129,13 +141,18 @@ def compute_structural_checks_ok(structural):
     Reduce a run_structural_checks result to the exact structural boolean that feeds all_loaded.
 
     Only the exact checks contribute: family completeness (every expected sample present and
-    non-empty) and per-sample ploidy cardinality. The duplication and truncation screens are
-    heuristics and deliberately do NOT gate all_loaded -- all_loaded is the factual "is the load
-    complete?" signal that fail-loud aborts on, and a heuristic flag does not make a complete load
-    incomplete. The screens instead gate the separate safe_to_delete_parquet predicate (see
-    compute_safe_to_delete_parquet).
+    non-empty), per-sample ploidy cardinality, and cross-family consistency (a sample present in some
+    families must be present in all -- catches the cross-family gap completeness judges vacuously). The
+    duplication and truncation screens are heuristics and deliberately do NOT gate all_loaded --
+    all_loaded is the factual "is the load complete?" signal that fail-loud aborts on, and a heuristic
+    flag does not make a complete load incomplete. The screens instead gate the separate
+    safe_to_delete_parquet predicate (see compute_safe_to_delete_parquet).
     """
-    return structural["completeness_ok"] and structural["cardinality_ok"]
+    return (
+        structural["completeness_ok"]
+        and structural["cardinality_ok"]
+        and structural["cross_family_ok"]
+    )
 
 
 def compute_all_loaded(missing_pairs, unmatched_files, structural_checks_ok):
@@ -183,9 +200,9 @@ def describe_incomplete_reasons(results):
 
     Kept a pure function of the results dict so the operator-facing diagnosis is unit-tested: this line
     is what an operator reads when a run has aborted. Only the exact checks can make all_loaded false
-    (missing/unmatched files, family completeness, ploidy cardinality); the vet duplication and
-    truncation screens never fail all_loaded -- they gate safe_to_delete_parquet instead -- so they are
-    deliberately absent here.
+    (missing/unmatched files, family completeness, ploidy cardinality, cross-family consistency); the
+    vet duplication and truncation screens never fail all_loaded -- they gate safe_to_delete_parquet
+    instead -- so they are deliberately absent here.
     """
     reasons = []
     missing_count = results.get("missing_files", 0) or 0
@@ -198,6 +215,8 @@ def describe_incomplete_reasons(results):
         reasons.append("family completeness check failed (missing or empty partitions)")
     if not results.get("ploidy_cardinality_ok", True):
         reasons.append("ploidy cardinality check failed (missing or off-reference samples)")
+    if not results.get("cross_family_consistency_ok", True):
+        reasons.append("cross-family consistency check failed (a sample present in some families is absent from another)")
     return reasons
 
 
@@ -296,17 +315,22 @@ def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
     # Derive, per family, the sample_ids GCS says should be loaded, then run row-count-based checks
     # that share no code with the loader's get_already_loaded_tables_and_sample_ids predicate.
     #
-    # This independence has a boundary: expected_by_family is sourced from all_gcs_pairs, which is
-    # the same GCS file listing (gcs_files_list, produced upstream by DiscoverParquetFiles) that the
-    # loader itself scatters over. A sample for which Parquet generation never produced output files
-    # at all -- as opposed to a sample whose files were produced but never loaded into BigQuery -- was
-    # never "expected" by this listing in the first place, so it is invisible to every check below,
-    # not just to the missing_pairs check above. Closing this needs an expected-sample source that
-    # does not derive from GCS: specifically this run's input sample set (the ingest FOFN). Note that
-    # sample_info cannot serve this wholesale -- it accumulates every sample ever ingested, including
-    # ones since withdrawn or deleted, so comparing against it in bulk would false-positive samples
-    # that are legitimately absent from this run; the expected set has to be scoped to the FOFN for
-    # this run. Tracked as a follow-up in VS-2016 (family-completeness independence); see also VS-1989.
+    # This independence has a boundary: expected_by_family is sourced from all_gcs_pairs, which is the
+    # same GCS file listing (gcs_files_list, produced upstream by DiscoverParquetFiles) that the loader
+    # itself scatters over. Within that listing the checks are now cross-family consistent -- a sample
+    # present in some families but absent from another is caught by assess_cross_family_consistency (all
+    # families are produced together per sample, so such a gap is a partial upload) rather than passing
+    # vacuously in the family that lacks it. What remains outside the listing is the whole-sample gap: a
+    # sample for which Parquet generation never produced output for ANY family was never in the listing
+    # at all, so it is in no family's expected set and no cross-family union, and stays invisible to
+    # every check here -- as opposed to a sample whose files were produced but never loaded into
+    # BigQuery, which the checks do catch. Closing that residual gap needs an expected-sample source
+    # that does not derive from GCS: specifically this run's input sample set (the ingest FOFN). Note
+    # that sample_info cannot serve this wholesale -- it accumulates every sample ever ingested,
+    # including ones since withdrawn or deleted, so comparing against it in bulk would false-positive
+    # samples that are legitimately absent from this run; the expected set has to be scoped to the FOFN
+    # for this run. Tracked as a follow-up in VS-2016 (family-completeness independence); see also
+    # VS-1989.
     expected_by_family = defaultdict(set)
     for table_name, sample_id in all_gcs_pairs:
         family = family_for_table(table_name, superpartitioned_table_prefixes)
@@ -370,6 +394,7 @@ def verify_all_loaded(project_id, dataset_name, gcs_files_list, output_dir,
         "structural_checks_ok": structural_checks_ok,
         "family_completeness_ok": structural["completeness_ok"],
         "ploidy_cardinality_ok": structural["cardinality_ok"],
+        "cross_family_consistency_ok": structural["cross_family_ok"],
         "vet_duplication_flagged": structural["duplication_flagged"],
         "vet_truncation_flagged": structural["truncation_flagged"],
         # Full per-check detail for humans and logs, with per-sample lists bounded so a large-callset

--- a/scripts/variantstore/scripts/verify_structural_checks.py
+++ b/scripts/variantstore/scripts/verify_structural_checks.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""
+Independent, row-count-based structural checks for Parquet ingest verification (VS-1989).
+
+These checks deliberately do NOT reuse ``get_already_loaded_tables_and_sample_ids`` -- the predicate
+``parse_and_group_files.py`` uses to decide which files to skip. That predicate answers only one
+question, "does this partition have ``total_logical_bytes > 0``?", so a verifier built on the same
+call can never contradict the loader: by construction it agrees. It is therefore blind to the two
+failure classes that matter most before the source Parquet is deleted:
+
+  * a partial or lost load -- a ``(table, sample_id)`` partition exists (bytes > 0) but holds fewer
+    rows than the source, and
+  * a duplicated load -- a partition holds *more* rows than the source, which presence-testing can
+    never see.
+
+The functions here ask a different question -- "how many rows?" -- through two cheap BigQuery
+metadata reads that share no code with the loader predicate:
+
+  * ``INFORMATION_SCHEMA.PARTITIONS.total_rows`` for the superpartitioned ``vet_%`` / ``ref_ranges_%``
+    families (partition metadata is a flat ~10 MB regardless of callset size; ``partition_id`` *is*
+    the ``sample_id`` because these tables are integer-range partitioned on ``sample_id`` with step
+    1), and
+  * a per-sample ``COUNT(*)`` on the regular ploidy table (scans a single column, ~100 MB on a
+    500k-sample callset).
+
+The crux of the independence is ``total_rows`` vs. ``total_logical_bytes``: a partition that is
+present but partial or duplicated has a wrong row count, which these checks catch and the loader
+predicate cannot.
+
+Scope notes (VS-1989):
+  * The exact footer-vs-BigQuery per-sample comparison (the gold-standard loss+duplication detector
+    from the ticket description) is intentionally deferred: it needs a new heavy image dependency
+    (pyarrow) and a footer read per file, which is prohibitive at AoU scale.
+  * ``ref_ranges`` has no cheap per-sample duplication signal -- its row count tracks GQ-band
+    transitions, not genome length, and legitimate samples reach many times the median -- so only
+    whole-sample presence is verified for it and the gap is recorded rather than papered over.
+  * The ploidy *duplication* reading holds only where a sample's ploidy rows were written at ingest;
+    a later backfill writes a full per-sample set regardless of what the reference tables contained,
+    masking a doubled sample. See ``PLOIDY_BACKFILL_CAVEAT``.
+"""
+
+import logging
+import statistics
+from collections import Counter, defaultdict
+
+try:
+    from google.cloud import bigquery
+except ImportError:
+    bigquery = None  # type: ignore  # will fail at runtime if BigQuery calls are made without the package installed
+
+# Reuse only the SQL-injection guard from the loader module. This is an input validator, not the
+# loader's "what is already loaded?" oracle, so importing it does not compromise the independence
+# these checks exist to provide.
+from parse_and_group_files import _validate_table_prefixes
+
+
+log = logging.getLogger(__name__)
+
+# Families for which a per-sample row-count-to-median duplication screen produces a usable signal.
+# Only ``vet`` qualifies (tight distribution); ``ref_ranges`` is deliberately excluded (see module
+# docstring). Callers may override.
+DEFAULT_DUPLICATION_SCREEN_FAMILIES = ["vet"]
+
+# Default ratio-to-median above which a vet sample is flagged as a possible duplicate. Miguel's
+# Foxtrot calibration found vet tight enough that 1.2x is safe against false positives; 1.6x is a
+# conservative default that still catches a doubled sample (~2.0x).
+DEFAULT_VET_DUPLICATION_THRESHOLD = 1.6
+
+PLOIDY_BACKFILL_CAVEAT = (
+    "Ploidy duplication is only detectable here where a sample's ploidy rows were written at ingest. "
+    "A later backfill writes a full per-sample set regardless, so a doubled sample would still show "
+    "the modal row count. Do not read a green ploidy result as a duplication guarantee for callsets "
+    "or sample ranges whose ploidy was backfilled (provenance is not captured today -- see VS-1989)."
+)
+
+
+def family_for_table(table_name, superpartitioned_table_prefixes):
+    """
+    Return the superpartitioned family prefix a concrete table name belongs to, or None.
+
+    A superpartitioned table name is ``<prefix>_<digits>`` (e.g. ``vet_001`` -> ``vet``,
+    ``ref_ranges_042`` -> ``ref_ranges``). The full-string match on ``^<prefix>_[0-9]+$`` avoids a
+    shorter prefix swallowing a longer table name.
+    """
+    for prefix in superpartitioned_table_prefixes:
+        remainder = table_name[len(prefix) + 1:]
+        if table_name.startswith(prefix + "_") and remainder.isdigit():
+            return prefix
+    return None
+
+
+def get_partition_row_counts(project_id, dataset_name, superpartitioned_table_prefixes):
+    """
+    Return per-partition row counts for the superpartitioned families as a list of
+    ``(table_name, sample_id, total_rows)`` tuples.
+
+    Reads ``INFORMATION_SCHEMA.PARTITIONS.total_rows`` directly. Unlike the loader predicate this
+    does NOT filter on ``total_logical_bytes > 0`` -- a present-but-empty partition (row count 0) is
+    exactly the partial-load signal we want to surface, so it must be included.
+    """
+    _validate_table_prefixes(superpartitioned_table_prefixes, [])
+
+    if not superpartitioned_table_prefixes:
+        return []
+
+    superpartitioned_regex = "|".join(
+        f"^{prefix}_[0-9]+$" for prefix in superpartitioned_table_prefixes
+    )
+    query = f"""
+        SELECT table_name AS table_name,
+               SAFE_CAST(partition_id AS INT64) AS sample_id,
+               total_rows AS total_rows
+        FROM `{project_id}.{dataset_name}.INFORMATION_SCHEMA.PARTITIONS`
+        WHERE
+            REGEXP_CONTAINS(table_name, '{superpartitioned_regex}') AND
+            NOT STARTS_WITH(partition_id, '__') AND
+            SAFE_CAST(partition_id AS INT64) IS NOT NULL
+        ORDER BY table_name, sample_id
+    """
+
+    try:
+        client = bigquery.Client(project=project_id)
+        results = client.query(query)
+        rows = [(row.table_name, row.sample_id, row.total_rows) for row in results]
+        log.info(f"Read {len(rows)} partition row counts from INFORMATION_SCHEMA.PARTITIONS")
+        return rows
+    except Exception as e:
+        log.error(f"ERROR: Could not read partition row counts from BigQuery: {e}")
+        raise
+
+
+def get_ploidy_row_counts(project_id, dataset_name, ploidy_table):
+    """
+    Return ``{sample_id: row_count}`` for a regular (non-superpartitioned) per-sample table by
+    grouping on ``sample_id``. Samples with zero rows simply do not appear.
+    """
+    _validate_table_prefixes([], [ploidy_table])
+
+    query = f"""
+        SELECT sample_id AS sample_id, COUNT(*) AS n
+        FROM `{project_id}.{dataset_name}.{ploidy_table}`
+        GROUP BY sample_id
+    """
+
+    try:
+        client = bigquery.Client(project=project_id)
+        results = client.query(query)
+        counts = {row.sample_id: row.n for row in results}
+        log.info(f"Read per-sample row counts for {len(counts)} samples from {ploidy_table}")
+        return counts
+    except Exception as e:
+        log.error(f"ERROR: Could not read per-sample row counts for {ploidy_table}: {e}")
+        raise
+
+
+def assess_family_completeness(partition_rows, regular_counts, expected_by_family,
+                               superpartitioned_table_prefixes, regular_table_prefixes):
+    """
+    Check that every sample GCS says should exist is present with a non-empty row count in each of
+    its families (the superpartitioned ``vet_%`` / ``ref_ranges_%`` and the regular ploidy table).
+
+    A sample expected in a superpartitioned family whose partition has ``total_rows == 0`` is
+    reported separately as ``empty`` -- present to the loader predicate (it may have bytes) but empty
+    in fact, i.e. a partial load the loader-shared check cannot see.
+
+    Returns a dict with an overall ``ok`` and a per-family breakdown.
+    """
+    present_by_family = defaultdict(set)
+    empty_by_family = defaultdict(set)
+
+    for table_name, sample_id, total_rows in partition_rows:
+        fam = family_for_table(table_name, superpartitioned_table_prefixes)
+        if fam is None:
+            continue
+        if total_rows and total_rows > 0:
+            present_by_family[fam].add(sample_id)
+        else:
+            empty_by_family[fam].add(sample_id)
+
+    for prefix in regular_table_prefixes:
+        counts = regular_counts.get(prefix, {})
+        present_by_family[prefix] = {sid for sid, n in counts.items() if n and n > 0}
+
+    per_family = {}
+    overall_ok = True
+    for fam, expected in sorted(expected_by_family.items()):
+        present = present_by_family.get(fam, set())
+        # An "empty" partition only matters if that sample was expected for this run.
+        empty = sorted(empty_by_family.get(fam, set()) & set(expected))
+        missing = sorted(set(expected) - present)
+        fam_ok = not missing and not empty
+        overall_ok = overall_ok and fam_ok
+        per_family[fam] = {
+            "ok": fam_ok,
+            "expected": len(expected),
+            "present": len(present & set(expected)),
+            "missing_samples": missing,
+            "empty_partition_samples": empty,
+        }
+
+    return {"ok": overall_ok, "per_family": per_family}
+
+
+def assess_cardinality(counts, expected_samples):
+    """
+    Check that every expected sample has the *same* per-sample row count -- the callset's modal
+    count -- and that none is missing.
+
+    Deliberately does not assume a fixed count (e.g. 24 for ploidy): that number is emergent (the
+    count of distinct non-PAR contigs, which chrM or non-WGS ingest can change), so each sample is
+    validated against the callset mode instead. A sample below the mode indicates a partial load; a
+    sample at a multiple of the mode indicates duplication (subject to PLOIDY_BACKFILL_CAVEAT).
+
+    ``counts`` is ``{sample_id: row_count}``; only ``expected_samples`` are assessed (extra samples
+    already in the table from prior loads are ignored).
+    """
+    expected = set(expected_samples)
+    present = {sid: counts[sid] for sid in expected if sid in counts and counts[sid] > 0}
+    missing = sorted(expected - set(present))
+
+    if not present:
+        return {
+            "ok": not expected,
+            "mode": None,
+            "min": None,
+            "max": None,
+            "distinct_samples": 0,
+            "total_rows": 0,
+            "missing_samples": missing,
+            "deviating_samples": [],
+        }
+
+    values = list(present.values())
+    mode = Counter(values).most_common(1)[0][0]
+    deviating = sorted(
+        ({"sample_id": sid, "count": n} for sid, n in present.items() if n != mode),
+        key=lambda d: d["sample_id"],
+    )
+
+    return {
+        "ok": not missing and not deviating,
+        "mode": mode,
+        "min": min(values),
+        "max": max(values),
+        "distinct_samples": len(present),
+        "total_rows": sum(values),
+        "missing_samples": missing,
+        "deviating_samples": deviating,
+    }
+
+
+def assess_duplication_screen(partition_rows, family, expected_samples,
+                              superpartitioned_table_prefixes, threshold):
+    """
+    Flag samples in ``family`` whose ``total_rows`` is at least ``threshold`` times the callset
+    median -- a heuristic screen for duplication. Returns the flagged samples; the caller decides
+    whether flags gate (strict) or merely warn (default).
+
+    Only meaningful for families with a tight per-sample distribution (``vet``); callers must not
+    apply it to ``ref_ranges``.
+    """
+    expected = set(expected_samples)
+    rows_by_sample = {
+        sample_id: total_rows
+        for table_name, sample_id, total_rows in partition_rows
+        if family_for_table(table_name, superpartitioned_table_prefixes) == family
+        and sample_id in expected
+        and total_rows and total_rows > 0
+    }
+
+    if not rows_by_sample:
+        return {"family": family, "threshold": threshold, "median": None,
+                "samples_screened": 0, "outliers": []}
+
+    median = statistics.median(rows_by_sample.values())
+    outliers = []
+    if median > 0:
+        for sid, rows in rows_by_sample.items():
+            ratio = rows / median
+            if ratio >= threshold:
+                outliers.append({"sample_id": sid, "rows": rows, "ratio": round(ratio, 3)})
+    outliers.sort(key=lambda d: d["ratio"], reverse=True)
+
+    return {
+        "family": family,
+        "threshold": threshold,
+        "median": median,
+        "samples_screened": len(rows_by_sample),
+        "outliers": outliers,
+    }
+
+
+def run_structural_checks(project_id, dataset_name, expected_by_family,
+                          superpartitioned_table_prefixes=None, regular_table_prefixes=None,
+                          vet_duplication_threshold=DEFAULT_VET_DUPLICATION_THRESHOLD,
+                          strict_vet_screen=False,
+                          duplication_screen_families=None):
+    """
+    Run the independent structural checks and return a result dict.
+
+    ``expected_by_family`` maps a family name (a superpartitioned prefix such as ``vet`` /
+    ``ref_ranges``, or a regular table name such as ``sample_chromosome_ploidy``) to the set of
+    ``sample_id`` values GCS says should be loaded for it.
+
+    The returned dict carries flat booleans the WDL reads shallowly (``completeness_ok``,
+    ``cardinality_ok``, ``duplication_flagged``) plus a nested ``details`` block for humans and logs.
+    ``completeness_ok`` and ``cardinality_ok`` are the hard-gate signals; the duplication screen only
+    contributes to the gate when ``strict_vet_screen`` is set.
+    """
+    if superpartitioned_table_prefixes is None:
+        superpartitioned_table_prefixes = ["vet", "ref_ranges"]
+    if regular_table_prefixes is None:
+        regular_table_prefixes = ["sample_chromosome_ploidy"]
+    if duplication_screen_families is None:
+        duplication_screen_families = DEFAULT_DUPLICATION_SCREEN_FAMILIES
+
+    partition_rows = get_partition_row_counts(
+        project_id, dataset_name, superpartitioned_table_prefixes
+    )
+    regular_counts = {
+        prefix: get_ploidy_row_counts(project_id, dataset_name, prefix)
+        for prefix in regular_table_prefixes
+    }
+
+    completeness = assess_family_completeness(
+        partition_rows, regular_counts, expected_by_family,
+        superpartitioned_table_prefixes, regular_table_prefixes,
+    )
+
+    # Per-sample cardinality consistency, applied to each regular per-sample table (ploidy is the
+    # exemplar): every sample should carry the callset's modal row count.
+    cardinality = {}
+    cardinality_ok = True
+    for prefix in regular_table_prefixes:
+        result = assess_cardinality(regular_counts.get(prefix, {}), expected_by_family.get(prefix, set()))
+        result["backfill_caveat"] = PLOIDY_BACKFILL_CAVEAT
+        cardinality[prefix] = result
+        cardinality_ok = cardinality_ok and result["ok"]
+
+    # Duplication screen on the usable superpartitioned families only (vet). ref_ranges is recorded
+    # as intentionally unchecked.
+    duplication = {}
+    for family in duplication_screen_families:
+        if family in superpartitioned_table_prefixes:
+            duplication[family] = assess_duplication_screen(
+                partition_rows, family, expected_by_family.get(family, set()),
+                superpartitioned_table_prefixes, vet_duplication_threshold,
+            )
+    unscreened = {
+        "checked": False,
+        "reason": ("No cheap per-sample duplication detector exists for these families "
+                   "(row count tracks GQ-band transitions, not genome length). See VS-1989."),
+        "families": sorted(f for f in superpartitioned_table_prefixes if f not in duplication),
+    }
+
+    duplication_flagged = any(d["outliers"] for d in duplication.values())
+
+    return {
+        "completeness_ok": completeness["ok"],
+        "cardinality_ok": cardinality_ok,
+        "duplication_flagged": duplication_flagged,
+        "strict_vet_screen": strict_vet_screen,
+        "details": {
+            "family_completeness": completeness,
+            "cardinality": cardinality,
+            "duplication_screen": duplication,
+            "duplication_unscreened": unscreened,
+        },
+    }

--- a/scripts/variantstore/scripts/verify_structural_checks.py
+++ b/scripts/variantstore/scripts/verify_structural_checks.py
@@ -33,7 +33,15 @@ Scope notes (VS-1989):
     (pyarrow) and a footer read per file, which is prohibitive at AoU scale.
   * ``ref_ranges`` has no cheap per-sample duplication signal -- its row count tracks GQ-band
     transitions, not genome length, and legitimate samples reach many times the median -- so only
-    whole-sample presence is verified for it and the gap is recorded rather than papered over.
+    whole-sample presence is verified for it and the gap is recorded rather than papered over. The
+    only detector that does work is exact: ``COUNT(*)`` vs. ``COUNT(DISTINCT packed_ref_data)`` per
+    sample, which costs a full per-sample scan rather than a partition-metadata read and so is out
+    of scope here. Comparing a sample's row count against its counterpart in the parent callset was
+    also considered and rejected: a child callset is seeded by copying its parent, so a defect
+    already present in the parent is copied forward identically and reads as agreement, not
+    disagreement. Cross-generation comparison can only catch a change introduced at or after the
+    copy -- never a defect the parent already had -- so it is not a substitute for a real detector
+    and is not implemented. Do not re-attempt either approach without re-reading this note.
   * The ploidy *duplication* reading holds only where a sample's ploidy rows were written at ingest;
     a later backfill writes a full per-sample set regardless of what the reference tables contained,
     masking a doubled sample. See ``PLOIDY_BACKFILL_CAVEAT``.
@@ -372,8 +380,13 @@ def run_structural_checks(project_id, dataset_name, expected_by_family,
             )
     unscreened = {
         "checked": False,
-        "reason": ("No cheap per-sample duplication detector exists for these families "
-                   "(row count tracks GQ-band transitions, not genome length). See VS-1989."),
+        "reason": ("No cheap per-sample duplication detector exists for these families (row count "
+                   "tracks GQ-band transitions, not genome length). The exact detector -- COUNT(*) "
+                   "vs. COUNT(DISTINCT packed_ref_data) per sample -- needs a full per-sample scan "
+                   "and is out of scope. Comparing against the parent callset's row count was also "
+                   "considered and rejected: a child callset copies its parent, so a pre-existing "
+                   "parent-side defect is copied forward identically and would read as agreement. "
+                   "See the module docstring and VS-1989."),
         "families": sorted(f for f in superpartitioned_table_prefixes if f not in duplication),
     }
 

--- a/scripts/variantstore/scripts/verify_structural_checks.py
+++ b/scripts/variantstore/scripts/verify_structural_checks.py
@@ -201,15 +201,22 @@ def assess_family_completeness(partition_rows, regular_counts, expected_by_famil
     return {"ok": overall_ok, "per_family": per_family}
 
 
-def assess_cardinality(counts, expected_samples):
+def assess_cardinality(counts, expected_samples, expected_count=None):
     """
-    Check that every expected sample has the *same* per-sample row count -- the callset's modal
-    count -- and that none is missing.
+    Check that every expected sample has the *same* per-sample row count and that none is missing.
 
-    Deliberately does not assume a fixed count (e.g. 24 for ploidy): that number is emergent (the
-    count of distinct non-PAR contigs, which chrM or non-WGS ingest can change), so each sample is
-    validated against the callset mode instead. A sample below the mode indicates a partial load; a
-    sample at a multiple of the mode indicates duplication (subject to PLOIDY_BACKFILL_CAVEAT).
+    By default the reference is the callset's own modal count, deliberately *not* a fixed number: for
+    ploidy the intuitive "24" is emergent (the count of distinct non-PAR contigs, which chrM or
+    non-WGS ingest can change), so hardcoding it would false-positive on exome/BGE/chrM callsets. A
+    sample below the reference indicates a partial load; a sample at a multiple of it indicates
+    duplication (subject to PLOIDY_BACKFILL_CAVEAT).
+
+    When ``expected_count`` is supplied the reference becomes that exact constant instead of the mode
+    (e.g. pass 24 for a WGS ploidy table). This recovers the ticket's exact-cardinality guarantee and
+    closes the one gap mode-based detection has -- if a majority of samples share the *wrong* count,
+    that wrong count becomes the mode and the correct minority would otherwise be flagged. The
+    observed mode is always reported alongside, so a mismatch between an override and reality is
+    visible rather than silently overriding it.
 
     ``counts`` is ``{sample_id: row_count}``; only ``expected_samples`` are assessed (extra samples
     already in the table from prior loads are ignored).
@@ -218,10 +225,14 @@ def assess_cardinality(counts, expected_samples):
     present = {sid: counts[sid] for sid in expected if sid in counts and counts[sid] > 0}
     missing = sorted(expected - set(present))
 
+    reference_source = "override" if expected_count is not None else "mode"
+
     if not present:
         return {
             "ok": not expected,
             "mode": None,
+            "reference_count": expected_count,
+            "reference_source": reference_source,
             "min": None,
             "max": None,
             "distinct_samples": 0,
@@ -231,15 +242,18 @@ def assess_cardinality(counts, expected_samples):
         }
 
     values = list(present.values())
-    mode = Counter(values).most_common(1)[0][0]
+    observed_mode = Counter(values).most_common(1)[0][0]
+    reference = expected_count if expected_count is not None else observed_mode
     deviating = sorted(
-        ({"sample_id": sid, "count": n} for sid, n in present.items() if n != mode),
+        ({"sample_id": sid, "count": n} for sid, n in present.items() if n != reference),
         key=lambda d: d["sample_id"],
     )
 
     return {
         "ok": not missing and not deviating,
-        "mode": mode,
+        "mode": observed_mode,
+        "reference_count": reference,
+        "reference_source": reference_source,
         "min": min(values),
         "max": max(values),
         "distinct_samples": len(present),
@@ -294,6 +308,7 @@ def run_structural_checks(project_id, dataset_name, expected_by_family,
                           superpartitioned_table_prefixes=None, regular_table_prefixes=None,
                           vet_duplication_threshold=DEFAULT_VET_DUPLICATION_THRESHOLD,
                           strict_vet_screen=False,
+                          expected_ploidy_rows_per_sample=None,
                           duplication_screen_families=None):
     """
     Run the independent structural checks and return a result dict.
@@ -301,6 +316,11 @@ def run_structural_checks(project_id, dataset_name, expected_by_family,
     ``expected_by_family`` maps a family name (a superpartitioned prefix such as ``vet`` /
     ``ref_ranges``, or a regular table name such as ``sample_chromosome_ploidy``) to the set of
     ``sample_id`` values GCS says should be loaded for it.
+
+    ``expected_ploidy_rows_per_sample``, when set, is the exact per-sample row count each regular
+    per-sample table (ploidy) is validated against instead of the callset mode; leave it unset to
+    infer the reference from the data. (There is one regular table -- ploidy -- today; if others with
+    differing exact counts are ever added this would need to become a per-table mapping.)
 
     The returned dict carries flat booleans the WDL reads shallowly (``completeness_ok``,
     ``cardinality_ok``, ``duplication_flagged``) plus a nested ``details`` block for humans and logs.
@@ -332,7 +352,11 @@ def run_structural_checks(project_id, dataset_name, expected_by_family,
     cardinality = {}
     cardinality_ok = True
     for prefix in regular_table_prefixes:
-        result = assess_cardinality(regular_counts.get(prefix, {}), expected_by_family.get(prefix, set()))
+        result = assess_cardinality(
+            regular_counts.get(prefix, {}),
+            expected_by_family.get(prefix, set()),
+            expected_count=expected_ploidy_rows_per_sample,
+        )
         result["backfill_caveat"] = PLOIDY_BACKFILL_CAVEAT
         cardinality[prefix] = result
         cardinality_ok = cardinality_ok and result["ok"]

--- a/scripts/variantstore/scripts/verify_structural_checks.py
+++ b/scripts/variantstore/scripts/verify_structural_checks.py
@@ -30,7 +30,16 @@ predicate cannot.
 Scope notes (VS-1989):
   * The exact footer-vs-BigQuery per-sample comparison (the gold-standard loss+duplication detector
     from the ticket description) is intentionally deferred: it needs a new heavy image dependency
-    (pyarrow) and a footer read per file, which is prohibitive at AoU scale.
+    (pyarrow) and a footer read per file, which is prohibitive at AoU scale. It would also catch
+    little that the checks here do not. A partial *load* cannot occur: BigQuery load jobs are atomic
+    (``load_parquet_to_bq.py`` loads each batch via ``load_table_from_uri`` with ``WRITE_APPEND``, and
+    a failed job commits nothing), so a present partition is either complete, empty (caught by
+    completeness), or duplicated (caught by the duplication screen). The one residual truncation source
+    is a Parquet file generated upstream with too few rows -- and there the footer count and the
+    BigQuery count agree, so footer-vs-BigQuery would pass it too. That case is instead surfaced
+    cheaply by ``assess_truncation_screen``, a below-median heuristic (the low-side mirror of the
+    duplication screen); catching it exactly would need a gVCF-level variant count, which is out of
+    scope. Do not re-attempt the footer comparison without re-reading this note.
   * ``ref_ranges`` has no cheap per-sample duplication signal -- its row count tracks GQ-band
     transitions, not genome length, and legitimate samples reach many times the median -- so only
     whole-sample presence is verified for it and the gap is recorded rather than papered over. The
@@ -329,6 +338,63 @@ def assess_duplication_screen(partition_rows, family, expected_samples,
     }
 
 
+def assess_truncation_screen(partition_rows, family, expected_samples,
+                             superpartitioned_table_prefixes, threshold):
+    """
+    Flag samples in ``family`` whose ``total_rows`` is at most ``median / threshold`` -- the low-side
+    mirror of ``assess_duplication_screen`` and a heuristic screen for a grossly truncated partition.
+    The same ``threshold`` governs both sides: a sample reads as a possible duplicate above
+    ``threshold * median`` and as a possible truncation below ``median / threshold``. Returns the
+    flagged samples; the caller decides whether flags gate (strict) or merely warn (default).
+
+    This is the only cheap detector for the one truncation source the rest of the row-count gate
+    misses: a Parquet file generated upstream with far fewer rows than its peers. Truncation cannot
+    arise from the load itself -- BigQuery load jobs are atomic (``load_parquet_to_bq.py`` loads each
+    batch via ``load_table_from_uri`` with ``WRITE_APPEND``, and a failed job commits nothing), so a
+    present partition is either complete, empty (zero rows, caught by completeness), or duplicated
+    (caught by the duplication screen), never partially committed. A load-vs-source row comparison
+    (the deferred footer-vs-BigQuery check) would therefore add cost -- a footer read per file, a new
+    pyarrow dependency -- without catching anything this does not: where a source Parquet is itself
+    truncated, its footer count and the BigQuery count agree, so that comparison would pass it too.
+    Catching the upstream case exactly would need a gVCF-level count, which is out of scope; a
+    below-peers heuristic is what remains, and that is this.
+
+    Only meaningful for families with a tight per-sample distribution (``vet``); callers must not apply
+    it to ``ref_ranges``, whose row count varies by orders of magnitude between legitimate samples.
+    Zero-row partitions are excluded here -- that is the completeness check's empty-partition case --
+    so this screen judges only partitions that are present and non-empty.
+    """
+    expected = set(expected_samples)
+    rows_by_sample = {
+        sample_id: total_rows
+        for table_name, sample_id, total_rows in partition_rows
+        if family_for_table(table_name, superpartitioned_table_prefixes) == family
+        and sample_id in expected
+        and total_rows and total_rows > 0
+    }
+
+    if not rows_by_sample:
+        return {"family": family, "threshold": threshold, "median": None,
+                "samples_screened": 0, "outliers": []}
+
+    median = statistics.median(rows_by_sample.values())
+    outliers = []
+    if median > 0:
+        floor = median / threshold
+        for sid, rows in rows_by_sample.items():
+            if rows <= floor:
+                outliers.append({"sample_id": sid, "rows": rows, "ratio": round(rows / median, 3)})
+    outliers.sort(key=lambda d: d["ratio"])
+
+    return {
+        "family": family,
+        "threshold": threshold,
+        "median": median,
+        "samples_screened": len(rows_by_sample),
+        "outliers": outliers,
+    }
+
+
 def run_structural_checks(project_id, dataset_name, expected_by_family,
                           superpartitioned_table_prefixes=None, regular_table_prefixes=None,
                           vet_duplication_threshold=DEFAULT_VET_DUPLICATION_THRESHOLD,
@@ -356,10 +422,11 @@ def run_structural_checks(project_id, dataset_name, expected_by_family,
     with differing exact counts are ever added this single override would need to become a per-table
     mapping.)
 
-    The returned dict carries flat booleans the WDL reads shallowly (``completeness_ok``,
-    ``cardinality_ok``, ``duplication_flagged``) plus a nested ``details`` block for humans and logs.
-    ``completeness_ok`` and ``cardinality_ok`` are the hard-gate signals; the duplication screen only
-    contributes to the gate when ``strict_vet_screen`` is set.
+    The returned dict carries flat booleans read shallowly downstream (``completeness_ok``,
+    ``cardinality_ok``, ``duplication_flagged``, ``truncation_flagged``) plus a nested ``details``
+    block for humans and logs. ``completeness_ok`` and ``cardinality_ok`` are the hard-gate signals;
+    the duplication and truncation screens contribute to the gate only when ``strict_vet_screen`` is
+    set (otherwise they warn).
     """
     if superpartitioned_table_prefixes is None:
         superpartitioned_table_prefixes = ["vet", "ref_ranges"]
@@ -402,12 +469,20 @@ def run_structural_checks(project_id, dataset_name, expected_by_family,
         cardinality[prefix] = result
         cardinality_ok = cardinality_ok and result["ok"]
 
-    # Duplication screen on the usable superpartitioned families only (vet). ref_ranges is recorded
-    # as intentionally unchecked.
+    # Duplication and truncation screens on the usable superpartitioned families only (vet): same
+    # families, same threshold, opposite sides of the median. ref_ranges is recorded as intentionally
+    # unchecked. The truncation screen is the low-side mirror -- it catches a grossly under-rowed
+    # partition, the one truncation source a row-count gate can produce cheaply (see
+    # assess_truncation_screen for why an exact load-vs-source comparison would add nothing here).
     duplication = {}
+    truncation = {}
     for family in duplication_screen_families:
         if family in superpartitioned_table_prefixes:
             duplication[family] = assess_duplication_screen(
+                partition_rows, family, expected_by_family.get(family, set()),
+                superpartitioned_table_prefixes, vet_duplication_threshold,
+            )
+            truncation[family] = assess_truncation_screen(
                 partition_rows, family, expected_by_family.get(family, set()),
                 superpartitioned_table_prefixes, vet_duplication_threshold,
             )
@@ -424,16 +499,19 @@ def run_structural_checks(project_id, dataset_name, expected_by_family,
     }
 
     duplication_flagged = any(d["outliers"] for d in duplication.values())
+    truncation_flagged = any(t["outliers"] for t in truncation.values())
 
     return {
         "completeness_ok": completeness["ok"],
         "cardinality_ok": cardinality_ok,
         "duplication_flagged": duplication_flagged,
+        "truncation_flagged": truncation_flagged,
         "strict_vet_screen": strict_vet_screen,
         "details": {
             "family_completeness": completeness,
             "cardinality": cardinality,
             "duplication_screen": duplication,
+            "truncation_screen": truncation,
             "duplication_unscreened": unscreened,
         },
     }

--- a/scripts/variantstore/scripts/verify_structural_checks.py
+++ b/scripts/variantstore/scripts/verify_structural_checks.py
@@ -57,6 +57,7 @@ Scope notes (VS-1989):
 """
 
 import logging
+import math
 import statistics
 from collections import Counter, defaultdict
 
@@ -428,6 +429,22 @@ def run_structural_checks(project_id, dataset_name, expected_by_family,
     the duplication and truncation screens contribute to the gate only when ``strict_vet_screen`` is
     set (otherwise they warn).
     """
+    # Reject a nonsensical ratio before any BigQuery read. 0 divides by zero in the truncation screen
+    # (median / threshold); any value <= 1 makes ordinary samples satisfy an outlier condition on both
+    # sides (>= threshold * median above, <= median / threshold below), so the screens would flag half
+    # the callset. Fail fast with an actionable message rather than crash mid-verification or silently
+    # flag everything.
+    try:
+        threshold_ok = math.isfinite(vet_duplication_threshold) and vet_duplication_threshold > 1
+    except TypeError:
+        threshold_ok = False
+    if not threshold_ok:
+        raise ValueError(
+            f"vet_duplication_threshold must be a finite number > 1 (got {vet_duplication_threshold!r}); "
+            "a ratio <= 1 flags ordinary samples on both screens and 0 divides by zero in the "
+            "truncation screen."
+        )
+
     if superpartitioned_table_prefixes is None:
         superpartitioned_table_prefixes = ["vet", "ref_ranges"]
     if regular_table_prefixes is None:

--- a/scripts/variantstore/scripts/verify_structural_checks.py
+++ b/scripts/variantstore/scripts/verify_structural_checks.py
@@ -169,7 +169,9 @@ def assess_family_completeness(partition_rows, regular_counts, expected_by_famil
 
     A sample expected in a superpartitioned family whose partition has ``total_rows == 0`` is
     reported separately as ``empty`` -- present to the loader predicate (it may have bytes) but empty
-    in fact, i.e. a partial load the loader-shared check cannot see.
+    in fact, i.e. a partial load the loader-shared check cannot see. It appears under
+    ``empty_partition_samples`` only and is never also counted under ``missing_samples`` -- "missing"
+    means the sample has no partition at all, so the two lists are disjoint.
 
     Returns a dict with an overall ``ok`` and a per-family breakdown.
     """
@@ -192,16 +194,21 @@ def assess_family_completeness(partition_rows, regular_counts, expected_by_famil
     per_family = {}
     overall_ok = True
     for fam, expected in sorted(expected_by_family.items()):
+        expected_set = set(expected)
         present = present_by_family.get(fam, set())
-        # An "empty" partition only matters if that sample was expected for this run.
-        empty = sorted(empty_by_family.get(fam, set()) & set(expected))
-        missing = sorted(set(expected) - present)
+        # A present-but-empty partition (total_rows == 0) is a partial load, reported on its own; an
+        # empty only matters if that sample was expected for this run.
+        empty_set = empty_by_family.get(fam, set()) & expected_set
+        empty = sorted(empty_set)
+        # "Missing" means no partition at all -- neither present nor empty. Excluding the empties here
+        # keeps the two lists disjoint so a present-but-empty sample is not double-counted as missing.
+        missing = sorted(expected_set - present - empty_set)
         fam_ok = not missing and not empty
         overall_ok = overall_ok and fam_ok
         per_family[fam] = {
             "ok": fam_ok,
-            "expected": len(expected),
-            "present": len(present & set(expected)),
+            "expected": len(expected_set),
+            "present": len(present & expected_set),
             "missing_samples": missing,
             "empty_partition_samples": empty,
         }

--- a/scripts/variantstore/scripts/verify_structural_checks.py
+++ b/scripts/variantstore/scripts/verify_structural_checks.py
@@ -236,9 +236,9 @@ def assess_family_completeness(partition_rows, regular_counts, expected_by_famil
     return {"ok": overall_ok, "per_family": per_family}
 
 
-def assess_cross_family_consistency(expected_by_family):
+def assess_cross_family_consistency(expected_by_family, required_families):
     """
-    Cross-check the per-family expected-sample sets against each other (VS-1989; narrows VS-2016).
+    Cross-check the required families' expected-sample sets against each other (VS-1989; narrows VS-2016).
 
     assess_family_completeness derives each family's expected set from that family's OWN GCS output
     files, so a sample for which one family's file was never produced is simply not "expected" in that
@@ -246,29 +246,41 @@ def assess_cross_family_consistency(expected_by_family):
     verify cleanly, and deletion of a source that is in fact incomplete gets authorized. On the Parquet
     ingest path every sample produces a vet, a ref_ranges and a ploidy file together
     (CreateVariantIngestFiles constructs all three creators unconditionally per sample, and a zero-row
-    file is still written on close), so within a single run the families' sample sets must be identical.
-    Any sample present in some families but absent from another is therefore a partial upload -- a real
+    file is still written on close), so within a single run the required families' sample sets must be
+    identical. Any sample present in some but absent from another is therefore a partial upload -- a real
     incompleteness -- and is caught here from the GCS listing alone, with no external sample source.
 
-    This deliberately does NOT close the whole-sample gap tracked in VS-2016: a sample absent from EVERY
-    family was never in the GCS listing at all, so it is not in the cross-family union and stays
-    invisible here; that still needs a non-GCS expected-sample source (this run's ingest FOFN). What it
-    does close is the narrower cross-family case -- present in some families, absent from another.
+    ``required_families`` is what this invocation declares it is loading (the configured superpartitioned
+    + regular table prefixes). Iterating over THAT rather than over the families that happen to appear in
+    ``expected_by_family`` is what catches an ENTIRELY absent family: a family for which not a single file
+    was produced has no key in expected_by_family, so a union taken only over present families would
+    silently omit it and pass while the load lacks all of its data. Each required family is taken as the
+    empty set when absent, so the union of every required family's samples is checked against it and an
+    absent required family is missing all of them. A run that legitimately loads none of the required
+    data families (a headers-only ingest) has an empty union and passes -- the check fires only when SOME
+    required families carry samples that another required family lacks. Required families are assumed
+    produced together per sample, which is the same premise the whole check rests on; a regular table
+    whose sample set legitimately differs must not be listed as required.
 
-    ``expected_by_family`` is ``{family: set(sample_id)}``. Returns an overall ``ok`` plus, per family,
-    the sample_ids in the cross-family union that this family is missing. A family entirely absent from
-    the listing has no key here and is not cross-checked -- that is the whole-family case above, not a
-    partial gap -- so the check never fires on a run that legitimately loads only one family.
+    This still does NOT close the whole-sample gap tracked in VS-2016: a sample absent from EVERY family
+    was never in the GCS listing at all, so it is in no family's set and no union, and stays invisible
+    here; catching it needs a non-GCS expected-sample source (this run's ingest FOFN). Unlike a whole
+    family, whose identity we know from the configured prefixes, a never-produced sample's identity is
+    unknowable without that source.
+
+    ``expected_by_family`` is ``{family: set(sample_id)}``. Returns an overall ``ok`` plus, per required
+    family, the sample_ids in the cross-family union that this family is missing.
     """
-    families = sorted(expected_by_family)
+    families = sorted(required_families)
     union = set()
     for fam in families:
-        union |= expected_by_family[fam]
+        union |= expected_by_family.get(fam, set())
 
     per_family = {}
     overall_ok = True
     for fam in families:
-        missing = sorted(union - expected_by_family[fam])
+        present = expected_by_family.get(fam, set())
+        missing = sorted(union - present)
         fam_ok = not missing
         overall_ok = overall_ok and fam_ok
         per_family[fam] = {"ok": fam_ok, "missing_samples": missing}
@@ -512,10 +524,13 @@ def run_structural_checks(project_id, dataset_name, expected_by_family,
     )
 
     # Cross-check the families' sample sets against one another. Completeness above judges each family
-    # only against its own GCS listing, so a family whose file was never produced for a sample passes
-    # vacuously there; this catches that cross-family gap from the GCS listing alone. Exact, so it gates
-    # all_loaded alongside completeness and cardinality (see assess_cross_family_consistency).
-    cross_family = assess_cross_family_consistency(expected_by_family)
+    # only against its own GCS listing, so a family whose file was never produced -- for a sample, or for
+    # the whole run -- passes vacuously there; this catches both from the GCS listing alone. The required
+    # family set is this invocation's configured prefixes, so an entirely absent family is compared as an
+    # empty set rather than silently dropped. Exact, so it gates all_loaded alongside completeness and
+    # cardinality (see assess_cross_family_consistency).
+    required_families = list(superpartitioned_table_prefixes) + list(regular_table_prefixes)
+    cross_family = assess_cross_family_consistency(expected_by_family, required_families)
 
     # Per-sample cardinality consistency, applied only to regular tables that carry a UNIFORM
     # per-sample row count (ploidy). Tables whose per-sample count legitimately varies -- notably

--- a/scripts/variantstore/scripts/verify_structural_checks.py
+++ b/scripts/variantstore/scripts/verify_structural_checks.py
@@ -303,7 +303,7 @@ def assess_duplication_screen(partition_rows, family, expected_samples,
     """
     Flag samples in ``family`` whose ``total_rows`` is at least ``threshold`` times the callset
     median -- a heuristic screen for duplication. Returns the flagged samples; the caller decides
-    whether flags gate (strict) or merely warn (default).
+    whether a flag blocks Parquet deletion (the default) or is waived (``allow_flagged_vet_loads``).
 
     Only meaningful for families with a tight per-sample distribution (``vet``); callers must not
     apply it to ``ref_ranges``.
@@ -346,7 +346,8 @@ def assess_truncation_screen(partition_rows, family, expected_samples,
     mirror of ``assess_duplication_screen`` and a heuristic screen for a grossly truncated partition.
     The same ``threshold`` governs both sides: a sample reads as a possible duplicate above
     ``threshold * median`` and as a possible truncation below ``median / threshold``. Returns the
-    flagged samples; the caller decides whether flags gate (strict) or merely warn (default).
+    flagged samples; the caller decides whether a flag blocks Parquet deletion (the default) or is
+    waived (``allow_flagged_vet_loads``).
 
     This is the only cheap detector for the one truncation source the rest of the row-count gate
     misses: a Parquet file generated upstream with far fewer rows than its peers. Truncation cannot
@@ -399,7 +400,7 @@ def assess_truncation_screen(partition_rows, family, expected_samples,
 def run_structural_checks(project_id, dataset_name, expected_by_family,
                           superpartitioned_table_prefixes=None, regular_table_prefixes=None,
                           vet_duplication_threshold=DEFAULT_VET_DUPLICATION_THRESHOLD,
-                          strict_vet_screen=False,
+                          allow_flagged_vet_loads=False,
                           expected_ploidy_rows_per_sample=None,
                           duplication_screen_families=None,
                           cardinality_table_prefixes=None):
@@ -425,9 +426,11 @@ def run_structural_checks(project_id, dataset_name, expected_by_family,
 
     The returned dict carries flat booleans read shallowly downstream (``completeness_ok``,
     ``cardinality_ok``, ``duplication_flagged``, ``truncation_flagged``) plus a nested ``details``
-    block for humans and logs. ``completeness_ok`` and ``cardinality_ok`` are the hard-gate signals;
-    the duplication and truncation screens contribute to the gate only when ``strict_vet_screen`` is
-    set (otherwise they warn).
+    block for humans and logs. ``completeness_ok`` and ``cardinality_ok`` are the exact signals that
+    gate ``all_loaded`` (and so the fail-loud abort). The duplication and truncation screens never
+    affect ``all_loaded``; they gate only the separate ``safe_to_delete_parquet`` predicate, and there
+    only when ``allow_flagged_vet_loads`` is false (its default). ``allow_flagged_vet_loads`` itself is
+    carried through unchanged, purely so the log summary can say whether a flag will block deletion.
     """
     # Reject a nonsensical ratio before any BigQuery read. 0 divides by zero in the truncation screen
     # (median / threshold); any value <= 1 makes ordinary samples satisfy an outlier condition on both
@@ -523,7 +526,7 @@ def run_structural_checks(project_id, dataset_name, expected_by_family,
         "cardinality_ok": cardinality_ok,
         "duplication_flagged": duplication_flagged,
         "truncation_flagged": truncation_flagged,
-        "strict_vet_screen": strict_vet_screen,
+        "allow_flagged_vet_loads": allow_flagged_vet_loads,
         "details": {
             "family_completeness": completeness,
             "cardinality": cardinality,

--- a/scripts/variantstore/scripts/verify_structural_checks.py
+++ b/scripts/variantstore/scripts/verify_structural_checks.py
@@ -69,6 +69,16 @@ log = logging.getLogger(__name__)
 # docstring). Callers may override.
 DEFAULT_DUPLICATION_SCREEN_FAMILIES = ["vet"]
 
+# Regular (non-superpartitioned) tables held to a UNIFORM per-sample row count by the cardinality
+# check. Only ploidy qualifies: its per-sample row count is a fixed function of the reference (the
+# non-PAR contig count). This is deliberately an allowlist, not a denylist -- a regular table whose
+# per-sample row count legitimately varies must be completeness-checked but never cardinality-checked,
+# and the safe default for any newly added regular table is "completeness only". In particular
+# ``vcf_header_lines_scratch`` writes one row per header line and header counts differ across samples
+# (VcfHeaderLineScratchCreator#apply), so including it here would false-positive every sample as
+# "deviating" and fail a valid headers-only ingest.
+DEFAULT_CARDINALITY_TABLE_PREFIXES = ["sample_chromosome_ploidy"]
+
 # Default ratio-to-median above which a vet sample is flagged as a possible duplicate. Miguel's
 # Foxtrot calibration found vet tight enough that 1.2x is safe against false positives; 1.6x is a
 # conservative default that still catches a doubled sample (~2.0x).
@@ -324,7 +334,8 @@ def run_structural_checks(project_id, dataset_name, expected_by_family,
                           vet_duplication_threshold=DEFAULT_VET_DUPLICATION_THRESHOLD,
                           strict_vet_screen=False,
                           expected_ploidy_rows_per_sample=None,
-                          duplication_screen_families=None):
+                          duplication_screen_families=None,
+                          cardinality_table_prefixes=None):
     """
     Run the independent structural checks and return a result dict.
 
@@ -332,10 +343,18 @@ def run_structural_checks(project_id, dataset_name, expected_by_family,
     ``ref_ranges``, or a regular table name such as ``sample_chromosome_ploidy``) to the set of
     ``sample_id`` values GCS says should be loaded for it.
 
-    ``expected_ploidy_rows_per_sample``, when set, is the exact per-sample row count each regular
-    per-sample table (ploidy) is validated against instead of the callset mode; leave it unset to
-    infer the reference from the data. (There is one regular table -- ploidy -- today; if others with
-    differing exact counts are ever added this would need to become a per-table mapping.)
+    ``regular_table_prefixes`` are the non-superpartitioned per-sample tables checked for completeness
+    (every expected sample present with > 0 rows). ``cardinality_table_prefixes`` is the subset of
+    those additionally held to a UNIFORM per-sample row count; it defaults to ploidy alone. A regular
+    table whose per-sample row count legitimately varies -- ``vcf_header_lines_scratch`` writes one row
+    per header line and samples differ -- must NOT be listed here, or every sample would read as
+    "deviating" and fail a valid ingest; completeness alone covers it.
+
+    ``expected_ploidy_rows_per_sample``, when set, is the exact per-sample row count each
+    cardinality-checked table is validated against instead of the callset mode; leave it unset to
+    infer the reference from the data. (Today ploidy is the only cardinality-checked table; if others
+    with differing exact counts are ever added this single override would need to become a per-table
+    mapping.)
 
     The returned dict carries flat booleans the WDL reads shallowly (``completeness_ok``,
     ``cardinality_ok``, ``duplication_flagged``) plus a nested ``details`` block for humans and logs.
@@ -348,6 +367,8 @@ def run_structural_checks(project_id, dataset_name, expected_by_family,
         regular_table_prefixes = ["sample_chromosome_ploidy"]
     if duplication_screen_families is None:
         duplication_screen_families = DEFAULT_DUPLICATION_SCREEN_FAMILIES
+    if cardinality_table_prefixes is None:
+        cardinality_table_prefixes = DEFAULT_CARDINALITY_TABLE_PREFIXES
 
     partition_rows = get_partition_row_counts(
         project_id, dataset_name, superpartitioned_table_prefixes
@@ -362,11 +383,16 @@ def run_structural_checks(project_id, dataset_name, expected_by_family,
         superpartitioned_table_prefixes, regular_table_prefixes,
     )
 
-    # Per-sample cardinality consistency, applied to each regular per-sample table (ploidy is the
-    # exemplar): every sample should carry the callset's modal row count.
+    # Per-sample cardinality consistency, applied only to regular tables that carry a UNIFORM
+    # per-sample row count (ploidy). Tables whose per-sample count legitimately varies -- notably
+    # vcf_header_lines_scratch, one row per header line with counts differing across samples -- are
+    # excluded here (completeness above still covers them); enforcing the mode on them would
+    # false-positive every sample as "deviating" and fail a valid ingest.
     cardinality = {}
     cardinality_ok = True
     for prefix in regular_table_prefixes:
+        if prefix not in cardinality_table_prefixes:
+            continue
         result = assess_cardinality(
             regular_counts.get(prefix, {}),
             expected_by_family.get(prefix, set()),

--- a/scripts/variantstore/scripts/verify_structural_checks.py
+++ b/scripts/variantstore/scripts/verify_structural_checks.py
@@ -236,6 +236,46 @@ def assess_family_completeness(partition_rows, regular_counts, expected_by_famil
     return {"ok": overall_ok, "per_family": per_family}
 
 
+def assess_cross_family_consistency(expected_by_family):
+    """
+    Cross-check the per-family expected-sample sets against each other (VS-1989; narrows VS-2016).
+
+    assess_family_completeness derives each family's expected set from that family's OWN GCS output
+    files, so a sample for which one family's file was never produced is simply not "expected" in that
+    family and its absence there passes vacuously -- meanwhile its files in the OTHER families load and
+    verify cleanly, and deletion of a source that is in fact incomplete gets authorized. On the Parquet
+    ingest path every sample produces a vet, a ref_ranges and a ploidy file together
+    (CreateVariantIngestFiles constructs all three creators unconditionally per sample, and a zero-row
+    file is still written on close), so within a single run the families' sample sets must be identical.
+    Any sample present in some families but absent from another is therefore a partial upload -- a real
+    incompleteness -- and is caught here from the GCS listing alone, with no external sample source.
+
+    This deliberately does NOT close the whole-sample gap tracked in VS-2016: a sample absent from EVERY
+    family was never in the GCS listing at all, so it is not in the cross-family union and stays
+    invisible here; that still needs a non-GCS expected-sample source (this run's ingest FOFN). What it
+    does close is the narrower cross-family case -- present in some families, absent from another.
+
+    ``expected_by_family`` is ``{family: set(sample_id)}``. Returns an overall ``ok`` plus, per family,
+    the sample_ids in the cross-family union that this family is missing. A family entirely absent from
+    the listing has no key here and is not cross-checked -- that is the whole-family case above, not a
+    partial gap -- so the check never fires on a run that legitimately loads only one family.
+    """
+    families = sorted(expected_by_family)
+    union = set()
+    for fam in families:
+        union |= expected_by_family[fam]
+
+    per_family = {}
+    overall_ok = True
+    for fam in families:
+        missing = sorted(union - expected_by_family[fam])
+        fam_ok = not missing
+        overall_ok = overall_ok and fam_ok
+        per_family[fam] = {"ok": fam_ok, "missing_samples": missing}
+
+    return {"ok": overall_ok, "union_size": len(union), "per_family": per_family}
+
+
 def assess_cardinality(counts, expected_samples, expected_count=None):
     """
     Check that every expected sample has the *same* per-sample row count and that none is missing.
@@ -425,9 +465,10 @@ def run_structural_checks(project_id, dataset_name, expected_by_family,
     mapping.)
 
     The returned dict carries flat booleans read shallowly downstream (``completeness_ok``,
-    ``cardinality_ok``, ``duplication_flagged``, ``truncation_flagged``) plus a nested ``details``
-    block for humans and logs. ``completeness_ok`` and ``cardinality_ok`` are the exact signals that
-    gate ``all_loaded`` (and so the fail-loud abort). The duplication and truncation screens never
+    ``cardinality_ok``, ``cross_family_ok``, ``duplication_flagged``, ``truncation_flagged``) plus a
+    nested ``details`` block for humans and logs. ``completeness_ok``, ``cardinality_ok`` and
+    ``cross_family_ok`` are the exact signals that gate ``all_loaded`` (and so the fail-loud abort).
+    The duplication and truncation screens never
     affect ``all_loaded``; they gate only the separate ``safe_to_delete_parquet`` predicate, and there
     only when ``allow_flagged_vet_loads`` is false (its default). ``allow_flagged_vet_loads`` itself is
     carried through unchanged, purely so the log summary can say whether a flag will block deletion.
@@ -469,6 +510,12 @@ def run_structural_checks(project_id, dataset_name, expected_by_family,
         partition_rows, regular_counts, expected_by_family,
         superpartitioned_table_prefixes, regular_table_prefixes,
     )
+
+    # Cross-check the families' sample sets against one another. Completeness above judges each family
+    # only against its own GCS listing, so a family whose file was never produced for a sample passes
+    # vacuously there; this catches that cross-family gap from the GCS listing alone. Exact, so it gates
+    # all_loaded alongside completeness and cardinality (see assess_cross_family_consistency).
+    cross_family = assess_cross_family_consistency(expected_by_family)
 
     # Per-sample cardinality consistency, applied only to regular tables that carry a UNIFORM
     # per-sample row count (ploidy). Tables whose per-sample count legitimately varies -- notably
@@ -524,11 +571,13 @@ def run_structural_checks(project_id, dataset_name, expected_by_family,
     return {
         "completeness_ok": completeness["ok"],
         "cardinality_ok": cardinality_ok,
+        "cross_family_ok": cross_family["ok"],
         "duplication_flagged": duplication_flagged,
         "truncation_flagged": truncation_flagged,
         "allow_flagged_vet_loads": allow_flagged_vet_loads,
         "details": {
             "family_completeness": completeness,
+            "cross_family_consistency": cross_family,
             "cardinality": cardinality,
             "duplication_screen": duplication,
             "truncation_screen": truncation,

--- a/scripts/variantstore/scripts/verify_structural_checks.py
+++ b/scripts/variantstore/scripts/verify_structural_checks.py
@@ -89,6 +89,16 @@ DEFAULT_DUPLICATION_SCREEN_FAMILIES = ["vet"]
 # "deviating" and fail a valid headers-only ingest.
 DEFAULT_CARDINALITY_TABLE_PREFIXES = ["sample_chromosome_ploidy"]
 
+# Families that Parquet generation produces TOGETHER, per sample, so their sample sets must be
+# identical within a run (the premise the cross-family consistency check rests on): a sample's vet,
+# ref_ranges and ploidy files are all written in the same pass (CreateVariantIngestFiles constructs all
+# three creators unconditionally per sample). ``vcf_header_lines_scratch`` is deliberately NOT a member
+# -- it is produced only on the header-loading path, on its own per-sample cadence, and a supported
+# headers-only ingest produces it while producing none of the data families. The cross-family check
+# activates only when at least one member is present, so a headers-only run (no data family present) is
+# not required to have them and passes; see assess_cross_family_consistency.
+DEFAULT_CO_PRODUCED_FAMILIES = ["vet", "ref_ranges", "sample_chromosome_ploidy"]
+
 # Default ratio-to-median above which a vet sample is flagged as a possible duplicate. Miguel's
 # Foxtrot calibration found vet tight enough that 1.2x is safe against false positives; 1.6x is a
 # conservative default that still catches a doubled sample (~2.0x).
@@ -236,9 +246,9 @@ def assess_family_completeness(partition_rows, regular_counts, expected_by_famil
     return {"ok": overall_ok, "per_family": per_family}
 
 
-def assess_cross_family_consistency(expected_by_family, required_families):
+def assess_cross_family_consistency(expected_by_family, co_produced_families):
     """
-    Cross-check the required families' expected-sample sets against each other (VS-1989; narrows VS-2016).
+    Cross-check the co-produced families' expected-sample sets against each other (VS-1989; narrows VS-2016).
 
     assess_family_completeness derives each family's expected set from that family's OWN GCS output
     files, so a sample for which one family's file was never produced is simply not "expected" in that
@@ -246,32 +256,39 @@ def assess_cross_family_consistency(expected_by_family, required_families):
     verify cleanly, and deletion of a source that is in fact incomplete gets authorized. On the Parquet
     ingest path every sample produces a vet, a ref_ranges and a ploidy file together
     (CreateVariantIngestFiles constructs all three creators unconditionally per sample, and a zero-row
-    file is still written on close), so within a single run the required families' sample sets must be
+    file is still written on close), so within a single run these families' sample sets must be
     identical. Any sample present in some but absent from another is therefore a partial upload -- a real
     incompleteness -- and is caught here from the GCS listing alone, with no external sample source.
 
-    ``required_families`` is what this invocation declares it is loading (the configured superpartitioned
-    + regular table prefixes). Iterating over THAT rather than over the families that happen to appear in
-    ``expected_by_family`` is what catches an ENTIRELY absent family: a family for which not a single file
-    was produced has no key in expected_by_family, so a union taken only over present families would
-    silently omit it and pass while the load lacks all of its data. Each required family is taken as the
-    empty set when absent, so the union of every required family's samples is checked against it and an
-    absent required family is missing all of them. A run that legitimately loads none of the required
-    data families (a headers-only ingest) has an empty union and passes -- the check fires only when SOME
-    required families carry samples that another required family lacks. Required families are assumed
-    produced together per sample, which is the same premise the whole check rests on; a regular table
-    whose sample set legitimately differs must not be listed as required.
+    ``co_produced_families`` is the group known to be generated together per sample (vet / ref_ranges /
+    ploidy; see DEFAULT_CO_PRODUCED_FAMILIES). The check is **presence-activated**: it fires only when at
+    least one member actually has files this run. This is what makes it correct across the phased ingest
+    without a phase flag. A member present-but-absent-from-another is a per-sample partial upload; a
+    member entirely absent while a sibling is present is a whole-family partial upload -- both fail. But
+    a run that produced NONE of the group (a supported headers-only ingest, whose only family is
+    ``vcf_header_lines_scratch`` -- deliberately not a member of this group -- while the data prefixes are
+    still configured, so their files are simply absent) has no member present, so the check is dormant
+    and passes. Membership must be limited to families with a single shared per-sample cadence; a family
+    on a different production cadence (headers) must not be listed, or a legitimate phase that produces
+    one but not the other would false-positive.
 
     This still does NOT close the whole-sample gap tracked in VS-2016: a sample absent from EVERY family
     was never in the GCS listing at all, so it is in no family's set and no union, and stays invisible
     here; catching it needs a non-GCS expected-sample source (this run's ingest FOFN). Unlike a whole
-    family, whose identity we know from the configured prefixes, a never-produced sample's identity is
+    family, whose identity we know from the co-produced group, a never-produced sample's identity is
     unknowable without that source.
 
-    ``expected_by_family`` is ``{family: set(sample_id)}``. Returns an overall ``ok`` plus, per required
-    family, the sample_ids in the cross-family union that this family is missing.
+    ``expected_by_family`` is ``{family: set(sample_id)}``. Returns an overall ``ok`` plus, per member
+    family, the sample_ids in the cross-family union that this family is missing. When no member is
+    present the returned ``per_family`` is empty and ``ok`` is True.
     """
-    families = sorted(required_families)
+    families = sorted(co_produced_families)
+    # Presence-activation: unless at least one co-produced family carries files this run, there is
+    # nothing to cross-check -- treating an absent group as a gap would fail a legitimate headers-only
+    # ingest (which produces none of these families) even though the data prefixes are configured.
+    if not any(expected_by_family.get(fam) for fam in families):
+        return {"ok": True, "union_size": 0, "per_family": {}}
+
     union = set()
     for fam in families:
         union |= expected_by_family.get(fam, set())
@@ -455,7 +472,8 @@ def run_structural_checks(project_id, dataset_name, expected_by_family,
                           allow_flagged_vet_loads=False,
                           expected_ploidy_rows_per_sample=None,
                           duplication_screen_families=None,
-                          cardinality_table_prefixes=None):
+                          cardinality_table_prefixes=None,
+                          co_produced_families=None):
     """
     Run the independent structural checks and return a result dict.
 
@@ -509,6 +527,8 @@ def run_structural_checks(project_id, dataset_name, expected_by_family,
         duplication_screen_families = DEFAULT_DUPLICATION_SCREEN_FAMILIES
     if cardinality_table_prefixes is None:
         cardinality_table_prefixes = DEFAULT_CARDINALITY_TABLE_PREFIXES
+    if co_produced_families is None:
+        co_produced_families = DEFAULT_CO_PRODUCED_FAMILIES
 
     partition_rows = get_partition_row_counts(
         project_id, dataset_name, superpartitioned_table_prefixes
@@ -523,14 +543,20 @@ def run_structural_checks(project_id, dataset_name, expected_by_family,
         superpartitioned_table_prefixes, regular_table_prefixes,
     )
 
-    # Cross-check the families' sample sets against one another. Completeness above judges each family
-    # only against its own GCS listing, so a family whose file was never produced -- for a sample, or for
-    # the whole run -- passes vacuously there; this catches both from the GCS listing alone. The required
-    # family set is this invocation's configured prefixes, so an entirely absent family is compared as an
-    # empty set rather than silently dropped. Exact, so it gates all_loaded alongside completeness and
-    # cardinality (see assess_cross_family_consistency).
-    required_families = list(superpartitioned_table_prefixes) + list(regular_table_prefixes)
-    cross_family = assess_cross_family_consistency(expected_by_family, required_families)
+    # Cross-check the co-produced families' sample sets against one another. Completeness above judges
+    # each family only against its own GCS listing, so a family whose file was never produced -- for a
+    # sample, or for the whole run -- passes vacuously there; this catches both from the GCS listing
+    # alone. The check ranges over the co-produced-data group (vet / ref_ranges / ploidy), which the Java
+    # ingest emits together per sample, NOT over every configured prefix: vcf_header_lines_scratch is on a
+    # different cadence and a headers-only phase produces only it. It is presence-activated -- dormant
+    # unless a group member has files this run -- so that supported headers-only ingest passes while a
+    # per-sample or whole-family gap within the data group still fails. The group is intersected with the
+    # configured prefixes so a run that does not load one of them cannot false-positive on its absence.
+    # Exact, so it gates all_loaded alongside completeness and cardinality (see
+    # assess_cross_family_consistency).
+    configured_families = set(superpartitioned_table_prefixes) | set(regular_table_prefixes)
+    active_co_produced_families = [f for f in co_produced_families if f in configured_families]
+    cross_family = assess_cross_family_consistency(expected_by_family, active_co_produced_families)
 
     # Per-sample cardinality consistency, applied only to regular tables that carry a UNIFORM
     # per-sample row count (ploidy). Tables whose per-sample count legitimately varies -- notably

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -68,6 +68,12 @@ workflow GvsBulkIngestGenomes {
         Boolean use_parquet_ingest = true
         # `parquet_output_gcs_dir` must be defined if `use_parquet_ingest` is true.
         String? parquet_output_gcs_dir
+        # Independent post-load structural checks (VS-1989), forwarded to GvsImportGenomes; see that
+        # workflow. Defaults preserve warn-only vet screening and mode-inferred ploidy, so leaving them
+        # unset changes nothing.
+        Float parquet_vet_duplication_threshold = 1.6
+        Boolean parquet_strict_vet_screen = false
+        Int? parquet_expected_ploidy_rows_per_sample
 
         Boolean use_compressed_references = false
     }
@@ -79,6 +85,9 @@ workflow GvsBulkIngestGenomes {
         vcf_index_files_column_name: "The column that supplies the path for the GVCF index files to be ingested. If not specified, the workflow will attempt to derive the column name."
         sample_set_name: "The recommended way to load samples; Sample sets must be created by the user. If no sample_set_name is specified, all samples will be loaded into GVS"
         bulk_ingest_fofn: "An explicitly specified FOFN of VCFs to be ingested. If specified, the workflow will not generate a FOFN from the data table. This can be useful for avoiding the scale limitations of Terra data tables. The format is tab delimited with no header: sample_name<tab>gvcf_file_path<tab>gvcf_index_file_path. If this value is specified, none of the data table parameters should be specified."
+        parquet_vet_duplication_threshold: "VS-1989 post-load verification, forwarded to GvsImportGenomes: ratio-to-callset-median at or above which a vet sample's row count is flagged as a possible duplicate, and (mirrored) at or below median/ratio as a possible truncation. Must be > 1; default 1.6."
+        parquet_strict_vet_screen: "VS-1989 post-load verification, forwarded to GvsImportGenomes: when true, a vet duplication- or truncation-screen flag fails verification and blocks Parquet deletion; when false (default) the screens only warn. Family completeness and ploidy cardinality always gate regardless."
+        parquet_expected_ploidy_rows_per_sample: "VS-1989 post-load verification, forwarded to GvsImportGenomes: exact per-sample sample_chromosome_ploidy row count to validate against (e.g. 24 for WGS) instead of the inferred callset mode; leave unset to infer from the data (correct for exome/BGE/chrM)."
     }
 
     if (!defined(git_hash) ||
@@ -178,6 +187,9 @@ workflow GvsBulkIngestGenomes {
             is_rate_limited_beta_customer = tighter_gcp_quotas,
             use_parquet_ingest = use_parquet_ingest,
             parquet_output_gcs_dir = parquet_output_gcs_dir,
+            parquet_vet_duplication_threshold = parquet_vet_duplication_threshold,
+            parquet_strict_vet_screen = parquet_strict_vet_screen,
+            parquet_expected_ploidy_rows_per_sample = parquet_expected_ploidy_rows_per_sample,
             is_wgs = is_wgs,
     }
 

--- a/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsBulkIngestGenomes.wdl
@@ -69,10 +69,10 @@ workflow GvsBulkIngestGenomes {
         # `parquet_output_gcs_dir` must be defined if `use_parquet_ingest` is true.
         String? parquet_output_gcs_dir
         # Independent post-load structural checks (VS-1989), forwarded to GvsImportGenomes; see that
-        # workflow. Defaults preserve warn-only vet screening and mode-inferred ploidy, so leaving them
-        # unset changes nothing.
+        # workflow. Defaults keep the vet screens blocking deletion on a flag and ploidy mode-inferred,
+        # so leaving them unset changes nothing.
         Float parquet_vet_duplication_threshold = 1.6
-        Boolean parquet_strict_vet_screen = false
+        Boolean parquet_allow_flagged_vet_loads = false
         Int? parquet_expected_ploidy_rows_per_sample
 
         Boolean use_compressed_references = false
@@ -86,7 +86,7 @@ workflow GvsBulkIngestGenomes {
         sample_set_name: "The recommended way to load samples; Sample sets must be created by the user. If no sample_set_name is specified, all samples will be loaded into GVS"
         bulk_ingest_fofn: "An explicitly specified FOFN of VCFs to be ingested. If specified, the workflow will not generate a FOFN from the data table. This can be useful for avoiding the scale limitations of Terra data tables. The format is tab delimited with no header: sample_name<tab>gvcf_file_path<tab>gvcf_index_file_path. If this value is specified, none of the data table parameters should be specified."
         parquet_vet_duplication_threshold: "VS-1989 post-load verification, forwarded to GvsImportGenomes: ratio-to-callset-median at or above which a vet sample's row count is flagged as a possible duplicate, and (mirrored) at or below median/ratio as a possible truncation. Must be > 1; default 1.6."
-        parquet_strict_vet_screen: "VS-1989 post-load verification, forwarded to GvsImportGenomes: when true, a vet duplication- or truncation-screen flag fails verification and blocks Parquet deletion; when false (default) the screens only warn. Family completeness and ploidy cardinality always gate regardless."
+        parquet_allow_flagged_vet_loads: "VS-1989 post-load verification, forwarded to GvsImportGenomes: when false (default), a vet duplication- or truncation-screen flag blocks deletion of the source Parquet (the load still succeeds and its Parquet is retained); when true the screens are waived and deletion proceeds despite a flag. Family completeness and ploidy cardinality are exact checks that always gate load completeness regardless."
         parquet_expected_ploidy_rows_per_sample: "VS-1989 post-load verification, forwarded to GvsImportGenomes: exact per-sample sample_chromosome_ploidy row count to validate against (e.g. 24 for WGS) instead of the inferred callset mode; leave unset to infer from the data (correct for exome/BGE/chrM)."
     }
 
@@ -188,7 +188,7 @@ workflow GvsBulkIngestGenomes {
             use_parquet_ingest = use_parquet_ingest,
             parquet_output_gcs_dir = parquet_output_gcs_dir,
             parquet_vet_duplication_threshold = parquet_vet_duplication_threshold,
-            parquet_strict_vet_screen = parquet_strict_vet_screen,
+            parquet_allow_flagged_vet_loads = parquet_allow_flagged_vet_loads,
             parquet_expected_ploidy_rows_per_sample = parquet_expected_ploidy_rows_per_sample,
             is_wgs = is_wgs,
     }

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -64,6 +64,9 @@ workflow GvsImportGenomes {
     # deletion (all_loaded=false) only when parquet_strict_vet_screen is set.
     Float parquet_vet_duplication_threshold = 1.6
     Boolean parquet_strict_vet_screen = false
+    # If set, the exact per-sample ploidy row count to validate against (e.g. 24 for WGS) instead of
+    # the callset mode. Leave unset to infer the reference from the data (correct for exome/BGE/chrM).
+    Int? parquet_expected_ploidy_rows_per_sample
 
     Boolean is_wgs = true
   }
@@ -304,6 +307,7 @@ workflow GvsImportGenomes {
         superpartitioned_table_prefixes = parquet_superpartitioned_prefixes,
         vet_duplication_threshold = parquet_vet_duplication_threshold,
         strict_vet_screen = parquet_strict_vet_screen,
+        expected_ploidy_rows_per_sample = parquet_expected_ploidy_rows_per_sample,
         go = LoadParquetFilesToBQ.done,
         variants_docker = effective_variants_docker,
     }
@@ -1352,6 +1356,8 @@ task VerifyParquetLoading {
     # Independent structural checks (VS-1989): duplication-screen ratio and whether a flag gates deletion.
     Float vet_duplication_threshold = 1.6
     Boolean strict_vet_screen = false
+    # Exact per-sample ploidy row count to validate against (e.g. 24 for WGS); unset infers the mode.
+    Int? expected_ploidy_rows_per_sample
     # Intentionally unused: this input exists solely to enforce task ordering - the upstream task's `done` output
     # is passed here to prevent this task from running until the upstream task has completed.
     #@ except: UnusedInput
@@ -1376,6 +1382,7 @@ task VerifyParquetLoading {
       --superpartitioned-table-prefixes ~{sep=" " superpartitioned_table_prefixes} \
       --vet-duplication-threshold ~{vet_duplication_threshold} \
       ~{true="--strict-vet-screen" false="" strict_vet_screen} \
+      ~{"--expected-ploidy-rows-per-sample " + expected_ploidy_rows_per_sample} \
       --output-dir verification_output
   >>>
 

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -59,6 +59,12 @@ workflow GvsImportGenomes {
     Boolean delete_parquet_files_after_loading = true
     Boolean use_alternate_parquet_delete_strategy = false
 
+    # Independent post-load structural checks (VS-1989). The vet duplication screen flags any sample
+    # whose vet row count is >= this ratio of the callset median; by default it only warns, and gates
+    # deletion (all_loaded=false) only when parquet_strict_vet_screen is set.
+    Float parquet_vet_duplication_threshold = 1.6
+    Boolean parquet_strict_vet_screen = false
+
     Boolean is_wgs = true
   }
 
@@ -296,6 +302,8 @@ workflow GvsImportGenomes {
         gcs_files_list = DiscoverParquetFiles.all_files_list,
         regular_table_prefixes = parquet_regular_prefixes,
         superpartitioned_table_prefixes = parquet_superpartitioned_prefixes,
+        vet_duplication_threshold = parquet_vet_duplication_threshold,
+        strict_vet_screen = parquet_strict_vet_screen,
         go = LoadParquetFilesToBQ.done,
         variants_docker = effective_variants_docker,
     }
@@ -365,6 +373,11 @@ workflow GvsImportGenomes {
     Boolean? parquet_loading_verified = VerifyParquetLoading.all_loaded
     Int? parquet_files_loaded = VerifyParquetLoading.loaded_files
     Int? parquet_total_files = VerifyParquetLoading.total_files
+    # Independent structural-check observability (VS-1989).
+    Boolean? parquet_structural_checks_ok = VerifyParquetLoading.structural_checks_ok
+    Boolean? parquet_family_completeness_ok = VerifyParquetLoading.family_completeness_ok
+    Boolean? parquet_ploidy_cardinality_ok = VerifyParquetLoading.ploidy_cardinality_ok
+    Boolean? parquet_vet_duplication_flagged = VerifyParquetLoading.vet_duplication_flagged
   }
 }
 
@@ -1336,6 +1349,9 @@ task VerifyParquetLoading {
     File gcs_files_list
     Array[String] regular_table_prefixes = ["sample_chromosome_ploidy"]
     Array[String] superpartitioned_table_prefixes = ["vet", "ref_ranges"]
+    # Independent structural checks (VS-1989): duplication-screen ratio and whether a flag gates deletion.
+    Float vet_duplication_threshold = 1.6
+    Boolean strict_vet_screen = false
     # Intentionally unused: this input exists solely to enforce task ordering - the upstream task's `done` output
     # is passed here to prevent this task from running until the upstream task has completed.
     #@ except: UnusedInput
@@ -1358,6 +1374,8 @@ task VerifyParquetLoading {
       --gcs-files-list ~{gcs_files_list} \
       --regular-table-prefixes ~{sep=" " regular_table_prefixes} \
       --superpartitioned-table-prefixes ~{sep=" " superpartitioned_table_prefixes} \
+      --vet-duplication-threshold ~{vet_duplication_threshold} \
+      ~{true="--strict-vet-screen" false="" strict_vet_screen} \
       --output-dir verification_output
   >>>
 
@@ -1376,6 +1394,12 @@ task VerifyParquetLoading {
     Int loaded_files = read_json(results_json)["loaded_files"]
     Int missing_files = read_json(results_json)["missing_files"]
     File? missing_files_list = "verification_output/missing_files.txt"
+    # Independent structural-check outcomes (VS-1989), read shallowly. structural_checks_ok is the
+    # composite that (together with the shared-predicate presence check) determines all_loaded.
+    Boolean structural_checks_ok = read_json(results_json)["structural_checks_ok"]
+    Boolean family_completeness_ok = read_json(results_json)["family_completeness_ok"]
+    Boolean ploidy_cardinality_ok = read_json(results_json)["ploidy_cardinality_ok"]
+    Boolean vet_duplication_flagged = read_json(results_json)["vet_duplication_flagged"]
     Boolean done = true
   }
 }

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -387,13 +387,15 @@ workflow GvsImportGenomes {
     Boolean? parquet_loading_verified = VerifyParquetLoading.all_loaded
     Int? parquet_files_loaded = VerifyParquetLoading.loaded_files
     Int? parquet_total_files = VerifyParquetLoading.total_files
-    # Independent structural-check observability (VS-1989). Only the vet-duplication screen is surfaced
-    # here: it is warn-only by default, so it can be observed true on a successful run. The composite
-    # structural verdict and its family-completeness / ploidy-cardinality components are hard checks that
-    # fail the fail-loud VerifyParquetLoading task, whose outputs Cromwell then never delocalizes -- so
-    # they could only ever be read as true and are not published. The full verdict (including those
-    # components) is written to verification_results.json, copied to a durable diagnostics path on failure.
+    # Independent structural-check observability (VS-1989). Both warn-only vet screens -- duplication and
+    # truncation -- are surfaced here: they are warn-only by default, so either can be observed true on a
+    # successful run. The composite structural verdict and its family-completeness / ploidy-cardinality
+    # components are hard checks that fail the fail-loud VerifyParquetLoading task, whose outputs Cromwell
+    # then never delocalizes -- so they could only ever be read as true and are not published. The full
+    # verdict (including those components) is written to verification_results.json, copied to a durable
+    # diagnostics path on failure.
     Boolean? parquet_vet_duplication_flagged = VerifyParquetLoading.vet_duplication_flagged
+    Boolean? parquet_vet_truncation_flagged = VerifyParquetLoading.vet_truncation_flagged
   }
 }
 
@@ -1469,14 +1471,15 @@ task VerifyParquetLoading {
     Int loaded_files = read_json(results_json)["loaded_files"]
     Int missing_files = read_json(results_json)["missing_files"]
     File? missing_files_list = "verification_output/missing_files.txt"
-    # Independent structural-check observability (VS-1989), read shallowly. Only the vet-duplication
-    # screen is exposed as a task output: it is warn-only by default, so it is meaningful on a task that
-    # succeeds. The composite structural verdict and its family-completeness / ploidy-cardinality
-    # components are hard checks -- when any fails, verify_all_loaded.py exits non-zero and this task
-    # fails, at which point Cromwell does not evaluate these outputs at all. Publishing them as task
-    # outputs would therefore only ever yield true, so they are omitted; the complete verdict lives in
-    # results_json (copied to the durable diagnostics path on failure).
+    # Independent structural-check observability (VS-1989), read shallowly. Both warn-only vet screens --
+    # duplication and truncation -- are exposed as task outputs: warn-only by default, so they are
+    # meaningful on a task that succeeds. The composite structural verdict and its family-completeness /
+    # ploidy-cardinality components are hard checks -- when any fails, verify_all_loaded.py exits non-zero
+    # and this task fails, at which point Cromwell does not evaluate these outputs at all. Publishing them
+    # as task outputs would therefore only ever yield true, so they are omitted; the complete verdict
+    # lives in results_json (copied to the durable diagnostics path on failure).
     Boolean vet_duplication_flagged = read_json(results_json)["vet_duplication_flagged"]
+    Boolean vet_truncation_flagged = read_json(results_json)["vet_truncation_flagged"]
     Boolean done = true
   }
 }

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -308,6 +308,8 @@ workflow GvsImportGenomes {
         vet_duplication_threshold = parquet_vet_duplication_threshold,
         strict_vet_screen = parquet_strict_vet_screen,
         expected_ploidy_rows_per_sample = parquet_expected_ploidy_rows_per_sample,
+        verification_diagnostics_gcs_dir = defined_parquet_output_dir + "/verification_diagnostics",
+        billing_project_id = billing_project_id,
         go = LoadParquetFilesToBQ.done,
         variants_docker = effective_variants_docker,
     }
@@ -377,10 +379,12 @@ workflow GvsImportGenomes {
     Boolean? parquet_loading_verified = VerifyParquetLoading.all_loaded
     Int? parquet_files_loaded = VerifyParquetLoading.loaded_files
     Int? parquet_total_files = VerifyParquetLoading.total_files
-    # Independent structural-check observability (VS-1989).
-    Boolean? parquet_structural_checks_ok = VerifyParquetLoading.structural_checks_ok
-    Boolean? parquet_family_completeness_ok = VerifyParquetLoading.family_completeness_ok
-    Boolean? parquet_ploidy_cardinality_ok = VerifyParquetLoading.ploidy_cardinality_ok
+    # Independent structural-check observability (VS-1989). Only the vet-duplication screen is surfaced
+    # here: it is warn-only by default, so it can be observed true on a successful run. The composite
+    # structural verdict and its family-completeness / ploidy-cardinality components are hard checks that
+    # fail the fail-loud VerifyParquetLoading task, whose outputs Cromwell then never delocalizes -- so
+    # they could only ever be read as true and are not published. The full verdict (including those
+    # components) is written to verification_results.json, copied to a durable diagnostics path on failure.
     Boolean? parquet_vet_duplication_flagged = VerifyParquetLoading.vet_duplication_flagged
   }
 }
@@ -1391,6 +1395,13 @@ task VerifyParquetLoading {
     Boolean strict_vet_screen = false
     # Exact per-sample ploidy row count to validate against (e.g. 24 for WGS); unset infers the mode.
     Int? expected_ploidy_rows_per_sample
+    # Optional durable location for the verdict JSON. This task is fail-loud -- a bad load exits non-zero
+    # and aborts the workflow -- and Cromwell does not delocalize a failed task's outputs, so copying the
+    # results JSON here keeps the diagnostic recoverable at a predictable path on failure. Unset -> no copy
+    # (the JSON still lives only in the task execution directory).
+    String? verification_diagnostics_gcs_dir
+    # Billing project for the diagnostics copy, required when the target bucket is requester-pays.
+    String? billing_project_id
     # Intentionally unused: this input exists solely to enforce task ordering - the upstream task's `done` output
     # is passed here to prevent this task from running until the upstream task has completed.
     #@ except: UnusedInput
@@ -1407,6 +1418,11 @@ task VerifyParquetLoading {
     set -o errexit -o nounset -o xtrace -o pipefail
     mkdir -p verification_output
 
+    # This verification is fail-loud: verify_all_loaded.py exits non-zero when the load is incomplete, and
+    # a non-zero task aborts the workflow before any irreversible Parquet deletion. Capture that exit code
+    # (rather than letting errexit abort here) so we can first copy the verdict JSON somewhere durable --
+    # Cromwell never delocalizes a failed task's outputs -- and then re-raise the code below.
+    rc=0
     python3 /app/verify_all_loaded.py \
       --project-id ~{project_id} \
       --dataset-name ~{dataset_name} \
@@ -1416,7 +1432,18 @@ task VerifyParquetLoading {
       --vet-duplication-threshold ~{vet_duplication_threshold} \
       ~{true="--strict-vet-screen" false="" strict_vet_screen} \
       ~{"--expected-ploidy-rows-per-sample " + expected_ploidy_rows_per_sample} \
-      --output-dir verification_output
+      --output-dir verification_output || rc=$?
+
+    # Copy the verdict JSON to a durable location if one was configured, so the diagnostic survives the
+    # fail-loud abort above. The copy must never mask the verification verdict, hence the trailing `|| true`.
+    diagnostics_dir='~{default="" verification_diagnostics_gcs_dir}'
+    if [[ -n "${diagnostics_dir}" && -f verification_output/verification_results.json ]]
+    then
+      gcloud storage cp ~{"--billing-project " + billing_project_id} \
+        verification_output/verification_results.json "${diagnostics_dir%/}/verification_results.json" || true
+    fi
+
+    exit $rc
   >>>
 
   runtime {
@@ -1434,11 +1461,13 @@ task VerifyParquetLoading {
     Int loaded_files = read_json(results_json)["loaded_files"]
     Int missing_files = read_json(results_json)["missing_files"]
     File? missing_files_list = "verification_output/missing_files.txt"
-    # Independent structural-check outcomes (VS-1989), read shallowly. structural_checks_ok is the
-    # composite that (together with the shared-predicate presence check) determines all_loaded.
-    Boolean structural_checks_ok = read_json(results_json)["structural_checks_ok"]
-    Boolean family_completeness_ok = read_json(results_json)["family_completeness_ok"]
-    Boolean ploidy_cardinality_ok = read_json(results_json)["ploidy_cardinality_ok"]
+    # Independent structural-check observability (VS-1989), read shallowly. Only the vet-duplication
+    # screen is exposed as a task output: it is warn-only by default, so it is meaningful on a task that
+    # succeeds. The composite structural verdict and its family-completeness / ploidy-cardinality
+    # components are hard checks -- when any fails, verify_all_loaded.py exits non-zero and this task
+    # fails, at which point Cromwell does not evaluate these outputs at all. Publishing them as task
+    # outputs would therefore only ever yield true, so they are omitted; the complete verdict lives in
+    # results_json (copied to the durable diagnostics path on failure).
     Boolean vet_duplication_flagged = read_json(results_json)["vet_duplication_flagged"]
     Boolean done = true
   }

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -71,6 +71,14 @@ workflow GvsImportGenomes {
     Boolean is_wgs = true
   }
 
+  parameter_meta {
+    # VS-1989 independent post-load structural checks; documented so these verification controls are
+    # discoverable (womtool inputs, Terra, integration tests) alongside use_parquet_ingest.
+    parquet_vet_duplication_threshold: "VS-1989 post-load verification: ratio-to-callset-median at or above which a vet sample's row count is flagged as a possible duplicate, and (mirrored) at or below median/ratio as a possible truncation. Must be > 1; default 1.6."
+    parquet_strict_vet_screen: "VS-1989 post-load verification: when true, a vet duplication- or truncation-screen flag fails verification and blocks Parquet deletion; when false (default) the screens only warn. Family completeness and ploidy cardinality always gate regardless."
+    parquet_expected_ploidy_rows_per_sample: "VS-1989 post-load verification: exact per-sample sample_chromosome_ploidy row count to validate against (e.g. 24 for WGS) instead of the inferred callset mode; leave unset to infer from the data (correct for exome/BGE/chrM)."
+  }
+
   Int max_auto_scatter_width = if is_wgs then 25000 else 100000
   String genome_type = if is_wgs then "WGS" else "exome"
 

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -60,10 +60,12 @@ workflow GvsImportGenomes {
     Boolean use_alternate_parquet_delete_strategy = false
 
     # Independent post-load structural checks (VS-1989). The vet duplication screen flags any sample
-    # whose vet row count is >= this ratio of the callset median; by default it only warns, and gates
-    # deletion (all_loaded=false) only when parquet_strict_vet_screen is set.
+    # whose vet row count is >= this ratio of the callset median (and the truncation screen the low-side
+    # mirror). By default a flag blocks deletion of the source Parquet -- the load still succeeds and
+    # its Parquet is retained; set parquet_allow_flagged_vet_loads to waive the screens and delete
+    # anyway.
     Float parquet_vet_duplication_threshold = 1.6
-    Boolean parquet_strict_vet_screen = false
+    Boolean parquet_allow_flagged_vet_loads = false
     # If set, the exact per-sample ploidy row count to validate against (e.g. 24 for WGS) instead of
     # the callset mode. Leave unset to infer the reference from the data (correct for exome/BGE/chrM).
     Int? parquet_expected_ploidy_rows_per_sample
@@ -75,7 +77,7 @@ workflow GvsImportGenomes {
     # VS-1989 independent post-load structural checks; documented so these verification controls are
     # discoverable (womtool inputs, Terra, integration tests) alongside use_parquet_ingest.
     parquet_vet_duplication_threshold: "VS-1989 post-load verification: ratio-to-callset-median at or above which a vet sample's row count is flagged as a possible duplicate, and (mirrored) at or below median/ratio as a possible truncation. Must be > 1; default 1.6."
-    parquet_strict_vet_screen: "VS-1989 post-load verification: when true, a vet duplication- or truncation-screen flag fails verification and blocks Parquet deletion; when false (default) the screens only warn. Family completeness and ploidy cardinality always gate regardless."
+    parquet_allow_flagged_vet_loads: "VS-1989 post-load verification: when false (default), a vet duplication- or truncation-screen flag blocks deletion of the source Parquet (the load still succeeds and its Parquet is retained); when true the screens are waived and deletion proceeds despite a flag. Family completeness and ploidy cardinality are exact checks that always gate load completeness regardless."
     parquet_expected_ploidy_rows_per_sample: "VS-1989 post-load verification: exact per-sample sample_chromosome_ploidy row count to validate against (e.g. 24 for WGS) instead of the inferred callset mode; leave unset to infer from the data (correct for exome/BGE/chrM)."
   }
 
@@ -314,7 +316,7 @@ workflow GvsImportGenomes {
         regular_table_prefixes = parquet_regular_prefixes,
         superpartitioned_table_prefixes = parquet_superpartitioned_prefixes,
         vet_duplication_threshold = parquet_vet_duplication_threshold,
-        strict_vet_screen = parquet_strict_vet_screen,
+        allow_flagged_vet_loads = parquet_allow_flagged_vet_loads,
         expected_ploidy_rows_per_sample = parquet_expected_ploidy_rows_per_sample,
         verification_diagnostics_gcs_dir = defined_parquet_output_dir + "/verification_diagnostics",
         billing_project_id = billing_project_id,
@@ -322,7 +324,7 @@ workflow GvsImportGenomes {
         variants_docker = effective_variants_docker,
     }
 
-    if (delete_parquet_files_after_loading && VerifyParquetLoading.all_loaded) {
+    if (delete_parquet_files_after_loading && VerifyParquetLoading.safe_to_delete_parquet) {
       call DeleteParquetFiles {
         input:
           output_gcs_dir = defined_parquet_output_dir,
@@ -385,15 +387,19 @@ workflow GvsImportGenomes {
     #@ except: UnnecessaryFunctionCall
     Array[File] load_data_stderrs = select_first([select_all(GenerateParquetFilesFromInputGVCFs.stderr), select_all(LoadDataViaBigQueryWriteAPI.stderr)])
     Boolean? parquet_loading_verified = VerifyParquetLoading.all_loaded
+    Boolean? parquet_safe_to_delete = VerifyParquetLoading.safe_to_delete_parquet
     Int? parquet_files_loaded = VerifyParquetLoading.loaded_files
     Int? parquet_total_files = VerifyParquetLoading.total_files
-    # Independent structural-check observability (VS-1989). Both warn-only vet screens -- duplication and
-    # truncation -- are surfaced here: they are warn-only by default, so either can be observed true on a
-    # successful run. The composite structural verdict and its family-completeness / ploidy-cardinality
-    # components are hard checks that fail the fail-loud VerifyParquetLoading task, whose outputs Cromwell
-    # then never delocalizes -- so they could only ever be read as true and are not published. The full
-    # verdict (including those components) is written to verification_results.json, copied to a durable
-    # diagnostics path on failure.
+    # Independent structural-check observability (VS-1989). parquet_loading_verified (all_loaded) is the
+    # factual "load complete?" verdict; parquet_safe_to_delete (safe_to_delete_parquet) is the deletion
+    # gate. They differ exactly when a vet screen flagged on an otherwise-complete load -- a case that
+    # now SUCCEEDS (all_loaded true) yet retains its Parquet (safe_to_delete_parquet false) unless
+    # parquet_allow_flagged_vet_loads waived the screens. Both vet screen flags are surfaced so that
+    # difference is observable on a successful run. The family-completeness / ploidy-cardinality
+    # components are exact checks that fail the fail-loud VerifyParquetLoading task, whose outputs
+    # Cromwell then never delocalizes -- so they could only ever be read as true and are not published;
+    # the full verdict is written to verification_results.json, copied to a durable diagnostics path on
+    # failure.
     Boolean? parquet_vet_duplication_flagged = VerifyParquetLoading.vet_duplication_flagged
     Boolean? parquet_vet_truncation_flagged = VerifyParquetLoading.vet_truncation_flagged
   }
@@ -1400,9 +1406,10 @@ task VerifyParquetLoading {
     File gcs_files_list
     Array[String] regular_table_prefixes = ["sample_chromosome_ploidy"]
     Array[String] superpartitioned_table_prefixes = ["vet", "ref_ranges"]
-    # Independent structural checks (VS-1989): duplication-screen ratio and whether a flag gates deletion.
+    # Independent structural checks (VS-1989): duplication-screen ratio and whether a screen flag is
+    # waived. By default (false) a flag blocks Parquet deletion; true waives the screens.
     Float vet_duplication_threshold = 1.6
-    Boolean strict_vet_screen = false
+    Boolean allow_flagged_vet_loads = false
     # Exact per-sample ploidy row count to validate against (e.g. 24 for WGS); unset infers the mode.
     Int? expected_ploidy_rows_per_sample
     # Optional durable location for the verdict JSON. This task is fail-loud -- a bad load exits non-zero
@@ -1440,7 +1447,7 @@ task VerifyParquetLoading {
       --regular-table-prefixes ~{sep=" " regular_table_prefixes} \
       --superpartitioned-table-prefixes ~{sep=" " superpartitioned_table_prefixes} \
       --vet-duplication-threshold ~{vet_duplication_threshold} \
-      ~{true="--strict-vet-screen" false="" strict_vet_screen} \
+      ~{true="--allow-flagged-vet-loads" false="" allow_flagged_vet_loads} \
       ~{"--expected-ploidy-rows-per-sample " + expected_ploidy_rows_per_sample} \
       --output-dir verification_output || rc=$?
 
@@ -1467,17 +1474,23 @@ task VerifyParquetLoading {
     # TODO: Sprocket flags read_json indexing as invalid on Union type; fix by upgrading to WDL 1.1 and using struct coercion — see VS-1957.
     File results_json = "verification_output/verification_results.json"
     Boolean all_loaded = read_json(results_json)["all_loaded"]
+    # The deletion gate DeleteParquetFiles is conditioned on: all_loaded AND no unwaived vet-screen flag.
+    # Distinct from all_loaded so a flagged-but-complete load succeeds (all_loaded true, this task exits
+    # zero) yet retains its Parquet (safe_to_delete_parquet false). Meaningful precisely on a task that
+    # succeeds, so -- unlike the exact-check components below -- it is safe to publish as a task output.
+    Boolean safe_to_delete_parquet = read_json(results_json)["safe_to_delete_parquet"]
     Int total_files = read_json(results_json)["total_files"]
     Int loaded_files = read_json(results_json)["loaded_files"]
     Int missing_files = read_json(results_json)["missing_files"]
     File? missing_files_list = "verification_output/missing_files.txt"
-    # Independent structural-check observability (VS-1989), read shallowly. Both warn-only vet screens --
-    # duplication and truncation -- are exposed as task outputs: warn-only by default, so they are
-    # meaningful on a task that succeeds. The composite structural verdict and its family-completeness /
-    # ploidy-cardinality components are hard checks -- when any fails, verify_all_loaded.py exits non-zero
-    # and this task fails, at which point Cromwell does not evaluate these outputs at all. Publishing them
-    # as task outputs would therefore only ever yield true, so they are omitted; the complete verdict
-    # lives in results_json (copied to the durable diagnostics path on failure).
+    # Independent structural-check observability (VS-1989), read shallowly. Both vet screens --
+    # duplication and truncation -- are exposed as task outputs: they never fail all_loaded (they gate
+    # safe_to_delete_parquet instead), so they are meaningful on a task that succeeds. The
+    # family-completeness / ploidy-cardinality components are exact checks -- when any fails,
+    # verify_all_loaded.py exits non-zero and this task fails, at which point Cromwell does not evaluate
+    # these outputs at all. Publishing them as task outputs would therefore only ever yield true, so they
+    # are omitted; the complete verdict lives in results_json (copied to the durable diagnostics path on
+    # failure).
     Boolean vet_duplication_flagged = read_json(results_json)["vet_duplication_flagged"]
     Boolean vet_truncation_flagged = read_json(results_json)["vet_truncation_flagged"]
     Boolean done = true

--- a/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
+++ b/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
@@ -38,9 +38,10 @@ workflow GvsJointVariantCalling {
         Boolean use_parquet_ingest = false
         String? parquet_output_gcs_dir
         # Independent post-load structural checks (VS-1989), forwarded through GvsBulkIngestGenomes to
-        # GvsImportGenomes. Defaults preserve warn-only vet screening and mode-inferred ploidy.
+        # GvsImportGenomes. Defaults keep the vet screens blocking deletion on a flag and ploidy
+        # mode-inferred.
         Float parquet_vet_duplication_threshold = 1.6
-        Boolean parquet_strict_vet_screen = false
+        Boolean parquet_allow_flagged_vet_loads = false
         Int? parquet_expected_ploidy_rows_per_sample
         String? sample_set_name ## NOTE: currently we only allow the loading of one sample set at a time
         String? billing_project_id
@@ -105,7 +106,7 @@ workflow GvsJointVariantCalling {
         # GvsImportGenomes; documented so these verification controls are discoverable (womtool inputs,
         # Terra, integration tests).
         parquet_vet_duplication_threshold: "VS-1989 post-load verification: ratio-to-callset-median at or above which a vet sample's row count is flagged as a possible duplicate, and (mirrored) at or below median/ratio as a possible truncation. Must be > 1; default 1.6."
-        parquet_strict_vet_screen: "VS-1989 post-load verification: when true, a vet duplication- or truncation-screen flag fails verification and blocks Parquet deletion; when false (default) the screens only warn. Family completeness and ploidy cardinality always gate regardless."
+        parquet_allow_flagged_vet_loads: "VS-1989 post-load verification: when false (default), a vet duplication- or truncation-screen flag blocks deletion of the source Parquet (the load still succeeds and its Parquet is retained); when true the screens are waived and deletion proceeds despite a flag. Family completeness and ploidy cardinality are exact checks that always gate load completeness regardless."
         parquet_expected_ploidy_rows_per_sample: "VS-1989 post-load verification: exact per-sample sample_chromosome_ploidy row count to validate against (e.g. 24 for WGS) instead of the inferred callset mode; leave unset to infer from the data (correct for exome/BGE/chrM)."
     }
 
@@ -182,7 +183,7 @@ workflow GvsJointVariantCalling {
             use_parquet_ingest = use_parquet_ingest,
             parquet_output_gcs_dir = parquet_output_gcs_dir,
             parquet_vet_duplication_threshold = parquet_vet_duplication_threshold,
-            parquet_strict_vet_screen = parquet_strict_vet_screen,
+            parquet_allow_flagged_vet_loads = parquet_allow_flagged_vet_loads,
             parquet_expected_ploidy_rows_per_sample = parquet_expected_ploidy_rows_per_sample,
     }
 

--- a/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
+++ b/scripts/variantstore/wdl/GvsJointVariantCalling.wdl
@@ -37,6 +37,11 @@ workflow GvsJointVariantCalling {
         # *NOTE* Parquet ingest off here by default until Parquet becomes the default ingest mode for Beta!
         Boolean use_parquet_ingest = false
         String? parquet_output_gcs_dir
+        # Independent post-load structural checks (VS-1989), forwarded through GvsBulkIngestGenomes to
+        # GvsImportGenomes. Defaults preserve warn-only vet screening and mode-inferred ploidy.
+        Float parquet_vet_duplication_threshold = 1.6
+        Boolean parquet_strict_vet_screen = false
+        Int? parquet_expected_ploidy_rows_per_sample
         String? sample_set_name ## NOTE: currently we only allow the loading of one sample set at a time
         String? billing_project_id
 
@@ -93,6 +98,15 @@ workflow GvsJointVariantCalling {
         File? sample_names_to_extract
         Int? split_intervals_disk_size_override
         Int? split_intervals_mem_override
+    }
+
+    parameter_meta {
+        # VS-1989 independent post-load structural checks, forwarded through GvsBulkIngestGenomes to
+        # GvsImportGenomes; documented so these verification controls are discoverable (womtool inputs,
+        # Terra, integration tests).
+        parquet_vet_duplication_threshold: "VS-1989 post-load verification: ratio-to-callset-median at or above which a vet sample's row count is flagged as a possible duplicate, and (mirrored) at or below median/ratio as a possible truncation. Must be > 1; default 1.6."
+        parquet_strict_vet_screen: "VS-1989 post-load verification: when true, a vet duplication- or truncation-screen flag fails verification and blocks Parquet deletion; when false (default) the screens only warn. Family completeness and ploidy cardinality always gate regardless."
+        parquet_expected_ploidy_rows_per_sample: "VS-1989 post-load verification: exact per-sample sample_chromosome_ploidy row count to validate against (e.g. 24 for WGS) instead of the inferred callset mode; leave unset to infer from the data (correct for exome/BGE/chrM)."
     }
 
     # The `call_set_identifier` string is used to name many different things throughout this workflow (BQ tables, vcfs etc).
@@ -167,6 +181,9 @@ workflow GvsJointVariantCalling {
             load_data_scatter_width = load_data_scatter_width,
             use_parquet_ingest = use_parquet_ingest,
             parquet_output_gcs_dir = parquet_output_gcs_dir,
+            parquet_vet_duplication_threshold = parquet_vet_duplication_threshold,
+            parquet_strict_vet_screen = parquet_strict_vet_screen,
+            parquet_expected_ploidy_rows_per_sample = parquet_expected_ploidy_rows_per_sample,
     }
 
     call PopulateAltAllele.GvsPopulateAltAllele {

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -131,7 +131,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-08-27-alpine-cd7979a04011"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-08-31-alpine-d4cf59ce1010"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -58,7 +58,7 @@ task GetToolVersions {
   }
 
   File monitoring_script = "gs://gvs_quickstart_storage/cromwell_monitoring_script.sh"
-  String cloud_sdk_docker_decl = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-alpine"
+  String cloud_sdk_docker_decl = "gcr.io/google.com/cloudsdktool/cloud-sdk:582.0.0-alpine"
 
   # For GVS releases, set `version` to match the release branch name, e.g. gvs_<major>.<minor>.<patch>.
   # For non-release, leave the value at "unspecified".
@@ -130,7 +130,7 @@ task GetToolVersions {
     String cloud_sdk_docker = cloud_sdk_docker_decl #   Defined above as a declaration.
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
-    String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
+    String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:582.0.0-slim"
     String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-08-31-alpine-d4cf59ce1010"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -131,7 +131,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-08-19-alpine-35878b6b6eca"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-08-27-alpine-cd7979a04011"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -146,7 +146,7 @@ task GetToolVersions {
     # Must stay in lockstep with `cloud_sdk_docker_decl` above -- 565.0.0 is the last tag whose `-slim`
     # sibling is Debian 12 / Python 3.11. See the note there before bumping.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-10-alpine-b8be4e9eeb1e"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-10-alpine-67944a2e4757"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -146,7 +146,7 @@ task GetToolVersions {
     # Must stay in lockstep with `cloud_sdk_docker_decl` above -- 565.0.0 is the last tag whose `-slim`
     # sibling is Debian 12 / Python 3.11. See the note there before bumping.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-10-alpine-67944a2e4757"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-10-alpine-cc40255fd476"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -146,7 +146,7 @@ task GetToolVersions {
     # Must stay in lockstep with `cloud_sdk_docker_decl` above -- 565.0.0 is the last tag whose `-slim`
     # sibling is Debian 12 / Python 3.11. See the note there before bumping.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-11-alpine-00b34eed918c"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-11-alpine-8d77abb1be9f"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -146,7 +146,7 @@ task GetToolVersions {
     # Must stay in lockstep with `cloud_sdk_docker_decl` above -- 565.0.0 is the last tag whose `-slim`
     # sibling is Debian 12 / Python 3.11. See the note there before bumping.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-10-alpine-cc40255fd476"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-10-alpine-c6a66ed44493"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -146,7 +146,7 @@ task GetToolVersions {
     # Must stay in lockstep with `cloud_sdk_docker_decl` above -- 565.0.0 is the last tag whose `-slim`
     # sibling is Debian 12 / Python 3.11. See the note there before bumping.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-11-alpine-8d77abb1be9f"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-11-alpine-592462cc3693"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -146,7 +146,7 @@ task GetToolVersions {
     # Must stay in lockstep with `cloud_sdk_docker_decl` above -- 565.0.0 is the last tag whose `-slim`
     # sibling is Debian 12 / Python 3.11. See the note there before bumping.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-10-alpine-c6a66ed44493"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-11-alpine-00b34eed918c"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -146,7 +146,7 @@ task GetToolVersions {
     # Must stay in lockstep with `cloud_sdk_docker_decl` above -- 565.0.0 is the last tag whose `-slim`
     # sibling is Debian 12 / Python 3.11. See the note there before bumping.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-11-alpine-a70267b35b5e"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-11-alpine-a530bdac1d86"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -146,7 +146,7 @@ task GetToolVersions {
     # Must stay in lockstep with `cloud_sdk_docker_decl` above -- 565.0.0 is the last tag whose `-slim`
     # sibling is Debian 12 / Python 3.11. See the note there before bumping.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-11-alpine-592462cc3693"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-11-alpine-a70267b35b5e"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"

--- a/scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
+++ b/scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
@@ -38,12 +38,12 @@ workflow GvsQuickstartIntegration {
         Boolean use_parquet_ingest = true
         # VS-1989 independent post-load structural checks, forwarded to every Parquet-ingest sub-workflow
         # (the VCF VETS/VQSR/exome/BGE calls and the Beta GvsJointVariantCalling call) so an integration
-        # run can exercise them; e.g. set parquet_strict_vet_screen = true to gate on the screens. Leave
-        # parquet_expected_ploidy_rows_per_sample unset unless every cohort in the run shares that exact
-        # per-sample row count -- the exome/BGE cohorts do not match the WGS value, so a top-level override
-        # would misfit them.
+        # run can exercise them; e.g. set parquet_allow_flagged_vet_loads = true to waive the screens and
+        # let deletion proceed despite a flag. Leave parquet_expected_ploidy_rows_per_sample unset unless
+        # every cohort in the run shares that exact per-sample row count -- the exome/BGE cohorts do not
+        # match the WGS value, so a top-level override would misfit them.
         Float parquet_vet_duplication_threshold = 1.6
-        Boolean parquet_strict_vet_screen = false
+        Boolean parquet_allow_flagged_vet_loads = false
         Int? parquet_expected_ploidy_rows_per_sample
         # DRAGEN version asserted by the header-validation check. Left unset, the BGE call defaults to
         # the triplet its samples carry ("3.7.8") and the other header-checked calls run consistency-
@@ -191,7 +191,7 @@ workflow GvsQuickstartIntegration {
                 maximum_alternate_alleles = maximum_alternate_alleles,
                 use_parquet_ingest = use_parquet_ingest,
                 parquet_vet_duplication_threshold = parquet_vet_duplication_threshold,
-                parquet_strict_vet_screen = parquet_strict_vet_screen,
+                parquet_allow_flagged_vet_loads = parquet_allow_flagged_vet_loads,
                 parquet_expected_ploidy_rows_per_sample = parquet_expected_ploidy_rows_per_sample,
         }
         call QuickstartVcfIntegration.GvsQuickstartVcfIntegration as QuickstartVcfVQSRIntegration {
@@ -222,7 +222,7 @@ workflow GvsQuickstartIntegration {
                 maximum_alternate_alleles = maximum_alternate_alleles,
                 use_parquet_ingest = use_parquet_ingest,
                 parquet_vet_duplication_threshold = parquet_vet_duplication_threshold,
-                parquet_strict_vet_screen = parquet_strict_vet_screen,
+                parquet_allow_flagged_vet_loads = parquet_allow_flagged_vet_loads,
                 parquet_expected_ploidy_rows_per_sample = parquet_expected_ploidy_rows_per_sample,
         }
 
@@ -277,7 +277,7 @@ workflow GvsQuickstartIntegration {
                 target_interval_list = target_interval_list,
                 use_parquet_ingest = use_parquet_ingest,
                 parquet_vet_duplication_threshold = parquet_vet_duplication_threshold,
-                parquet_strict_vet_screen = parquet_strict_vet_screen,
+                parquet_allow_flagged_vet_loads = parquet_allow_flagged_vet_loads,
                 parquet_expected_ploidy_rows_per_sample = parquet_expected_ploidy_rows_per_sample,
         }
 
@@ -326,7 +326,7 @@ workflow GvsQuickstartIntegration {
                 target_interval_list = target_interval_list,
                 use_parquet_ingest = use_parquet_ingest,
                 parquet_vet_duplication_threshold = parquet_vet_duplication_threshold,
-                parquet_strict_vet_screen = parquet_strict_vet_screen,
+                parquet_allow_flagged_vet_loads = parquet_allow_flagged_vet_loads,
                 parquet_expected_ploidy_rows_per_sample = parquet_expected_ploidy_rows_per_sample,
         }
 
@@ -382,7 +382,7 @@ workflow GvsQuickstartIntegration {
                 use_parquet_ingest = use_parquet_ingest,
                 parquet_output_gcs_dir = parquet_output_gcs_dir,
                 parquet_vet_duplication_threshold = parquet_vet_duplication_threshold,
-                parquet_strict_vet_screen = parquet_strict_vet_screen,
+                parquet_allow_flagged_vet_loads = parquet_allow_flagged_vet_loads,
                 parquet_expected_ploidy_rows_per_sample = parquet_expected_ploidy_rows_per_sample,
         }
 

--- a/scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
+++ b/scripts/variantstore/wdl/test/GvsQuickstartIntegration.wdl
@@ -36,6 +36,15 @@ workflow GvsQuickstartIntegration {
         Int? maximum_alternate_alleles
         File? gatk_override
         Boolean use_parquet_ingest = true
+        # VS-1989 independent post-load structural checks, forwarded to every Parquet-ingest sub-workflow
+        # (the VCF VETS/VQSR/exome/BGE calls and the Beta GvsJointVariantCalling call) so an integration
+        # run can exercise them; e.g. set parquet_strict_vet_screen = true to gate on the screens. Leave
+        # parquet_expected_ploidy_rows_per_sample unset unless every cohort in the run shares that exact
+        # per-sample row count -- the exome/BGE cohorts do not match the WGS value, so a top-level override
+        # would misfit them.
+        Float parquet_vet_duplication_threshold = 1.6
+        Boolean parquet_strict_vet_screen = false
+        Int? parquet_expected_ploidy_rows_per_sample
         # DRAGEN version asserted by the header-validation check. Left unset, the BGE call defaults to
         # the triplet its samples carry ("3.7.8") and the other header-checked calls run consistency-
         # only. When set, this value flows to BOTH the VETS/Hail (WGS) call and the BGE call. The WGS
@@ -181,6 +190,9 @@ workflow GvsQuickstartIntegration {
                 submission_id = submission_id,
                 maximum_alternate_alleles = maximum_alternate_alleles,
                 use_parquet_ingest = use_parquet_ingest,
+                parquet_vet_duplication_threshold = parquet_vet_duplication_threshold,
+                parquet_strict_vet_screen = parquet_strict_vet_screen,
+                parquet_expected_ploidy_rows_per_sample = parquet_expected_ploidy_rows_per_sample,
         }
         call QuickstartVcfIntegration.GvsQuickstartVcfIntegration as QuickstartVcfVQSRIntegration {
             input:
@@ -209,6 +221,9 @@ workflow GvsQuickstartIntegration {
                 submission_id = submission_id,
                 maximum_alternate_alleles = maximum_alternate_alleles,
                 use_parquet_ingest = use_parquet_ingest,
+                parquet_vet_duplication_threshold = parquet_vet_duplication_threshold,
+                parquet_strict_vet_screen = parquet_strict_vet_screen,
+                parquet_expected_ploidy_rows_per_sample = parquet_expected_ploidy_rows_per_sample,
         }
 
         if (QuickstartVcfVQSRIntegration.used_tighter_gcp_quotas) {
@@ -261,6 +276,9 @@ workflow GvsQuickstartIntegration {
                 maximum_alternate_alleles = maximum_alternate_alleles,
                 target_interval_list = target_interval_list,
                 use_parquet_ingest = use_parquet_ingest,
+                parquet_vet_duplication_threshold = parquet_vet_duplication_threshold,
+                parquet_strict_vet_screen = parquet_strict_vet_screen,
+                parquet_expected_ploidy_rows_per_sample = parquet_expected_ploidy_rows_per_sample,
         }
 
         if (QuickstartVcfExomeIntegration.used_tighter_gcp_quotas) {
@@ -307,6 +325,9 @@ workflow GvsQuickstartIntegration {
                 maximum_alternate_alleles = maximum_alternate_alleles,
                 target_interval_list = target_interval_list,
                 use_parquet_ingest = use_parquet_ingest,
+                parquet_vet_duplication_threshold = parquet_vet_duplication_threshold,
+                parquet_strict_vet_screen = parquet_strict_vet_screen,
+                parquet_expected_ploidy_rows_per_sample = parquet_expected_ploidy_rows_per_sample,
         }
 
         if (QuickstartVcfBgeIntegration.used_tighter_gcp_quotas) {
@@ -360,6 +381,9 @@ workflow GvsQuickstartIntegration {
                 collect_variant_calling_metrics = collect_variant_calling_metrics,
                 use_parquet_ingest = use_parquet_ingest,
                 parquet_output_gcs_dir = parquet_output_gcs_dir,
+                parquet_vet_duplication_threshold = parquet_vet_duplication_threshold,
+                parquet_strict_vet_screen = parquet_strict_vet_screen,
+                parquet_expected_ploidy_rows_per_sample = parquet_expected_ploidy_rows_per_sample,
         }
 
         if (!QuickstartBeta.used_tighter_gcp_quotas) {

--- a/scripts/variantstore/wdl/test/GvsQuickstartVcfIntegration.wdl
+++ b/scripts/variantstore/wdl/test/GvsQuickstartVcfIntegration.wdl
@@ -22,6 +22,11 @@ workflow GvsQuickstartVcfIntegration {
         # (its samples predate DRAGEN, so the DRAGEN check is informational there).
         String? expected_dragen_version
         Boolean use_parquet_ingest = true
+        # VS-1989 independent post-load structural checks, forwarded through GvsJointVariantCalling so an
+        # integration run can exercise them (e.g. set parquet_strict_vet_screen = true to gate on the screens).
+        Float parquet_vet_duplication_threshold = 1.6
+        Boolean parquet_strict_vet_screen = false
+        Int? parquet_expected_ploidy_rows_per_sample
         String drop_state = "FORTY"
         Boolean bgzip_output_vcfs = false
         String dataset_suffix
@@ -136,6 +141,9 @@ workflow GvsQuickstartVcfIntegration {
             extract_output_gcs_dir = extract_output_gcs_dir,
             use_parquet_ingest = use_parquet_ingest,
             parquet_output_gcs_dir = parquet_output_gcs_dir,
+            parquet_vet_duplication_threshold = parquet_vet_duplication_threshold,
+            parquet_strict_vet_screen = parquet_strict_vet_screen,
+            parquet_expected_ploidy_rows_per_sample = parquet_expected_ploidy_rows_per_sample,
     }
 
     # VS-1966: if headers were loaded, validate them end to end and fail the test if validation fails.

--- a/scripts/variantstore/wdl/test/GvsQuickstartVcfIntegration.wdl
+++ b/scripts/variantstore/wdl/test/GvsQuickstartVcfIntegration.wdl
@@ -23,9 +23,10 @@ workflow GvsQuickstartVcfIntegration {
         String? expected_dragen_version
         Boolean use_parquet_ingest = true
         # VS-1989 independent post-load structural checks, forwarded through GvsJointVariantCalling so an
-        # integration run can exercise them (e.g. set parquet_strict_vet_screen = true to gate on the screens).
+        # integration run can exercise them (e.g. set parquet_allow_flagged_vet_loads = true to waive the
+        # screens and let deletion proceed despite a flag).
         Float parquet_vet_duplication_threshold = 1.6
-        Boolean parquet_strict_vet_screen = false
+        Boolean parquet_allow_flagged_vet_loads = false
         Int? parquet_expected_ploidy_rows_per_sample
         String drop_state = "FORTY"
         Boolean bgzip_output_vcfs = false
@@ -142,7 +143,7 @@ workflow GvsQuickstartVcfIntegration {
             use_parquet_ingest = use_parquet_ingest,
             parquet_output_gcs_dir = parquet_output_gcs_dir,
             parquet_vet_duplication_threshold = parquet_vet_duplication_threshold,
-            parquet_strict_vet_screen = parquet_strict_vet_screen,
+            parquet_allow_flagged_vet_loads = parquet_allow_flagged_vet_loads,
             parquet_expected_ploidy_rows_per_sample = parquet_expected_ploidy_rows_per_sample,
     }
 


### PR DESCRIPTION
##  [VS-1989](https://broadworkbench.atlassian.net/browse/VS-1989): Parquet-ingest verification that is independent from the loader
[Integration Run](https://app.terra.bio/#workspaces/gp-dsp-gvs-operations-terra/GVS%20Integration%20-%20Nalini/submission_history/165b77a6-4087-498d-a499-0b0741bc396c)

## Summary

In the Parquet ingest path, `DiscoverParquetFiles` (which decides what to load) and `VerifyParquetLoading` (which decides whether it's safe to delete the source Parquet) both call the same predicate, `get_already_loaded_tables_and_sample_ids`. That predicate answers exactly one question — "does this `(table, sample_id)` partition have `total_logical_bytes > 0`?" — so a verifier built on it can never contradict the loader: by construction it agrees. It is therefore blind to the two failure classes that matter most before an irreversible delete: a **partial/lost load** (partition present with bytes, but fewer rows than the source) and a **duplicated load** (partition present with *more* rows than the source). This is load-bearing because `all_loaded` gates `DeleteParquetFiles` (`GvsImportGenomes.wdl`).

This PR adds a second, independent verification layer that asks a different question — "how many rows?" — sharing no code with the loader predicate, and makes `all_loaded` depend on it.

## What changed

**New — `scripts/variantstore/scripts/verify_structural_checks.py`.** Row-count-based checks over two cheap BigQuery metadata reads that the loader predicate never consults:
- **Family completeness** — reads `INFORMATION_SCHEMA.PARTITIONS.total_rows` over the `vet_%` / `ref_ranges_%` families (flat ~10 MB regardless of callset size; `partition_id` *is* the `sample_id`, since these tables are integer-range partitioned on `sample_id` with step 1), deliberately *without* the `total_logical_bytes > 0` filter so a present-but-empty partition surfaces as the partial-load signal it is. Catches a sample missing variant or reference data entirely.
- **Cross-family consistency** — cross-checks the co-produced data families' expected-sample sets against each other. Family completeness derives each family's expected set from that family's *own* GCS output files, so a sample whose file was never produced for one family is simply not "expected" there and its absence passes vacuously — while its files in the other families load and verify cleanly. Because every sample on the Parquet path produces a vet, a ref_ranges *and* a ploidy file together (all three creators are constructed unconditionally per sample in `CreateVariantIngestFiles`, and a zero-row file is still written on close), these families' sample sets must be identical within a run. The check ranges over that co-produced group (vet / ref_ranges / ploidy) rather than over every configured prefix, so it catches two gaps a per-family view misses: a sample present in some members but absent from another, *and* an entirely absent member (compared as an empty set rather than silently dropped — e.g. no `vet` files produced at all while `ref_ranges`/`ploidy` are complete). Both are partial uploads, caught from the GCS listing alone with no external sample source. The check is **presence-activated**: it fires only when at least one group member has files this run, so a supported headers-only ingest — which produces only `vcf_header_lines_scratch` (deliberately not a group member) while the data prefixes are configured but land nothing — stays dormant and passes, rather than reporting every header sample missing from all three data families. This is exact, so it gates `all_loaded` alongside completeness and cardinality.
- **Cardinality** — per-sample COUNT(*) and COUNT(DISTINCT chromosome) on the ploidy table. In mode-inferred mode (the default), verifies COUNT(*) == COUNT(DISTINCT chromosome) to catch chromosome duplication exactly, applies a contig floor (n ≥ mode - 2) to reject partial loads missing autosomes (e.g. 20 vs 24) while permitting legitimate karyotype variations (23 for females lacking chrY, 25 with chrM), checks a 1.5 × duplication ceiling, and breaks mode ties deterministically. When an explicit --expected-ploidy-rows-per-sample is set (e.g. 24 for WGS), exact matching is strictly enforced.
- **Optional exact-cardinality override** — `--expected-ploidy-rows-per-sample` (e.g. 24 for WGS) pins the ploidy reference to a constant instead of the inferred mode. This closes the one blind spot mode-based detection has: if a *majority* of samples share the *wrong* count, that wrong count becomes the mode and the correct minority gets flagged instead. It's unset by default because the "right" count is emergent (25 with chrM, fewer on exome/BGE), and the observed mode is always reported alongside so an override that disagrees with reality is visible rather than silently trusted.
- **vet duplication screen** — flags any vet sample whose row count is ≥ a ratio (default 1.6×) of the callset baseline (median for N ≥ 3; lower count for N = 2). Singletons (N = 1) are flagged conservatively by default since no cohort baseline exists.
- **vet truncation screen** — the low-side mirror: flags any present, non-empty vet sample whose row count is ≤ the baseline divided by that ratio (median for N ≥ 3; upper count for N = 2). This is the cheap stand-in for a per-row source comparison (see Design decisions).

**Modified — `verify_all_loaded.py`.** Splits the verdict into two distinct predicates, both pure and directly unit-tested. `all_loaded` is the **factual** "is the load complete?" signal: nothing missing/unmatched, plus the exact structural checks (family completeness, ploidy cardinality, cross-family consistency) via `compute_structural_checks_ok` — the vet screens deliberately do not enter it. `safe_to_delete_parquet` (`compute_safe_to_delete_parquet`) is the **deletion gate**: `all_loaded` AND no vet duplication/truncation-screen flag, unless the screens are waived with `--allow-flagged-vet-loads`. The consequence is that a flagged-but-complete load now *succeeds* (`all_loaded` true, so the task exits zero) and simply retains its Parquet (`safe_to_delete_parquet` false), rather than failing the import. The pre-existing check it keeps — GCS paths that do not parse into a `(table, sample_id)` pair at all, genuinely independent of the shared predicate — still fails `all_loaded` via `unmatched_files`. The results JSON carries the full verdict — `all_loaded`, `safe_to_delete_parquet`, the file counts, the flat structural booleans (`structural_checks_ok`, `family_completeness_ok`, `ploidy_cardinality_ok`, `cross_family_consistency_ok`, `vet_duplication_flagged`, `vet_truncation_flagged`), and a nested `structural_checks` detail block — with per-sample lists bounded so a large-callset failure cannot bloat the file the WDL re-parses.

**Modified — `GvsImportGenomes.wdl`.** New workflow inputs `parquet_vet_duplication_threshold` (default 1.6) and `parquet_allow_flagged_vet_loads` (default false), threaded through `VerifyParquetLoading`. `DeleteParquetFiles` is now conditioned on `safe_to_delete_parquet` rather than `all_loaded`, so a vet-screen flag blocks the irreversible delete by default while the load still succeeds. Verification is **fail-loud** on the factual signal: `verify_all_loaded.py` exits non-zero whenever `all_loaded` is false, so the task fails and the workflow aborts before any Parquet is deleted. Because Cromwell does not delocalize a failed task's outputs, the command captures the verification exit code, copies `verification_results.json` to an optional durable diagnostics path (`verification_diagnostics_gcs_dir`, with `billing_project_id` for requester-pays), and then re-raises — so the full verdict survives the abort. Published outputs are `all_loaded`, `safe_to_delete_parquet`, the file counts, and both screen flags (`vet_duplication_flagged`, `vet_truncation_flagged`); the family-completeness / ploidy-cardinality components are intentionally *not* published as outputs (see Design decisions).

## Design decisions

The "24 rows per sample" for ploidy is **emergent, not a constant** — it's the count of distinct non-PAR contigs, which chrM ingest or exome/BGE callsets change. The checks validate each sample against the callset **mode** rather than hardcoding 24. Because a sample's ploidy rows are committed in the same block as its reference data (samplePloidyCreator alongside refRangesCreator), the ploidy cardinality check doubles as the only per-sample duplication signal available for the *reference* side — a doubled ref_ranges sample shows up as doubled ploidy rows — subject to the backfill caveat in Follow-ups.

**Two predicates: `all_loaded` (factual) and `safe_to_delete_parquet` (deletion gate).** The verdict is deliberately split along the line between "is the load complete?" and "is it safe to delete the source?". The exact checks — the shared-predicate presence check, family completeness, and ploidy cardinality — gate `all_loaded`, which is factual and is what fail-loud aborts on; a heuristic screen flag does not make a complete load incomplete, so the screens are kept out of it. Deletion is instead gated on `safe_to_delete_parquet` = `all_loaded` AND no unwaived vet-screen flag. **A screen flag blocks deletion by default.** This is the safe direction for an irreversible operation: a screen false positive here only over-retains Parquet (cheap and reversible), whereas trusting a flagged load and deleting its source is not — the same asymmetry the earlier warn-only default had backwards. Waiving the screens is therefore an opt-out, `--allow-flagged-vet-loads` (`parquet_allow_flagged_vet_loads`), so the default deletes nothing a screen objected to. A CLI `store_true` flag defaults false, so making the *safe* behavior the default required inverting the sense of the previous `--strict-vet-screen` flag rather than merely flipping its default.

**Which outputs are published, and why.** `all_loaded` and `safe_to_delete_parquet` are both published, as are both screen flags — all four are meaningful on a task that *succeeds* (a flagged-but-complete load succeeds, and the flags explain why `safe_to_delete_parquet` is false while `all_loaded` is true). The family-completeness and ploidy-cardinality components are *not* published: they can only fail `all_loaded`, which exits the task non-zero, and Cromwell then never evaluates its outputs — so those booleans could only ever be observed as `true`, which is misleading. The complete verdict lives in `verification_results.json`, copied to the durable diagnostics path on failure.

**The exact footer-vs-BigQuery per-sample comparison (the gold-standard detector named in the ticket description) is intentionally deferred, and would add little.** It needs a heavy new image dependency (pyarrow, not in the Variants image) and a footer read per file, prohibitive at AoU scale. It would also catch almost nothing the checks here miss: a partial *load* cannot occur, because BigQuery load jobs are atomic (`load_parquet_to_bq.py` loads each batch with `WRITE_APPEND`, and a failed job commits nothing), so a present partition is either complete, empty (caught by completeness), or duplicated (caught by the duplication screen). The one residual truncation source is a Parquet file generated upstream with too few rows — and there the footer count and the BigQuery count agree, so footer-vs-BigQuery would pass it too. That case is instead surfaced cheaply by the truncation screen; catching it exactly would need a gVCF-level variant count, which is out of scope. A present-but-truncated vet partition therefore **blocks Parquet deletion by default** (`safe_to_delete_parquet` false) while the load itself still succeeds; the block is waived under `--allow-flagged-vet-loads`.

`ref_ranges` is **left unscreened for duplication and truncation by design** — its row count tracks GQ-band transitions, not genome length, so legitimate samples reach many times the median (on Foxtrot a 1.6× screen flagged 38,629 of 540,545 ref_ranges samples, versus 2 for vet) and no cheap per-sample outlier signal exists. Two exact alternatives were considered and are recorded so they are not re-attempted: a per-sample `COUNT(*)` vs `COUNT(DISTINCT packed_ref_data)` (the only detector that actually works for reference-side duplication, but a full per-sample scan rather than a metadata read, so out of scope here); and comparing a sample's row count against its counterpart in the parent callset (rejected outright — a child callset is seeded by copying its parent, so a pre-existing parent-side defect copies forward identically and reads as agreement, never as the disagreement a detector needs). The gap and both alternatives are recorded in the verifier output rather than papered over.

## Follow-ups / needs a decision

**Family-completeness independence has a residual GCS-sourced boundary ([VS-2016](https://broadworkbench.atlassian.net/browse/VS-2016)).** The per-family expected-sample set is derived from the same GCS file listing the loader scatters over. The *cross-family* cases — a sample present in some families' listing but absent from another's, and an entirely absent co-produced family — are now closed by the cross-family consistency check above, entirely from the listing (the co-produced group is known statically). What remains is the *whole-sample* case: a sample for which Parquet generation never produced output for *any* family was never in the listing at all, so it is in no family's expected set and no cross-family union, and stays invisible to every check here — as opposed to a sample whose files were produced but never loaded, which the checks do catch. Unlike a whole family, whose identity is known from the co-produced group, a never-produced sample's identity is unknowable without a non-GCS source: this run's input sample set (the ingest FOFN). Note `sample_info` cannot serve this wholesale — it accumulates every sample ever ingested, including ones since withdrawn or deleted, so a bulk comparison would false-positive samples legitimately absent from this run; the expected set has to be scoped to the run's FOFN. This is out of scope here and tracked in VS-2016, referenced from the code comment at `verify_all_loaded.py`.

**Ploidy-duplication provenance (team input wanted).** The ploidy duplication reading holds only where a sample's ploidy rows were written at ingest; a later backfill writes a full per-sample set regardless, masking a doubled sample. Backfill provenance is not captured today, so a green ploidy result must not be read as a duplication guarantee for backfilled sample ranges. This is surfaced in the verifier output/logs (`PLOIDY_BACKFILL_CAVEAT`) but the underlying provenance gap — recording which callsets and sample ranges had ingest-time ploidy writes — is a broader question for the team.

## Testing

- `test/test_verify_structural_checks.py` (79 tests) — the pure assessment functions (completeness, cross-family consistency, cardinality + override, duplication and truncation screens) plus SQL-shape assertions on the two BigQuery reads, including an explicit check that the partition query reads `total_rows` and does **not** filter on `total_logical_bytes` (the independence property). Includes the regression for a nonzero-but-truncated partition passing the exact checks while the truncation screen flags it, the per-sample cross-family gap (present in vet/ploidy but absent from ref_ranges) passing family completeness vacuously while the cross-family check fails it, the entirely-absent-member case (no vet files at all, ref_ranges/ploidy complete) likewise failing only cross-family, and a headers-only run with real `vcf_header_lines_scratch` samples (and the data prefixes configured but empty) passing because the presence-activated cross-family check stays dormant.
- `test/test_verify_all_loaded.py` (34 tests) — composition and the three extracted gate helpers: exact-check failures — including a cross-family gap — block `all_loaded` even when the shared-predicate presence check is fully satisfied; the shared predicate still gates independently; a vet-screen flag leaves `all_loaded` true but drops `safe_to_delete_parquet` by default and is waived under `allow_flagged_vet_loads`; the fail-loud operator message names only exact-check causes (never a screen flag); the results-JSON detail lists are bounded; new and legacy JSON keys present.
- `test/test_parquet_loading.py` (65 tests) — unchanged by this PR, continues to pass.
- `womtool validate GvsImportGenomes.wdl` — Success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[VS-1989]: https://broadworkbench.atlassian.net/browse/VS-1989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[VS-2016]: https://broadworkbench.atlassian.net/browse/VS-2016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ