### PR TITLE
Rebuild Variants images for Cloud SDK 565, patch TNU [VS-2002]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -227,7 +227,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - ng_vs_1966_explicit_header_checks
        tags:
          - /.*/
    - name: GvsPrepareRangesCallset
@@ -332,7 +331,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - ng_vs_1966_explicit_header_checks
          tags:
              - /.*/
    - name: GvsQuickstartHailIntegration
@@ -342,7 +340,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - ng_vs_1966_explicit_header_checks
          tags:
              - /.*/
    - name: GvsQuickstartIntegration
@@ -352,7 +349,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - vs_2002_update_variants_images
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -173,7 +173,6 @@ workflows:
        branches:
          - master
          - ah_var_store
-         - ng_vs_1966_explicit_header_checks
        tags:
          - /.*/
    - name: GvsMergeAndRescoreVDSes
@@ -353,7 +352,7 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - ng_vs_1966_explicit_header_checks
+             - vs_2002_update_variants_images
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/scripts/Dockerfile
+++ b/scripts/variantstore/scripts/Dockerfile
@@ -32,32 +32,14 @@ RUN mkdir /fiss-build && \
     python setup.py install
 
 # Patch `terra-notebook-utils` for a urllib3 2.x incompatibility.
-# Its `table.py` still passes urllib3 1.x's `method_whitelist` keyword to `Retry`; urllib3 2.0 removed that
-# keyword in favor of `allowed_methods`. Upstream migrated its own `http.py` but missed `table.py`, so every
-# Terra entity-table call raises
-# `TypeError: Retry.__init__() got an unexpected keyword argument 'method_whitelist'`.
-# Upstream PR #424 (merged 2026-08-26, shipped in 0.16.1/0.16.2) relaxed the hard caps `requests<=2.29.0`
-# and `urllib3<=1.26.19` to `<3` and fixed the identical call site in `http.py`, but missed this second one
-# in `table.py`. Until that release the caps held us on urllib3 1.26.x, where the keyword still exists but is
-# deprecated, so nothing failed.
-# This is NOT a Python version problem, and the `cloud_sdk_docker_decl` pin does not fix it: with the caps
-# gone, whether the resolver picks urllib3 1.x or 2.x depends on the pip build bundled in the base image
-# (pip 25.0.1 in cloud-sdk 565 resolves urllib3 1.26.20; pip 26.1.2 in 582 resolves 2.7.0). This patch is
-# what actually fixes it -- do not drop it on the assumption that the base image pin covers it.
-# Patching is preferred over re-pinning `urllib3 < 2`, which would hold the whole image back to an
-# end-of-life urllib3. `git apply` fails the build if the upstream line ever changes, which is the signal to re-check
-# whether this workaround can be dropped.
+# An PR will be opened in `terra-notebook-utils` to fix this upstream, but until then we patch it here.
 COPY terra_notebook_utils_urllib3.patch /terra_notebook_utils_urllib3.patch
 RUN . /localvenv/bin/activate && \
     cd "$(python3 -c 'import terra_notebook_utils as m, pathlib; print(pathlib.Path(m.__file__).parent.parent)')" && \
-    git apply /terra_notebook_utils_urllib3.patch && \
-    python3 -c "from urllib3.util.retry import Retry; Retry(total=10, status_forcelist=[429], allowed_methods=['GET'])"
+    git apply /terra_notebook_utils_urllib3.patch
 
 # The main layer does not install development tools, instead copies artifacts from the build layer above.
 # IMPORTANT: must stay on the same Python version as the `build` stage's FROM above -- see the note there.
-# 565.0.0 is a deliberate ceiling -- see the note above this Dockerfile's `build` stage FROM, in
-# build_base.Dockerfile, and in GvsUtils.wdl's `cloud_sdk_docker_decl`. 568.0.0 and later bundle Python 3.14,
-# which hail cannot be installed on.
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-alpine AS main
 
 RUN apk update && apk upgrade

--- a/scripts/variantstore/scripts/Dockerfile
+++ b/scripts/variantstore/scripts/Dockerfile
@@ -6,7 +6,7 @@
 # expensive to create and isn't expected to change often, while the steps in this Dockerfile are much less expensive and
 # more likely to change. Using a build-base image essentially allows the expensive layers to be globally cached which
 # should make building the final image much faster in most cases.
