### PR TITLE
[DRAFT] Pin Alpine's python3 to 3.12 instead of cloud-sdk's bundled python3.14 [VS-2004]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -351,6 +351,7 @@ workflows:
              - master
              - ah_var_store
              - vs_2002_update_variants_images
+             - ng_vs_2004_pin_python_3_12
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -173,7 +173,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - ng_vs_1966_explicit_header_checks
        tags:
          - /.*/
    - name: GvsMergeAndRescoreVDSes
@@ -228,7 +227,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - ng_vs_1966_explicit_header_checks
        tags:
          - /.*/
    - name: GvsPrepareRangesCallset
@@ -333,7 +331,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - ng_vs_1966_explicit_header_checks
          tags:
              - /.*/
    - name: GvsQuickstartHailIntegration
@@ -343,7 +340,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - ng_vs_1966_explicit_header_checks
          tags:
              - /.*/
    - name: GvsQuickstartIntegration
@@ -353,7 +349,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - ng_vs_1966_explicit_header_checks
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/scripts/Dockerfile
+++ b/scripts/variantstore/scripts/Dockerfile
@@ -6,7 +6,13 @@
 # expensive to create and isn't expected to change often, while the steps in this Dockerfile are much less expensive and
 # more likely to change. Using a build-base image essentially allows the expensive layers to be globally cached which
 # should make building the final image much faster in most cases.
-FROM us.gcr.io/broad-dsde-methods/variantstore:2026-09-02-alpine-build-base AS build
+#
+# IMPORTANT: this tag is built and pushed separately by build_build_base_docker.sh from build_base.Dockerfile, and
+# must be on the same Google Cloud SDK / Python version as the `main` stage's FROM below. If they diverge, the venv
+# built here and copied into `main` via `COPY --from=build /localvenv /localvenv` gets a dangling `python3` symlink,
+# so `python3` in `main` silently falls back to the bare system interpreter with none of the pip-installed packages.
+# Bumping either FROM requires rebuilding build_base.Dockerfile, pushing a new tag, and updating both lines together.
+FROM us.gcr.io/broad-dsde-methods/variantstore:2026-09-01-2-alpine-build-base AS build
 
 # Install all of our variantstore Python requirements.
 # We constrain the version of setuptools to sidestep an issue in `terra-notebook-util`'s FISS dependency.
@@ -41,12 +47,15 @@ RUN . /localvenv/bin/activate && \
 
 # The main layer does not install development tools, instead copies artifacts from the build layer above.
 # IMPORTANT: must stay on the same Python version as the `build` stage's FROM above -- see the note there.
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-alpine AS main
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:582.0.0-alpine AS main
 
 RUN apk update && apk upgrade
 
 # Add any generally useful Alpine packages here.
-RUN apk add --no-cache perl jq
+# `python3` (Alpine's own package, not this base image's bundled gcloud-internal interpreter -- see the note on the
+# `build` stage FROM above) must match what /localvenv was built against in the `build` stage, since the venv copied
+# in below is not self-contained and needs a matching /usr/bin/python3 and its shared libs present at the same path.
+RUN apk add --no-cache perl jq python3
 
 # The build stage generated Python artifacts to /root/.local via `pip install --user`, so grab all of those.
 COPY --from=build /localvenv /localvenv

--- a/scripts/variantstore/scripts/Dockerfile
+++ b/scripts/variantstore/scripts/Dockerfile
@@ -6,7 +6,7 @@
 # expensive to create and isn't expected to change often, while the steps in this Dockerfile are much less expensive and
 # more likely to change. Using a build-base image essentially allows the expensive layers to be globally cached which
 # should make building the final image much faster in most cases.
-FROM us.gcr.io/broad-dsde-methods/variantstore:2026-06-23-alpine-build-base AS build
+FROM us.gcr.io/broad-dsde-methods/variantstore:2026-09-02-alpine-build-base AS build
 
 # Install all of our variantstore Python requirements.
 # We constrain the version of setuptools to sidestep an issue in `terra-notebook-util`'s FISS dependency.
@@ -31,8 +31,17 @@ RUN mkdir /fiss-build && \
     . /localvenv/bin/activate && \
     python setup.py install
 
