### PR TITLE
Rebuild Variants image and base image [VS-2002]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -350,6 +350,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - vs_2002_update_variants_images
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/scripts/Dockerfile
+++ b/scripts/variantstore/scripts/Dockerfile
@@ -6,7 +6,7 @@
 # expensive to create and isn't expected to change often, while the steps in this Dockerfile are much less expensive and
 # more likely to change. Using a build-base image essentially allows the expensive layers to be globally cached which
 # should make building the final image much faster in most cases.
-FROM us.gcr.io/broad-dsde-methods/variantstore:2026-06-23-alpine-build-base AS build
+FROM us.gcr.io/broad-dsde-methods/variantstore:2026-09-01-alpine-build-base AS build
 
 # Install all of our variantstore Python requirements.
 # We constrain the version of setuptools to sidestep an issue in `terra-notebook-util`'s FISS dependency.

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -131,7 +131,7 @@ task GetToolVersions {
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:582.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-08-24-alpine-2992179e6bf4"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-01-alpine-df98d9b0a485"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"


### PR DESCRIPTION
Actually rebuild these images with the very latest Google SDK image. Catastrophically failing integration test run [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration%20mcovarr/submission_history/dccb27fd-3f6a-43e1-8d54-6e503340b205).

VAT build failing with
```
$ pip3 install hail==0.2.134
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [20 lines of output]
      + /mnt/disks/cromwell_root/localvenv/bin/python3 /mnt/disks/cromwell_root/tmp.EeNPLb/pip-install-d79547wp/numpy_77d7168d9ec74c9f82322c15830e42e6/vendored-meson/meson/meson.py setup /mnt/disks/cromwell_root/tmp.EeNPLb/pip-install-d79547wp/numpy_77d7168d9ec74c9f82322c15830e42e6 /mnt/disks/cromwell_root/tmp.EeNPLb/pip-install-d79547wp/numpy_77d7168d9ec74c9f82322c15830e42e6/.mesonpy-2xxyod40 -Dbuildtype=release -Db_ndebug=if-release -Db_vscrt=md --native-file=/mnt/disks/cromwell_root/tmp.EeNPLb/pip-install-d79547wp/numpy_77d7168d9ec74c9f82322c15830e42e6/.mesonpy-2xxyod40/meson-python-native-file.ini
      The Meson build system
      Version: 1.2.99
      Source dir: /mnt/disks/cromwell_root/tmp.EeNPLb/pip-install-d79547wp/numpy_77d7168d9ec74c9f82322c15830e42e6
      Build dir: /mnt/disks/cromwell_root/tmp.EeNPLb/pip-install-d79547wp/numpy_77d7168d9ec74c9f82322c15830e42e6/.mesonpy-2xxyod40
      Build type: native build
      Project name: NumPy
      Project version: 1.26.4
      
      ../meson.build:1:0: ERROR: Unknown compiler(s): [['cc'], ['gcc'], ['clang'], ['nvc'], ['pgcc'], ['icc'], ['icx']]
      The following exception(s) were encountered:
      Running `cc --version` gave "[Errno 2] No such file or directory: 'cc'"
      Running `gcc --version` gave "[Errno 2] No such file or directory: 'gcc'"
      Running `clang --version` gave "[Errno 2] No such file or directory: 'clang'"
      Running `nvc --version` gave "[Errno 2] No such file or directory: 'nvc'"
      Running `pgcc --version` gave "[Errno 2] No such file or directory: 'pgcc'"
      Running `icc --version` gave "[Errno 2] No such file or directory: 'icc'"
      Running `icx --version` gave "[Errno 2] No such file or directory: 'icx'"
      
      A full log can be found at /mnt/disks/cromwell_root/tmp.EeNPLb/pip-install-d79547wp/numpy_77d7168d9ec74c9f82322c15830e42e6/.mesonpy-2xxyod40/meson-logs/meson-log.txt
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> numpy

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

Other branches failing with
```
$ python3 /app/get_columns_for_import.py --user_defined_sample_id sample_id --entity_set_name exome_integration_sample_set --user_defined_vcf hg38_reblocked_gvcf --user_defined_index hg38_reblocked_gvcf_index --entity_type sample --vcf_output vcf_files_column_name.txt --vcf_index_output vcf_index_files_column_name.txt
Traceback (most recent call last):
  File "/app/get_columns_for_import.py", line 360, in <module>
    entity_type = get_entity_data(args.entity_type, args.entity_set_name)
  File "/app/get_columns_for_import.py", line 46, in get_entity_data
    tables_list=list(table.list_tables())
  File "/localvenv/lib/python3.14/site-packages/terra_notebook_utils/table.py", line 205, in list_tables
    resp = fiss().list_entity_types(workspace_namespace, workspace)
           ~~~~^^
  File "/localvenv/lib/python3.14/site-packages/terra_notebook_utils/table.py", line 45, in fiss
    retry = Retry(total=10,
                  status_forcelist=[429, 500, 502, 503, 504],
                  method_whitelist=['GET', 'HEAD', 'DELETE', 'PATCH', 'PUT'])
TypeError: Retry.__init__() got an unexpected keyword argument 'method_whitelist'
```