-FROM us.gcr.io/broad-dsde-methods/variantstore:2026-09-01-alpine-build-base AS build
+FROM us.gcr.io/broad-dsde-methods/variantstore:2026-09-02-alpine-build-base AS build
 
 # Install all of our variantstore Python requirements.
 # We constrain the version of setuptools to sidestep an issue in `terra-notebook-util`'s FISS dependency.
@@ -36,11 +36,16 @@ RUN mkdir /fiss-build && \
 # keyword in favor of `allowed_methods`. Upstream migrated its own `http.py` but missed `table.py`, so every
 # Terra entity-table call raises
 # `TypeError: Retry.__init__() got an unexpected keyword argument 'method_whitelist'`.
-# This was latent until the Cloud SDK base image moved to Python 3.14: on 3.12 pip happened to resolve
-# urllib3 1.26.x (where the keyword still exists but is deprecated), so nothing failed. That was luck, not a
-# constraint anyone wrote down, and it stopped holding on 3.14, where pip resolves urllib3 2.x.
-# Patching is preferred over pinning `urllib3 < 2`, which would hold the whole image back to an end-of-life
-# urllib3. `git apply` fails the build if the upstream line ever changes, which is the signal to re-check
+# Upstream PR #424 (merged 2026-08-26, shipped in 0.16.1/0.16.2) relaxed the hard caps `requests<=2.29.0`
+# and `urllib3<=1.26.19` to `<3` and fixed the identical call site in `http.py`, but missed this second one
+# in `table.py`. Until that release the caps held us on urllib3 1.26.x, where the keyword still exists but is
+# deprecated, so nothing failed.
+# This is NOT a Python version problem, and the `cloud_sdk_docker_decl` pin does not fix it: with the caps
+# gone, whether the resolver picks urllib3 1.x or 2.x depends on the pip build bundled in the base image
+# (pip 25.0.1 in cloud-sdk 565 resolves urllib3 1.26.20; pip 26.1.2 in 582 resolves 2.7.0). This patch is
+# what actually fixes it -- do not drop it on the assumption that the base image pin covers it.
+# Patching is preferred over re-pinning `urllib3 < 2`, which would hold the whole image back to an
+# end-of-life urllib3. `git apply` fails the build if the upstream line ever changes, which is the signal to re-check
 # whether this workaround can be dropped.
 COPY terra_notebook_utils_urllib3.patch /terra_notebook_utils_urllib3.patch
 RUN . /localvenv/bin/activate && \

--- a/scripts/variantstore/scripts/Dockerfile
+++ b/scripts/variantstore/scripts/Dockerfile
@@ -6,7 +6,7 @@
 # expensive to create and isn't expected to change often, while the steps in this Dockerfile are much less expensive and
 # more likely to change. Using a build-base image essentially allows the expensive layers to be globally cached which
 # should make building the final image much faster in most cases.
-FROM us.gcr.io/broad-dsde-methods/variantstore:2026-06-23-alpine-build-base AS build
+FROM us.gcr.io/broad-dsde-methods/variantstore:2026-09-01-alpine-build-base AS build
 
 # Install all of our variantstore Python requirements.
 # We constrain the version of setuptools to sidestep an issue in `terra-notebook-util`'s FISS dependency.
@@ -31,8 +31,29 @@ RUN mkdir /fiss-build && \
     . /localvenv/bin/activate && \
     python setup.py install
 