+# Patch `terra-notebook-utils` for a urllib3 2.x incompatibility.
+# A PR has been opened in `terra-notebook-utils` to fix this upstream, but until that lands we patch this here.
+# https://github.com/DataBiosphere/terra-notebook-utils/pull/426
+COPY terra_notebook_utils_urllib3.patch /terra_notebook_utils_urllib3.patch
+RUN . /localvenv/bin/activate && \
+    cd "$(python3 -c 'import terra_notebook_utils as m, pathlib; print(pathlib.Path(m.__file__).parent.parent)')" && \
+    git apply /terra_notebook_utils_urllib3.patch
+
 # The main layer does not install development tools, instead copies artifacts from the build layer above.
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-alpine AS main
+# IMPORTANT: must stay on the same Python version as the `build` stage's FROM above -- see the note there.
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-alpine AS main
 
 RUN apk update && apk upgrade
 

--- a/scripts/variantstore/scripts/Dockerfile
+++ b/scripts/variantstore/scripts/Dockerfile
@@ -12,7 +12,7 @@
 # built here and copied into `main` via `COPY --from=build /localvenv /localvenv` gets a dangling `python3` symlink,
 # so `python3` in `main` silently falls back to the bare system interpreter with none of the pip-installed packages.
 # Bumping either FROM requires rebuilding build_base.Dockerfile, pushing a new tag, and updating both lines together.
-FROM us.gcr.io/broad-dsde-methods/variantstore:2026-09-01-alpine-build-base AS build
+FROM us.gcr.io/broad-dsde-methods/variantstore:2026-09-01-2-alpine-build-base AS build
 
 # Install all of our variantstore Python requirements.
 # We constrain the version of setuptools to sidestep an issue in `terra-notebook-util`'s FISS dependency.

--- a/scripts/variantstore/scripts/Dockerfile
+++ b/scripts/variantstore/scripts/Dockerfile
@@ -44,7 +44,10 @@ FROM gcr.io/google.com/cloudsdktool/cloud-sdk:582.0.0-alpine AS main
 RUN apk update && apk upgrade
 
 # Add any generally useful Alpine packages here.
-RUN apk add --no-cache perl jq
+# `python3` (Alpine's own package, not this base image's bundled gcloud-internal interpreter -- see the note on the
+# `build` stage FROM above) must match what /localvenv was built against in the `build` stage, since the venv copied
+# in below is not self-contained and needs a matching /usr/bin/python3 and its shared libs present at the same path.
+RUN apk add --no-cache perl jq python3
 
 # The build stage generated Python artifacts to /root/.local via `pip install --user`, so grab all of those.
 COPY --from=build /localvenv /localvenv

--- a/scripts/variantstore/scripts/build_base.Dockerfile
+++ b/scripts/variantstore/scripts/build_base.Dockerfile
@@ -10,7 +10,10 @@
 #
 # Note: pyarrow was previously built from source here because Alpine's musl libc was incompatible with PyPI's
 # manylinux wheels. It has since been removed from the image entirely as no production code requires it.
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-alpine
+#
+# 565.0.0 is a deliberate ceiling, not merely "the version we happened to test". Do not bump it without
+# reading the note in GvsUtils.wdl's `cloud_sdk_docker_decl`.
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-alpine
 
 RUN apk update && apk upgrade
 

--- a/scripts/variantstore/scripts/build_base.Dockerfile
+++ b/scripts/variantstore/scripts/build_base.Dockerfile
@@ -11,15 +11,28 @@
 # Note: pyarrow was previously built from source here because Alpine's musl libc was incompatible with PyPI's
 # manylinux wheels. It has since been removed from the image entirely as no production code requires it.
 #
