### PR TITLE
Bump cloud-sdk base image, 524.0.0 no longer exists [VS-2002]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -350,6 +350,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - vs_2002_update_variants_images
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/scripts/Dockerfile
+++ b/scripts/variantstore/scripts/Dockerfile
@@ -32,7 +32,7 @@ RUN mkdir /fiss-build && \
     python setup.py install
 
 # The main layer does not install development tools, instead copies artifacts from the build layer above.
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-alpine AS main
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:582.0.0-alpine AS main
 
 RUN apk update && apk upgrade
 

--- a/scripts/variantstore/scripts/Dockerfile
+++ b/scripts/variantstore/scripts/Dockerfile
@@ -12,7 +12,7 @@
 # built here and copied into `main` via `COPY --from=build /localvenv /localvenv` gets a dangling `python3` symlink,
 # so `python3` in `main` silently falls back to the bare system interpreter with none of the pip-installed packages.
 # Bumping either FROM requires rebuilding build_base.Dockerfile, pushing a new tag, and updating both lines together.
-FROM us.gcr.io/broad-dsde-methods/variantstore:2026-06-23-alpine-build-base AS build
+FROM us.gcr.io/broad-dsde-methods/variantstore:2026-09-01-alpine-build-base AS build
 
 # Install all of our variantstore Python requirements.
 # We constrain the version of setuptools to sidestep an issue in `terra-notebook-util`'s FISS dependency.

--- a/scripts/variantstore/scripts/Dockerfile
+++ b/scripts/variantstore/scripts/Dockerfile
@@ -6,6 +6,12 @@
 # expensive to create and isn't expected to change often, while the steps in this Dockerfile are much less expensive and
 # more likely to change. Using a build-base image essentially allows the expensive layers to be globally cached which
 # should make building the final image much faster in most cases.
+#
+# IMPORTANT: this tag is built and pushed separately by build_build_base_docker.sh from build_base.Dockerfile, and
+# must be on the same Google Cloud SDK / Python version as the `main` stage's FROM below. If they diverge, the venv
+# built here and copied into `main` via `COPY --from=build /localvenv /localvenv` gets a dangling `python3` symlink,
+# so `python3` in `main` silently falls back to the bare system interpreter with none of the pip-installed packages.
+# Bumping either FROM requires rebuilding build_base.Dockerfile, pushing a new tag, and updating both lines together.
 FROM us.gcr.io/broad-dsde-methods/variantstore:2026-06-23-alpine-build-base AS build
 
 # Install all of our variantstore Python requirements.
@@ -32,6 +38,7 @@ RUN mkdir /fiss-build && \
     python setup.py install
 
 # The main layer does not install development tools, instead copies artifacts from the build layer above.
+# IMPORTANT: must stay on the same Python version as the `build` stage's FROM above -- see the note there.
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:582.0.0-alpine AS main
 
 RUN apk update && apk upgrade

--- a/scripts/variantstore/scripts/build_base.Dockerfile
+++ b/scripts/variantstore/scripts/build_base.Dockerfile
@@ -10,6 +10,13 @@
 #
 # Note: pyarrow was previously built from source here because Alpine's musl libc was incompatible with PyPI's
 # manylinux wheels. It has since been removed from the image entirely as no production code requires it.
+#
+# IMPORTANT: bumping the tag below only changes what this Dockerfile produces; it has no effect until the resulting
+# image is rebuilt and pushed via `build_build_base_docker.sh` and the new tag is wired into Dockerfile's `build`
+# stage FROM line. Until that happens, Dockerfile's `build` and `main` stages are on different Python versions, which
+# silently breaks the venv copied from `build` into `main` (its `python3` symlink dangles, so `python3` falls back to
+# the bare system interpreter with none of the pip-installed packages -- e.g. `ModuleNotFoundError: No module named
+# 'google'`). Keep the version here and in Dockerfile's `build` stage FROM in lockstep.
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:582.0.0-alpine
 
 RUN apk update && apk upgrade

--- a/scripts/variantstore/scripts/build_base.Dockerfile
+++ b/scripts/variantstore/scripts/build_base.Dockerfile
@@ -10,7 +10,7 @@
 #
 # Note: pyarrow was previously built from source here because Alpine's musl libc was incompatible with PyPI's
 # manylinux wheels. It has since been removed from the image entirely as no production code requires it.
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-alpine
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:582.0.0-alpine
 
 RUN apk update && apk upgrade
 

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -58,7 +58,7 @@ task GetToolVersions {
   }
 
   File monitoring_script = "gs://gvs_quickstart_storage/cromwell_monitoring_script.sh"
-  String cloud_sdk_docker_decl = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-alpine"
+  String cloud_sdk_docker_decl = "gcr.io/google.com/cloudsdktool/cloud-sdk:582.0.0-alpine"
 
   # For GVS releases, set `version` to match the release branch name, e.g. gvs_<major>.<minor>.<patch>.
   # For non-release, leave the value at "unspecified".
@@ -130,7 +130,7 @@ task GetToolVersions {
     String cloud_sdk_docker = cloud_sdk_docker_decl #   Defined above as a declaration.
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
-    String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
+    String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:582.0.0-slim"
     String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-08-19-alpine-35878b6b6eca"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -58,6 +58,11 @@ task GetToolVersions {
   }
 
   File monitoring_script = "gs://gvs_quickstart_storage/cromwell_monitoring_script.sh"
+  # Bumping this version does not touch the Variants image (see `variants_docker` below): that image's build-base
+  # stage is a separately built and pinned image (scripts/variantstore/scripts/build_base.Dockerfile, built via
+  # build_build_base_docker.sh) that must be rebuilt and re-pinned in lockstep, or its Python version drifts from
+  # this one and the Variants image's venv silently breaks at runtime. See the notes in build_base.Dockerfile and
+  # Dockerfile for details.
   String cloud_sdk_docker_decl = "gcr.io/google.com/cloudsdktool/cloud-sdk:582.0.0-alpine"
 
   # For GVS releases, set `version` to match the release branch name, e.g. gvs_<major>.<minor>.<patch>.
@@ -131,6 +136,9 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:582.0.0-slim"
+    # This has no effect until the image is rebuilt (build_docker.sh) and this tag is updated to match -- see the
+    # "Variants Docker Image" section of the top-level CLAUDE.md. Editing the image's Dockerfiles (including the
+    # cloud_sdk_docker_decl-equivalent base image tags above) has no runtime effect until that rebuild happens either.
     String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-08-24-alpine-2992179e6bf4"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -139,7 +139,7 @@ task GetToolVersions {
     # This has no effect until the image is rebuilt (build_docker.sh) and this tag is updated to match -- see the
     # "Variants Docker Image" section of the top-level CLAUDE.md. Editing the image's Dockerfiles (including the
     # cloud_sdk_docker_decl-equivalent base image tags above) has no runtime effect until that rebuild happens either.
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-08-24-alpine-2992179e6bf4"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-01-alpine-df98d9b0a485"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"


### PR DESCRIPTION
[VS-2002](https://broadworkbench.atlassian.net/browse/VS-2002): bump cloud-sdk base image, 524.0.0 no longer exists
    
    gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-alpine/-slim have aged
    out of the registry, failing GetToolVersions' Docker lookup before any
    task runs. Bump to 582.0.0, confirmed present on gcr.io as of today.
    Also bump the same stale tag in Dockerfile and build_base.Dockerfile,
    which pin it as the Variants image's base and would otherwise fail the
    next `build_docker.sh` run.


[VS-2002]: https://broadworkbench.atlassian.net/browse/VS-2002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