+# Patch `terra-notebook-utils` for a urllib3 2.x incompatibility.
+# Its `table.py` still passes urllib3 1.x's `method_whitelist` keyword to `Retry`; urllib3 2.0 removed that
+# keyword in favor of `allowed_methods`. Upstream migrated its own `http.py` but missed `table.py`, so every
+# Terra entity-table call raises
+# `TypeError: Retry.__init__() got an unexpected keyword argument 'method_whitelist'`.
+# This was latent until the Cloud SDK base image moved to Python 3.14: on 3.12 pip happened to resolve
+# urllib3 1.26.x (where the keyword still exists but is deprecated), so nothing failed. That was luck, not a
+# constraint anyone wrote down, and it stopped holding on 3.14, where pip resolves urllib3 2.x.
+# Patching is preferred over pinning `urllib3 < 2`, which would hold the whole image back to an end-of-life
+# urllib3. `git apply` fails the build if the upstream line ever changes, which is the signal to re-check
+# whether this workaround can be dropped.
+COPY terra_notebook_utils_urllib3.patch /terra_notebook_utils_urllib3.patch
+RUN . /localvenv/bin/activate && \
+    cd "$(python3 -c 'import terra_notebook_utils as m, pathlib; print(pathlib.Path(m.__file__).parent.parent)')" && \
+    git apply /terra_notebook_utils_urllib3.patch && \
+    python3 -c "from urllib3.util.retry import Retry; Retry(total=10, status_forcelist=[429], allowed_methods=['GET'])"
+
 # The main layer does not install development tools, instead copies artifacts from the build layer above.
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-alpine AS main
+# IMPORTANT: must stay on the same Python version as the `build` stage's FROM above -- see the note there.
+# 565.0.0 is a deliberate ceiling -- see the note above this Dockerfile's `build` stage FROM, in
+# build_base.Dockerfile, and in GvsUtils.wdl's `cloud_sdk_docker_decl`. 568.0.0 and later bundle Python 3.14,
+# which hail cannot be installed on.
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-alpine AS main
 
 RUN apk update && apk upgrade
 

--- a/scripts/variantstore/scripts/Dockerfile
+++ b/scripts/variantstore/scripts/Dockerfile
@@ -32,7 +32,8 @@ RUN mkdir /fiss-build && \
     python setup.py install
 
 # Patch `terra-notebook-utils` for a urllib3 2.x incompatibility.
-# An PR will be opened in `terra-notebook-utils` to fix this upstream, but until then we patch it here.
+# A PR has been opened in `terra-notebook-utils` to fix this upstream, but until that lands we patch this here.
+# https://github.com/DataBiosphere/terra-notebook-utils/pull/426
 COPY terra_notebook_utils_urllib3.patch /terra_notebook_utils_urllib3.patch
 RUN . /localvenv/bin/activate && \
     cd "$(python3 -c 'import terra_notebook_utils as m, pathlib; print(pathlib.Path(m.__file__).parent.parent)')" && \

--- a/scripts/variantstore/scripts/build_base.Dockerfile
+++ b/scripts/variantstore/scripts/build_base.Dockerfile
@@ -12,11 +12,7 @@
 # manylinux wheels. It has since been removed from the image entirely as no production code requires it.
 #
 # 565.0.0 is a deliberate ceiling, not merely "the version we happened to test". Do not bump it without
-# reading the note in GvsUtils.wdl's `cloud_sdk_docker_decl`: the `-alpine` images switched to a bundled
-# Python 3.14 at 568.0.0, and hail's pinned numpy has no musl wheel for anything past cp312, so the VAT's
-# `GenerateSitesOnlyVcf` cannot install hail on 568+. 565.0.0 is also the last tag whose `-slim` sibling is
-# still Debian 12 / Python 3.11, which the hail tasks in GvsCreateVDS/GvsValidateVDS/GvsCountVdsNovelLoci/
-# GvsTieOutVDS depend on for their `apt install python3.11-venv` step.
+# reading the note in GvsUtils.wdl's `cloud_sdk_docker_decl`.
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-alpine
 
 RUN apk update && apk upgrade

--- a/scripts/variantstore/scripts/build_base.Dockerfile
+++ b/scripts/variantstore/scripts/build_base.Dockerfile
@@ -10,7 +10,14 @@
 #
 # Note: pyarrow was previously built from source here because Alpine's musl libc was incompatible with PyPI's
 # manylinux wheels. It has since been removed from the image entirely as no production code requires it.
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-alpine
+#
+# 565.0.0 is a deliberate ceiling, not merely "the version we happened to test". Do not bump it without
+# reading the note in GvsUtils.wdl's `cloud_sdk_docker_decl`: the `-alpine` images switched to a bundled
+# Python 3.14 at 568.0.0, and hail's pinned numpy has no musl wheel for anything past cp312, so the VAT's
+# `GenerateSitesOnlyVcf` cannot install hail on 568+. 565.0.0 is also the last tag whose `-slim` sibling is
+# still Debian 12 / Python 3.11, which the hail tasks in GvsCreateVDS/GvsValidateVDS/GvsCountVdsNovelLoci/
+# GvsTieOutVDS depend on for their `apt install python3.11-venv` step.
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-alpine
 
 RUN apk update && apk upgrade
 