-# 565.0.0 is a deliberate ceiling, not merely "the version we happened to test". Do not bump it without
-# reading the note in GvsUtils.wdl's `cloud_sdk_docker_decl`.
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-alpine
+# IMPORTANT: bumping the tag below only changes what this Dockerfile produces; it has no effect until the resulting
+# image is rebuilt and pushed via `build_build_base_docker.sh` and the new tag is wired into Dockerfile's `build`
+# stage FROM line. Until that happens, Dockerfile's `build` and `main` stages are on different Python versions, which
+# silently breaks the venv copied from `build` into `main` (its `python3` symlink dangles, so `python3` falls back to
+# the bare system interpreter with none of the pip-installed packages -- e.g. `ModuleNotFoundError: No module named
+# 'google'`). Keep the version here and in Dockerfile's `build` stage FROM in lockstep.
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:582.0.0-alpine
 
 RUN apk update && apk upgrade
 
 # Add all required build tools. These are not added to the main stage as they are only needed at compile time.
-RUN apk add autoconf bash g++ gcc make python3-dev git openssl-dev zlib-dev xz-dev bzip2-dev curl-dev
-RUN python3 -m venv /localvenv && . /localvenv/bin/activate && python3 -m ensurepip --upgrade
+# `python3` is listed explicitly (it's also a transitive dependency of python3-dev) because this image's cloud-sdk
+# base bundles its own private Python interpreter for gcloud's internal use, at /usr/local/bin, ahead of Alpine's own
+# apk-managed /usr/bin/python3 on PATH. That bundled interpreter's version moves independently with every cloud-sdk
+# release (it jumped 3.12 -> 3.14 between the 524.0.0 and 582.0.0 tags) and is not meant to be used outside gcloud
+# itself, so relying on a bare `python3` here would silently tie our venv to whatever Python gcloud happens to embed.
+# Alpine's own python3 package tracks the (much more slowly moving) Alpine release instead, so the venv below is
+# built against /usr/bin/python3 explicitly. Dockerfile's `main` stage must also `apk add python3` for the same
+# reason: this venv is copied there via `COPY --from=build`, and needs the matching interpreter/shared libs present
+# at the same path to not be a dangling symlink. See the notes in Dockerfile.
+RUN apk add autoconf bash g++ gcc make python3 python3-dev git openssl-dev zlib-dev xz-dev bzip2-dev curl-dev
+RUN /usr/bin/python3 -m venv /localvenv && . /localvenv/bin/activate && python3 -m ensurepip --upgrade
 
 
 ARG HTSLIB_VERSION=1.23.1

--- a/scripts/variantstore/scripts/build_base.Dockerfile
+++ b/scripts/variantstore/scripts/build_base.Dockerfile
@@ -22,8 +22,17 @@ FROM gcr.io/google.com/cloudsdktool/cloud-sdk:582.0.0-alpine
 RUN apk update && apk upgrade
 
 # Add all required build tools. These are not added to the main stage as they are only needed at compile time.
-RUN apk add autoconf bash g++ gcc make python3-dev git openssl-dev zlib-dev xz-dev bzip2-dev curl-dev
-RUN python3 -m venv /localvenv && . /localvenv/bin/activate && python3 -m ensurepip --upgrade
+# `python3` is listed explicitly (it's also a transitive dependency of python3-dev) because this image's cloud-sdk
+# base bundles its own private Python interpreter for gcloud's internal use, at /usr/local/bin, ahead of Alpine's own
+# apk-managed /usr/bin/python3 on PATH. That bundled interpreter's version moves independently with every cloud-sdk
+# release (it jumped 3.12 -> 3.14 between the 524.0.0 and 582.0.0 tags) and is not meant to be used outside gcloud
+# itself, so relying on a bare `python3` here would silently tie our venv to whatever Python gcloud happens to embed.
+# Alpine's own python3 package tracks the (much more slowly moving) Alpine release instead, so the venv below is
+# built against /usr/bin/python3 explicitly. Dockerfile's `main` stage must also `apk add python3` for the same
+# reason: this venv is copied there via `COPY --from=build`, and needs the matching interpreter/shared libs present
+# at the same path to not be a dangling symlink. See the notes in Dockerfile.
+RUN apk add autoconf bash g++ gcc make python3 python3-dev git openssl-dev zlib-dev xz-dev bzip2-dev curl-dev
+RUN /usr/bin/python3 -m venv /localvenv && . /localvenv/bin/activate && python3 -m ensurepip --upgrade
 
 
 ARG HTSLIB_VERSION=1.23.1