--- a/scripts/variantstore/scripts/terra_notebook_utils_urllib3.patch
+++ b/scripts/variantstore/scripts/terra_notebook_utils_urllib3.patch
@@ -1,0 +1,12 @@
+diff --git a/terra_notebook_utils/table.py b/terra_notebook_utils/table.py
+--- a/terra_notebook_utils/table.py
++++ b/terra_notebook_utils/table.py
+@@ -44,7 +44,7 @@ def fiss():
+     # This is especially useful for fiss.fapi.update_entity, which enjoys throwing spurious PATCH 500 errors.
+     retry = Retry(total=10,
+                   status_forcelist=[429, 500, 502, 503, 504],
+-                  method_whitelist=['GET', 'HEAD', 'DELETE', 'PATCH', 'PUT'])
++                  allowed_methods=['GET', 'HEAD', 'DELETE', 'PATCH', 'PUT'])
+     http_session(fiss.fapi.__SESSION, retry)
+     return fiss.fapi
+

--- a/scripts/variantstore/utils/format_markdown_tables.py
+++ b/scripts/variantstore/utils/format_markdown_tables.py
@@ -26,7 +26,13 @@ import os
 import re
 import sys
 
-FENCE = re.compile(r'^\s*(```|~~~)')
+# A fence is a run of three or more backticks or tildes. Per CommonMark a fence is closed only
+# by a run of the *same* character, at least as long as the opener and carrying no info string;
+# a run of the other character inside the block is ordinary content. Matching either character
+# indiscriminately silently corrupts the scan: the `~~~~^^` caret annotation in a Python 3.11+
+# traceback quoted inside a ``` block would end the block early, leaving every table after it
+# looking fenced and therefore skipped.
+FENCE = re.compile(r'^\s*(`{3,}|~{3,})(.*)$')
 SEPARATOR_CELL = re.compile(r'^:?-+:?$')
 UNESCAPED_PIPE = re.compile(r'(?<!\\)\|')
 # Up to three spaces of indentation still parses as a table; four or more is an indented
@@ -103,18 +109,26 @@ def format_table(rows, indent=''):
 def format_text(text):
     """Return (formatted_text, tables_changed)."""
     lines = text.split('\n')
-    out, index, in_fence, changed = [], 0, False, 0
+    out, index, changed = [], 0, 0
+    fence_char, fence_len = None, 0
 
     while index < len(lines):
         line = lines[index]
 
-        if FENCE.match(line):
-            in_fence = not in_fence
+        fence = FENCE.match(line)
+        if fence:
+            marker, info = fence.group(1), fence.group(2)
+            if fence_char is None:
+                # A backtick fence's info string may not itself contain a backtick.
+                if marker[0] == '~' or '`' not in info:
+                    fence_char, fence_len = marker[0], len(marker)
+            elif marker[0] == fence_char and len(marker) >= fence_len and not info.strip():
+                fence_char, fence_len = None, 0
             out.append(line)
             index += 1
             continue
 
-        header = None if in_fence else TABLE_LINE.match(line)
+        header = None if fence_char else TABLE_LINE.match(line)
         if header:
             end = index
             while end < len(lines) and TABLE_LINE.match(lines[end]):

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -149,7 +149,7 @@ task GetToolVersions {
     # This has no effect until the image is rebuilt (build_docker.sh) and this tag is updated to match -- see the
     # "Variants Docker Image" section of the top-level CLAUDE.md. Editing the image's Dockerfiles (including the
     # cloud_sdk_docker_decl-equivalent base image tags above) has no runtime effect until that rebuild happens either.
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-01-alpine-df98d9b0a485"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-01-alpine-fdf40647cbfd"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -58,7 +58,20 @@ task GetToolVersions {
   }
 
   File monitoring_script = "gs://gvs_quickstart_storage/cromwell_monitoring_script.sh"
-  String cloud_sdk_docker_decl = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-alpine"
+  # 565.0.0 is a ceiling, not just the last version anyone tested. Google removes Cloud SDK images about a
+  # year after publication, so this tag will need to move again around 2027-04-14 -- but it cannot simply be
+  # bumped to the newest release, for two independent reasons:
+  #   * The `-alpine` images stopped using Alpine's system Python and began bundling Python 3.14 at 568.0.0.
+  #     hail (see `hail_version` below) pins numpy<2, and numpy 1.26.4 publishes musl wheels only through
+  #     cp312, so `pip install hail` in GvsCreateVATfromVDS's `GenerateSitesOnlyVcf` falls back to a source
+  #     build and fails -- the image ships no compiler. Adding one would not help: numpy 1.26.4 does not
+  #     support Python 3.13+ at all.
+  #   * The `-slim` images moved from Debian 12 to Debian 13 at 566.0.0, which drops Python 3.11. The hail
+  #     tasks in GvsCreateVDS, GvsValidateVDS, GvsCountVdsNovelLoci and GvsTieOutVDS all run
+  #     `apt install python3.11-venv`, which fails outright on Debian 13.
+  # Escaping this ceiling means moving those tasks to hail >= 0.2.135 (the release that repins numpy to >=2),
+  # which is a pipeline-wide change requiring VDS revalidation -- not something to fold into an image bump.
+  String cloud_sdk_docker_decl = "gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-alpine"
 
   # For GVS releases, set `version` to match the release branch name, e.g. gvs_<major>.<minor>.<patch>.
   # For non-release, leave the value at "unspecified".
@@ -130,8 +143,13 @@ task GetToolVersions {
     String cloud_sdk_docker = cloud_sdk_docker_decl #   Defined above as a declaration.
     # GVS generally uses the smallest `alpine` version of the Google Cloud SDK as it suffices for most tasks, but
     # there are a handful of tasks that require the larger GNU libc-based `slim`.
-    String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:524.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-08-24-alpine-2992179e6bf4"
+    # Must stay in lockstep with `cloud_sdk_docker_decl` above -- 565.0.0 is the last tag whose `-slim`
+    # sibling is Debian 12 / Python 3.11. See the note there before bumping.
+    String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-slim"
+    # This has no effect until the image is rebuilt (build_docker.sh) and this tag is updated to match -- see the
+    # "Variants Docker Image" section of the top-level CLAUDE.md. Editing the image's Dockerfiles (including the
+    # cloud_sdk_docker_decl-equivalent base image tags above) has no runtime effect until that rebuild happens either.
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-01-alpine-df98d9b0a485"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -146,9 +146,6 @@ task GetToolVersions {
     # Must stay in lockstep with `cloud_sdk_docker_decl` above -- 565.0.0 is the last tag whose `-slim`
     # sibling is Debian 12 / Python 3.11. See the note there before bumping.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-slim"
-    # This has no effect until the image is rebuilt (build_docker.sh) and this tag is updated to match -- see the
-    # "Variants Docker Image" section of the top-level CLAUDE.md. Editing the image's Dockerfiles (including the
-    # cloud_sdk_docker_decl-equivalent base image tags above) has no runtime effect until that rebuild happens either.
     String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-02-alpine-fdf40647cbfd"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -149,7 +149,7 @@ task GetToolVersions {
     # This has no effect until the image is rebuilt (build_docker.sh) and this tag is updated to match -- see the
     # "Variants Docker Image" section of the top-level CLAUDE.md. Editing the image's Dockerfiles (including the
     # cloud_sdk_docker_decl-equivalent base image tags above) has no runtime effect until that rebuild happens either.
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-01-alpine-fdf40647cbfd"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-02-alpine-fdf40647cbfd"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"


### PR DESCRIPTION
Green integration run [here](https://app.terra.bio/#workspaces/gvs-dev/GVS%20Integration%20mcovarr/submission_history/17df4447-b638-434d-afd1-6a63b7cadb7e) 🎉 

- Pins to `565.0.0`
- Patches a `tnu` bug while a [PR is pending](https://github.com/DataBiosphere/terra-notebook-utils/pull/426) on that repo
- Stowaway improvements to the Markdown formatting script