--- a/scripts/variantstore/scripts/terra_notebook_utils_urllib3.patch
+++ b/scripts/variantstore/scripts/terra_notebook_utils_urllib3.patch
@@ -1,0 +1,12 @@
+diff --git a/terra_notebook_utils/table.py b/terra_notebook_utils/table.py
+--- a/terra_notebook_utils/table.py
++++ b/terra_notebook_utils/table.py
+@@ -44,7 +44,7 @@ def fiss():
+     # This is especially useful for fiss.fapi.update_entity, which enjoys throwing spurious PATCH 500 errors.
+     retry = Retry(total=10,
+                   status_forcelist=[429, 500, 502, 503, 504],
+-                  method_whitelist=['GET', 'HEAD', 'DELETE', 'PATCH', 'PUT'])
++                  allowed_methods=['GET', 'HEAD', 'DELETE', 'PATCH', 'PUT'])
+     http_session(fiss.fapi.__SESSION, retry)
+     return fiss.fapi
+

--- a/scripts/variantstore/utils/format_markdown_tables.py
+++ b/scripts/variantstore/utils/format_markdown_tables.py
@@ -26,7 +26,13 @@ import os
 import re
 import sys
 
-FENCE = re.compile(r'^\s*(```|~~~)')
+# A fence is a run of three or more backticks or tildes. Per CommonMark a fence is closed only
+# by a run of the *same* character, at least as long as the opener and carrying no info string;
+# a run of the other character inside the block is ordinary content. Matching either character
+# indiscriminately silently corrupts the scan: the `~~~~^^` caret annotation in a Python 3.11+
+# traceback quoted inside a ``` block would end the block early, leaving every table after it
+# looking fenced and therefore skipped.
+FENCE = re.compile(r'^\s*(`{3,}|~{3,})(.*)$')
 SEPARATOR_CELL = re.compile(r'^:?-+:?$')
 UNESCAPED_PIPE = re.compile(r'(?<!\\)\|')
 # Up to three spaces of indentation still parses as a table; four or more is an indented
@@ -103,18 +109,26 @@ def format_table(rows, indent=''):
 def format_text(text):
     """Return (formatted_text, tables_changed)."""
     lines = text.split('\n')
-    out, index, in_fence, changed = [], 0, False, 0
+    out, index, changed = [], 0, 0
+    fence_char, fence_len = None, 0
 
     while index < len(lines):
         line = lines[index]
 
-        if FENCE.match(line):
-            in_fence = not in_fence
+        fence = FENCE.match(line)
+        if fence:
+            marker, info = fence.group(1), fence.group(2)
+            if fence_char is None:
+                # A backtick fence's info string may not itself contain a backtick.
+                if marker[0] == '~' or '`' not in info:
+                    fence_char, fence_len = marker[0], len(marker)
+            elif marker[0] == fence_char and len(marker) >= fence_len and not info.strip():
+                fence_char, fence_len = None, 0
             out.append(line)
             index += 1
             continue
 
-        header = None if in_fence else TABLE_LINE.match(line)
+        header = None if fence_char else TABLE_LINE.match(line)
         if header:
             end = index
             while end < len(lines) and TABLE_LINE.match(lines[end]):

--- a/scripts/variantstore/wdl/GvsCountVdsNovelLoci.wdl
+++ b/scripts/variantstore/wdl/GvsCountVdsNovelLoci.wdl
@@ -140,9 +140,12 @@ task CountVdsNovelLoci {
 
         account_name=$(gcloud config list account --format "value(core.account)")
 
-        apt-get update
-        apt-get install --assume-yes python3.11-venv
-        python3 -m venv ./localvenv
+        # Debian 13 (Cloud SDK 582 -slim) no longer packages python3.11. Install a standalone Python 3.11 via
+        # uv (independent of apt) and build the venv with it; --seed provisions pip so the pip3 installs below
+        # work unchanged. See the note on cloud_sdk_docker_decl in GvsUtils.wdl.
+        curl -LsSf https://astral.sh/uv/0.12.9/install.sh | env UV_NO_MODIFY_PATH=1 sh
+        export PATH="$HOME/.local/bin:$PATH"
+        uv venv --python 3.11 --seed ./localvenv
         . ./localvenv/bin/activate
 
         pip3 install --upgrade pip

--- a/scripts/variantstore/wdl/GvsCreateVDS.wdl
+++ b/scripts/variantstore/wdl/GvsCreateVDS.wdl
@@ -169,9 +169,12 @@ task CreateVds {
 
         account_name=$(gcloud config list account --format "value(core.account)")
 
-        apt-get update
-        apt install --assume-yes python3.11-venv
-        python3 -m venv ./localvenv
+        # Debian 13 (Cloud SDK 582 -slim) no longer packages python3.11. Install a standalone Python 3.11 via
+        # uv (independent of apt) and build the venv with it; --seed provisions pip so the pip3 installs below
+        # work unchanged. See the note on cloud_sdk_docker_decl in GvsUtils.wdl.
+        curl -LsSf https://astral.sh/uv/0.12.9/install.sh | env UV_NO_MODIFY_PATH=1 sh
+        export PATH="$HOME/.local/bin:$PATH"
+        uv venv --python 3.11 --seed ./localvenv
         . ./localvenv/bin/activate
 
         pip3 install --upgrade pip

--- a/scripts/variantstore/wdl/GvsMergeAndRescoreVDSes.wdl
+++ b/scripts/variantstore/wdl/GvsMergeAndRescoreVDSes.wdl
@@ -190,9 +190,12 @@ task MergeAndRescoreVDS {
 
         account_name=$(gcloud config list account --format "value(core.account)")
 
-        apt-get update
-        apt-get install --assume-yes python3.11-venv
-        python3 -m venv ./localvenv
+        # Debian 13 (Cloud SDK 582 -slim) no longer packages python3.11. Install a standalone Python 3.11 via
+        # uv (independent of apt) and build the venv with it; --seed provisions pip so the pip3 installs below
+        # work unchanged. See the note on cloud_sdk_docker_decl in GvsUtils.wdl.
+        curl -LsSf https://astral.sh/uv/0.12.9/install.sh | env UV_NO_MODIFY_PATH=1 sh
+        export PATH="$HOME/.local/bin:$PATH"
+        uv venv --python 3.11 --seed ./localvenv
         . ./localvenv/bin/activate
 
         pip3 install --upgrade pip

--- a/scripts/variantstore/wdl/GvsRemoveSamplesFromVDS.wdl
+++ b/scripts/variantstore/wdl/GvsRemoveSamplesFromVDS.wdl
@@ -149,9 +149,12 @@ task RemoveSamplesFromVDS {
 
         account_name=$(gcloud config list account --format "value(core.account)")
 
-        apt-get update
-        apt-get install --assume-yes python3.11-venv
-        python3 -m venv ./localvenv
+        # Debian 13 (Cloud SDK 582 -slim) no longer packages python3.11. Install a standalone Python 3.11 via
+        # uv (independent of apt) and build the venv with it; --seed provisions pip so the pip3 installs below
+        # work unchanged. See the note on cloud_sdk_docker_decl in GvsUtils.wdl.
+        curl -LsSf https://astral.sh/uv/0.12.9/install.sh | env UV_NO_MODIFY_PATH=1 sh
+        export PATH="$HOME/.local/bin:$PATH"
+        uv venv --python 3.11 --seed ./localvenv
         . ./localvenv/bin/activate
 
         pip3 install --upgrade pip

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -58,7 +58,20 @@ task GetToolVersions {
   }
 
   File monitoring_script = "gs://gvs_quickstart_storage/cromwell_monitoring_script.sh"
-  String cloud_sdk_docker_decl = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-alpine"
+  # 565.0.0 is a ceiling, not just the last version anyone tested. Google removes Cloud SDK images about a
+  # year after publication, so this tag will need to move again around 2027-04-14 -- but it cannot simply be
+  # bumped to the newest release, for two independent reasons:
+  #   * The `-alpine` images stopped using Alpine's system Python and began bundling Python 3.14 at 568.0.0.
+  #     hail (see `hail_version` below) pins numpy<2, and numpy 1.26.4 publishes musl wheels only through
+  #     cp312, so `pip install hail` in GvsCreateVATfromVDS's `GenerateSitesOnlyVcf` falls back to a source
+  #     build and fails -- the image ships no compiler. Adding one would not help: numpy 1.26.4 does not
+  #     support Python 3.13+ at all.
+  #   * The `-slim` images moved from Debian 12 to Debian 13 at 566.0.0, which drops Python 3.11. The hail
+  #     tasks in GvsCreateVDS, GvsValidateVDS, GvsCountVdsNovelLoci and GvsTieOutVDS all run
+  #     `apt install python3.11-venv`, which fails outright on Debian 13.
+  # Escaping this ceiling means moving those tasks to hail >= 0.2.135 (the release that repins numpy to >=2),
+  # which is a pipeline-wide change requiring VDS revalidation -- not something to fold into an image bump.
+  String cloud_sdk_docker_decl = "gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-alpine"
 
   # For GVS releases, set `version` to match the release branch name, e.g. gvs_<major>.<minor>.<patch>.
   # For non-release, leave the value at "unspecified".
@@ -130,8 +143,10 @@ task GetToolVersions {
     String cloud_sdk_docker = cloud_sdk_docker_decl #   Defined above as a declaration.
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
-    String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-08-24-alpine-2992179e6bf4"
+    # Must stay in lockstep with `cloud_sdk_docker_decl` above -- 565.0.0 is the last tag whose `-slim`
+    # sibling is Debian 12 / Python 3.11. See the note there before bumping.
+    String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-slim"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-02-alpine-fdf40647cbfd"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -139,7 +139,7 @@ task GetToolVersions {
     # This has no effect until the image is rebuilt (build_docker.sh) and this tag is updated to match -- see the
     # "Variants Docker Image" section of the top-level CLAUDE.md. Editing the image's Dockerfiles (including the
     # cloud_sdk_docker_decl-equivalent base image tags above) has no runtime effect until that rebuild happens either.
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-01-alpine-318b4da50e1c"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-01-alpine-37a0a74a7f56"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -139,7 +139,7 @@ task GetToolVersions {
     # This has no effect until the image is rebuilt (build_docker.sh) and this tag is updated to match -- see the
     # "Variants Docker Image" section of the top-level CLAUDE.md. Editing the image's Dockerfiles (including the
     # cloud_sdk_docker_decl-equivalent base image tags above) has no runtime effect until that rebuild happens either.
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-01-alpine-df98d9b0a485"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-01-alpine-318b4da50e1c"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -150,10 +150,7 @@ task GetToolVersions {
     # which drops the python3.11 apt package; the hail tasks that use this image install Python 3.11 via uv
     # instead. See the note on `cloud_sdk_docker_decl` before bumping.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:582.0.0-slim"
-    # REBUILD REQUIRED: this tag is a placeholder from the earlier 582 build and predates the terra-notebook-utils
-    # urllib3 patch now added in scripts/Dockerfile. Rebuild via build_docker.sh and update this to the new tag
-    # before relying on this image (see the Variants Docker Image note in CLAUDE.md).
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-01-alpine-37a0a74a7f56"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-03-alpine-43268e7d90fe"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -58,20 +58,23 @@ task GetToolVersions {
   }
 
   File monitoring_script = "gs://gvs_quickstart_storage/cromwell_monitoring_script.sh"
-  # 565.0.0 is a ceiling, not just the last version anyone tested. Google removes Cloud SDK images about a
-  # year after publication, so this tag will need to move again around 2027-04-14 -- but it cannot simply be
-  # bumped to the newest release, for two independent reasons:
-  #   * The `-alpine` images stopped using Alpine's system Python and began bundling Python 3.14 at 568.0.0.
-  #     hail (see `hail_version` below) pins numpy<2, and numpy 1.26.4 publishes musl wheels only through
-  #     cp312, so `pip install hail` in GvsCreateVATfromVDS's `GenerateSitesOnlyVcf` falls back to a source
-  #     build and fails -- the image ships no compiler. Adding one would not help: numpy 1.26.4 does not
-  #     support Python 3.13+ at all.
-  #   * The `-slim` images moved from Debian 12 to Debian 13 at 566.0.0, which drops Python 3.11. The hail
-  #     tasks in GvsCreateVDS, GvsValidateVDS, GvsCountVdsNovelLoci and GvsTieOutVDS all run
-  #     `apt install python3.11-venv`, which fails outright on Debian 13.
-  # Escaping this ceiling means moving those tasks to hail >= 0.2.135 (the release that repins numpy to >=2),
-  # which is a pipeline-wide change requiring VDS revalidation -- not something to fold into an image bump.
-  String cloud_sdk_docker_decl = "gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-alpine"
+  # We run Cloud SDK 582.0.0 on hail 0.2.134 (which pins numpy<2) by working around the two problems that
+  # made 565.0.0 a ceiling, rather than taking the hail >= 0.2.135 bump those problems would otherwise force:
+  #   * `-alpine`: at 568.0.0 these images stopped using Alpine's system Python and began bundling Python 3.14
+  #     for gcloud's own internal use. numpy 1.26.4 (hail's numpy<2 pin) publishes musl wheels only through
+  #     cp312, so `pip install hail` against 3.14 in GvsCreateVATfromVDS's `GenerateSitesOnlyVcf` would fall
+  #     back to a source build and fail (the image ships no compiler). The variants image sidesteps this by
+  #     building its venv against Alpine's own /usr/bin/python3 (3.12) instead of the bundled interpreter --
+  #     see the notes in scripts/Dockerfile and scripts/build_base.Dockerfile.
+  #   * `-slim`: at 566.0.0 these images moved from Debian 12 to Debian 13, which drops the python3.11 apt
+  #     package. The hail tasks in GvsCreateVDS, GvsValidateVDS, GvsCountVdsNovelLoci, GvsMergeAndRescoreVDSes
+  #     and GvsRemoveSamplesFromVDS install Python 3.11 via uv (a standalone build, independent of apt).
+  # This is a bridge, not a permanent escape: numpy 1.26.4's musl wheels stop at cp312, so the variants image
+  # depends on Alpine's own python3 staying <= 3.12. When Cloud SDK's alpine base moves to an Alpine shipping
+  # Python 3.13+, `apk add python3` yields 3.13 and the alpine path breaks again -- and Alpine carries only one
+  # python3 per release, so it cannot be pinned back to 3.12. The durable fix remains moving these tasks to
+  # hail >= 0.2.135 (which repins numpy to >=2), a pipeline-wide change requiring VDS revalidation.
+  String cloud_sdk_docker_decl = "gcr.io/google.com/cloudsdktool/cloud-sdk:582.0.0-alpine"
 
   # For GVS releases, set `version` to match the release branch name, e.g. gvs_<major>.<minor>.<patch>.
   # For non-release, leave the value at "unspecified".
@@ -143,10 +146,14 @@ task GetToolVersions {
     String cloud_sdk_docker = cloud_sdk_docker_decl #   Defined above as a declaration.
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
-    # Must stay in lockstep with `cloud_sdk_docker_decl` above -- 565.0.0 is the last tag whose `-slim`
-    # sibling is Debian 12 / Python 3.11. See the note there before bumping.
-    String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-02-alpine-fdf40647cbfd"
+    # Must stay in lockstep with `cloud_sdk_docker_decl` above. At 582.0.0 the `-slim` sibling is Debian 13,
+    # which drops the python3.11 apt package; the hail tasks that use this image install Python 3.11 via uv
+    # instead. See the note on `cloud_sdk_docker_decl` before bumping.
+    String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:582.0.0-slim"
+    # REBUILD REQUIRED: this tag is a placeholder from the earlier 582 build and predates the terra-notebook-utils
+    # urllib3 patch now added in scripts/Dockerfile. Rebuild via build_docker.sh and update this to the new tag
+    # before relying on this image (see the Variants Docker Image note in CLAUDE.md).
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-01-alpine-37a0a74a7f56"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"

--- a/scripts/variantstore/wdl/GvsValidateVDS.wdl
+++ b/scripts/variantstore/wdl/GvsValidateVDS.wdl
@@ -159,9 +159,12 @@ task ValidateVds {
 
         account_name=$(gcloud config list account --format "value(core.account)")
 
-        apt-get update
-        apt install --assume-yes python3.11-venv
-        python3 -m venv ./localvenv
+        # Debian 13 (Cloud SDK 582 -slim) no longer packages python3.11. Install a standalone Python 3.11 via
+        # uv (independent of apt) and build the venv with it; --seed provisions pip so the pip3 installs below
+        # work unchanged. See the note on cloud_sdk_docker_decl in GvsUtils.wdl.
+        curl -LsSf https://astral.sh/uv/0.12.9/install.sh | env UV_NO_MODIFY_PATH=1 sh
+        export PATH="$HOME/.local/bin:$PATH"
+        uv venv --python 3.11 --seed ./localvenv
         . ./localvenv/bin/activate
 
         pip3 install --upgrade pip

--- a/scripts/variantstore/wdl/test/GvsQuickstartHailIntegration.wdl
+++ b/scripts/variantstore/wdl/test/GvsQuickstartHailIntegration.wdl
@@ -226,8 +226,12 @@ task TieOutVds {
         apt-get -qq update
         apt -qq install -y temurin-11-jdk
 
-        apt install --assume-yes python3.11-venv
-        python3 -m venv ./localvenv
+        # Debian 13 (Cloud SDK 582 -slim) no longer packages python3.11. Install a standalone Python 3.11 via
+        # uv (independent of apt) and build the venv with it; --seed provisions pip so the pip installs below
+        # work unchanged. See the note on cloud_sdk_docker_decl in GvsUtils.wdl.
+        curl -LsSf https://astral.sh/uv/0.12.9/install.sh | env UV_NO_MODIFY_PATH=1 sh
+        export PATH="$HOME/.local/bin:$PATH"
+        uv venv --python 3.11 --seed ./localvenv
         . ./localvenv/bin/activate
 
         export PYSPARK_SUBMIT_ARGS='--driver-memory 16g --executor-memory 16g pyspark-shell'

--- a/scripts/variantstore/wdl/test/GvsTieOutVDS.wdl
+++ b/scripts/variantstore/wdl/test/GvsTieOutVDS.wdl
@@ -99,8 +99,12 @@ task TieOutVDS {
         apt-get -qq update
         apt -qq install --assume-yes temurin-11-jdk
 
-        apt install --assume-yes python3.11-venv
-        python3 -m venv ./localvenv
+        # Debian 13 (Cloud SDK 582 -slim) no longer packages python3.11. Install a standalone Python 3.11 via
+        # uv (independent of apt) and build the venv with it; --seed provisions pip so the pip installs below
+        # work unchanged. See the note on cloud_sdk_docker_decl in GvsUtils.wdl.
+        curl -LsSf https://astral.sh/uv/0.12.9/install.sh | env UV_NO_MODIFY_PATH=1 sh
+        export PATH="$HOME/.local/bin:$PATH"
+        uv venv --python 3.11 --seed ./localvenv
         . ./localvenv/bin/activate
 
         export PYSPARK_SUBMIT_ARGS='--driver-memory 16g --executor-memory 16g pyspark-shell'


### PR DESCRIPTION
[VS-2004](https://broadworkbench.atlassian.net/browse/VS-2004): Pin Alpine's own python3 for the Variants image

Hail's install failed because the `cloud-sdk` base image bundles its own private Python for `gcloud's` internal use, which jumped from `3.12` to `3.14` between the 524.0.0 and 582.0.0 `cloud-sdk` tags — incompatible with Hail's numpy pin. build_base.Dockerfile and Dockerfile now explicitly apk add python3 (Alpine's own, still 3.12.14) and build the venv against /usr/bin/python3 directly, so the image stays on a stable Python regardless of what gcloud embeds internally.

Rebuilt and re-pinned both the build-base and main Variants images to pick up the fix. Verified: /localvenv/bin/python3 is 3.12.14 and full Python unit test suite passes. Integration tests are currently being run.

[VS-2004]: https://broadworkbench.atlassian.net/browse/VS-2004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