### PR TITLE
Fail fast when the Parquet GCS listing fails [VS-1990]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -340,6 +340,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - ng_vs_1990_gcs_listing_fail_fast
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -349,7 +349,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - ng_vs_1990_gcs_listing_fail_fast
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/scripts/build_docker.sh
+++ b/scripts/variantstore/scripts/build_docker.sh
@@ -54,6 +54,34 @@ docker tag "${IMAGE_ID}" "${REPO_WITH_TAG}"
 # is shared with CI (see run_python_unit_tests.sh); errexit aborts the build here if any test fails.
 ./run_python_unit_tests.sh "${REPO_WITH_TAG}"
 
+# VS-1990: validate that the gcloud pinned in THIS image still classifies an empty vs. a failed GCS
+# listing the way GvsImportGenomes.wdl's DiscoverParquetFiles expects ("One or more URLs matched
+# no objects" == empty directory; anything else fails fast). A cloud-sdk bump is the only thing that
+# can reword that message, and a cloud-sdk bump forces this rebuild and the canary tests for changed
+# messages from gcloud.
+# The canary must run INSIDE the freshly built image to exercise the pinned gcloud (not the host's)
+# and needs GCS credentials.
+GCLOUD_CONFIG_DIR="${CLOUDSDK_CONFIG:-${HOME}/.config/gcloud}"
+CANARY_DIR="$(pwd)/test/gcs_listing_canary"
+set +o errexit
+docker run --platform linux/amd64 --rm \
+    -v "${GCLOUD_CONFIG_DIR}":/gcloud-config-ro:ro \
+    -v "${CANARY_DIR}":/canary:ro \
+    -t "${REPO_WITH_TAG}" \
+    bash -c 'cp -r /gcloud-config-ro /tmp/gcloud-config && export CLOUDSDK_CONFIG=/tmp/gcloud-config && /canary/run_gcs_listing_canary.sh'
+CANARY_RC=$?
+set -o errexit
+case "${CANARY_RC}" in
+    0)  echo "GCS-listing canary passed against the pinned gcloud." ;;
+    77) echo "WARNING: GCS-listing canary SKIPPED -- no gcloud credentials or GCS unreachable in the" >&2
+        echo "build environment. The pinned gcloud's empty-vs-error listing wording was NOT validated" >&2
+        echo "for this image. Re-run build_docker.sh authenticated to validate it." >&2 ;;
+    *)  echo "ERROR: GCS-listing canary FAILED -- the pinned gcloud's listing wording has drifted." >&2
+        echo "Update the grep in GvsImportGenomes.wdl (DiscoverParquetFiles) and the SENTINEL in" >&2
+        echo "test/gcs_listing_canary/run_gcs_listing_canary.sh, then rebuild." >&2
+        exit "${CANARY_RC}" ;;
+esac
+
 GAR_TAG="us-central1-docker.pkg.dev/${REPO_WITH_TAG}"
 docker tag "${REPO_WITH_TAG}" "${GAR_TAG}"
 

--- a/scripts/variantstore/scripts/test/gcs_listing_canary/README.md
+++ b/scripts/variantstore/scripts/test/gcs_listing_canary/README.md
@@ -1,0 +1,71 @@
+# GCS-listing canary (VS-1990)
+
+`DiscoverParquetFiles` in `scripts/variantstore/wdl/GvsImportGenomes.wdl` lists the Parquet output
+directory with `gcloud storage ls` and treats **exactly one** failure mode — stderr containing
+`One or more URLs matched no objects` — as a legitimately empty directory (proceed with an empty
+file list). Every other non-zero exit fails the task. This is what makes re-runs idempotent when a
+sample produced no output, while still failing loudly on a real listing error.
+
+That behavior is coupled to gcloud's error wording. `gcloud` is version-pinned in the Variants
+Docker image, so the wording can only change at a deliberate cloud-sdk bump — a reviewed,
+integration-tested event, not something that drifts under a running pipeline. This canary is the
+automated "watch it": run it against a real `gcloud` and real GCS and it asserts, on live output,
+that the empty-vs-error classification still holds.
+
+## What it checks
+
+A **preflight** runs first: it lists a known non-empty prefix. If that fails we cannot reach GCS
+(no credentials, no network, or no access), so the empty-vs-error contract cannot be evaluated and
+the canary **skips** (exit 77) rather than reporting a false drift. If the preflight succeeds, two
+checks run, each using the same command shape as the WDL task (`gcloud storage ls --recursive
+[--billing-project P] "<url>/"`):
+
+1. **Empty prefix under an existing bucket** → non-zero exit **and** stderr matches the sentinel.
+   This is the drift canary. If a cloud-sdk bump reworded the message, the WDL would stop
+   recognizing the empty case. The WDL failure is fail-safe (a legitimately empty directory would
+   fail the task loudly rather than silently load nothing), but this catches the drift earlier, in
+   a test, and tells you to update both places.
+2. **Nonexistent bucket (a genuine error)** → non-zero exit **and** stderr does **not** match the
+   sentinel. This proves a real listing error stays distinguishable, so the WDL still fails fast on
+   it — the direction that would otherwise be silent data loss.
+
+## When it runs
+
+`build_docker.sh` runs this canary **inside every freshly built Variants image**, after the unit
+tests and before the push, so a cloud-sdk bump that reworded the message is caught at rebuild time
+— which is the only time the pinned `gcloud` can change. It runs against the image's `gcloud` (not
+the host's), using the building developer's mounted credentials; a drift (exit 1) aborts the build,
+while an unreachable/unauthenticated environment (exit 77) only warns so an unrelated rebuild is not
+blocked. You can also run it standalone as below.
+
+## The coupling you must maintain
+
+The `SENTINEL` in `run_gcs_listing_canary.sh` must stay byte-for-byte identical to the `grep`
+pattern in `DiscoverParquetFiles`. If you change one, change the other — and re-run this canary.
+
+## Prerequisites
+
+- A real `gcloud` (the one whose wording you want to validate — normally the version pinned in the
+  Variants image).
+- Credentials that can list a GCS bucket. The defaults list a public Broad bucket
+  (`gs://gcp-public-data--broad-references`), so an authenticated Broad account works out of the box.
+
+## Usage
+
+```shell
+./run_gcs_listing_canary.sh
+```
+
+Optional env vars (defaults shown):
+
+| Var               | Default                                           | Meaning                                                                      |
+|-------------------|---------------------------------------------------|------------------------------------------------------------------------------|
+| `BILLING_PROJECT` | `$(gcloud config get-value project)`              | Passed as `--billing-project`; if empty the flag is omitted (as in the WDL). |
+| `EMPTY_BUCKET`    | `gs://gcp-public-data--broad-references`          | Any bucket you can list; a UUID subpath under it is the empty prefix.        |
+| `NONEMPTY_URL`    | `gs://gcp-public-data--broad-references/hg38/v0/` | A known non-empty prefix for the happy-path check.                           |
+
+Exit status: **0** when all checks pass, **1** when the contract has drifted, **77** when the canary
+skipped because it could not reach GCS (no credentials, no network, or no access).
+`run_gcs_listing_canary.txt` in this directory is a captured passing run for reference.
+
+The canary creates nothing — it lists throwaway UUID paths that are guaranteed empty or nonexistent.

--- a/scripts/variantstore/scripts/test/gcs_listing_canary/run_gcs_listing_canary.sh
+++ b/scripts/variantstore/scripts/test/gcs_listing_canary/run_gcs_listing_canary.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# VS-1990 — canary for the "empty GCS listing is OK, everything else fails fast" logic in
+# GvsImportGenomes.wdl's DiscoverParquetFiles task.
+#
+# That task treats exactly one gcloud failure mode -- stderr containing
+#   "One or more URLs matched no objects"
+# -- as a legitimately empty directory (proceed with an empty file list); every other non-zero
+# exit fails the task. This couples GVS idempotency to gcloud's wording. gcloud is version-pinned
+# in the Variants image, so the wording can only change at a deliberate cloud-sdk bump -- and a
+# cloud-sdk bump forces a Variants image rebuild, so build_docker.sh runs this canary against the
+# freshly built image's gcloud (see build_docker.sh). It also runs standalone. Given a real gcloud
+# + real GCS it asserts, on live output, that
+#
+#   1. an EMPTY prefix under an existing bucket        -> non-zero exit AND stderr matches SENTINEL
+#      (the drift canary: if a cloud-sdk bump reworded this, the WDL would stop recognizing the
+#       empty case -- the failure is fail-safe/loud, but this catches it earlier, in a test)
+#   2. a NONEXISTENT bucket (a genuine listing error)  -> non-zero exit AND stderr does NOT match
+#      SENTINEL (proves a real error stays distinguishable, so the WDL still fails fast on it --
+#      this is the direction that would otherwise be silent data loss)
+#
+# A PREFLIGHT lists a known non-empty prefix first. If that fails we cannot reach GCS (no
+# credentials, no network, no access), so the empty-vs-error contract cannot be evaluated and the
+# canary SKIPS rather than reporting a false drift.
+#
+# SENTINEL below MUST stay identical to the grep pattern in DiscoverParquetFiles
+# (scripts/variantstore/wdl/GvsImportGenomes.wdl). If you change one, change the other.
+#
+# Exit status: 0 = contract holds; 1 = contract drifted; 77 = SKIPPED (GCS unreachable/unauthed).
+#
+# This is a MANUAL / build-time harness, NOT a CI unit test: it needs a real gcloud and credentials
+# that can list a GCS bucket. It creates nothing (it lists throwaway UUID paths that are guaranteed
+# empty / nonexistent) and cleans up nothing.
+#
+# Optional env vars (defaults shown):
+#   BILLING_PROJECT   $(gcloud config get-value project)   # passed as --billing-project; if empty
+#                                                           # the flag is omitted (matches the WDL,
+#                                                           # where billing_project_id is optional)
+#   EMPTY_BUCKET      gs://gcp-public-data--broad-references  # any bucket you can list; a UUID
+#                                                           # subpath under it is the empty prefix
+#   NONEMPTY_URL      gs://gcp-public-data--broad-references/hg38/v0/  # a known non-empty prefix
+#
+# Usage:
+#   ./run_gcs_listing_canary.sh
+#   BILLING_PROJECT=my-proj EMPTY_BUCKET=gs://my-bucket ./run_gcs_listing_canary.sh
+#
+set -o errexit -o nounset -o pipefail
+
+# MUST match GvsImportGenomes.wdl DiscoverParquetFiles.
+SENTINEL='One or more URLs matched no objects'
+
+# Exit code for "environment cannot run the check" (automake's conventional SKIP code).
+readonly SKIP_EXIT=77
+
+BILLING_PROJECT=${BILLING_PROJECT:-$(gcloud config get-value project 2>/dev/null || true)}
+EMPTY_BUCKET=${EMPTY_BUCKET:-gs://gcp-public-data--broad-references}
+NONEMPTY_URL=${NONEMPTY_URL:-gs://gcp-public-data--broad-references/hg38/v0/}
+
+BILLING_FLAG=()
+if [[ -n "${BILLING_PROJECT}" ]]; then
+  BILLING_FLAG=(--billing-project "${BILLING_PROJECT}")
+fi
+
+UUID=$(python3 -c 'import uuid; print(uuid.uuid4())')
+EMPTY_URL="${EMPTY_BUCKET%/}/gvs-1990-canary-empty-${UUID}/"
+MISSING_URL="gs://gvs-1990-canary-missing-${UUID}/some/dir/"
+
+banner() { echo; echo "==================== $* ===================="; }
+
+# Run the exact command shape DiscoverParquetFiles uses. Sets globals RC and STDERR_FILE.
+run_ls() {  # $1 = url
+  local url=$1
+  STDERR_FILE=$(mktemp)
+  set +o errexit
+  gcloud storage ls --recursive "${BILLING_FLAG[@]}" "${url}" >/dev/null 2>"${STDERR_FILE}"
+  RC=$?
+  set -o errexit
+}
+
+FAILURES=0
+pass() { echo "  PASS: $*"; }
+fail() { echo "  FAIL: $*"; FAILURES=$((FAILURES + 1)); }
+
+banner "gcloud version (for the GCS listing canary)"
+gcloud --version | head -1
+echo "billing project: ${BILLING_PROJECT:-<none>}"
+echo "empty bucket:    ${EMPTY_BUCKET}"
+echo "non-empty url:   ${NONEMPTY_URL}"
+
+banner "PREFLIGHT: reach GCS by listing a known non-empty prefix"
+run_ls "${NONEMPTY_URL}"
+echo "  url=${NONEMPTY_URL}  exit=${RC}"
+if [[ ${RC} -ne 0 ]]; then
+  echo "  stderr: $(cat "${STDERR_FILE}")"
+  echo "  SKIP: could not list a known non-empty prefix. This is an environment problem (no gcloud"
+  echo "  credentials, no network, or no access) -- NOT a wording drift. The empty-vs-error contract"
+  echo "  was not evaluated."
+  exit "${SKIP_EXIT}"
+fi
+pass "reached GCS and listed a non-empty prefix"
+
+banner "CASE 1: empty prefix under an existing bucket -> non-zero + SENTINEL"
+run_ls "${EMPTY_URL}"
+echo "  url=${EMPTY_URL}"
+echo "  exit=${RC}  stderr: $(cat "${STDERR_FILE}")"
+[[ ${RC} -ne 0 ]] && pass "non-zero exit as expected" || fail "expected non-zero exit, got 0"
+if grep -qF "${SENTINEL}" "${STDERR_FILE}"; then
+  pass "stderr still matches SENTINEL -- the WDL will treat this as an empty directory"
+else
+  fail "stderr NO LONGER matches SENTINEL ('${SENTINEL}') -- gcloud reworded the empty-listing"
+  fail "message. DiscoverParquetFiles would now FAIL FAST on a legitimately empty directory."
+  fail "Update the grep pattern in GvsImportGenomes.wdl AND the SENTINEL in this script."
+fi
+
+banner "CASE 2: nonexistent bucket (genuine error) -> non-zero + NO SENTINEL"
+run_ls "${MISSING_URL}"
+echo "  url=${MISSING_URL}"
+echo "  exit=${RC}  stderr: $(cat "${STDERR_FILE}")"
+[[ ${RC} -ne 0 ]] && pass "non-zero exit as expected" || fail "expected non-zero exit, got 0"
+if grep -qF "${SENTINEL}" "${STDERR_FILE}"; then
+  fail "a genuine listing error NOW matches SENTINEL -- DiscoverParquetFiles would mis-read this"
+  fail "real failure as 'empty' and silently load nothing. This is the dangerous direction."
+else
+  pass "stderr does not match SENTINEL -- the WDL will fail fast on this real error"
+fi
+
+banner "RESULT"
+if [[ ${FAILURES} -eq 0 ]]; then
+  echo "ALL CHECKS PASSED -- the empty/error classification still holds on this gcloud."
+  exit 0
+else
+  echo "${FAILURES} CHECK(S) FAILED -- see above. The gcloud listing contract has drifted."
+  exit 1
+fi

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -1256,10 +1256,26 @@ task DiscoverParquetFiles {
     # Normalize GCS path to ensure exactly one trailing slash
     OUTPUT_GCS_DIR=$(echo ~{output_gcs_dir} | sed 's/\/$//')
 
-    # List all objects, filter for Parquet files
+    # List all objects, filter for Parquet files.
+    # "One or more URLs matched no objects" is a valid outcome (the directory is legitimately empty),
+    # not a listing failure, so only that specific error is tolerated; anything else fails fast.
     echo "Listing files in ${OUTPUT_GCS_DIR}..."
+    set +o errexit
     gcloud storage ls --recursive ~{"--billing-project " + billing_project_id} \
-      "${OUTPUT_GCS_DIR}/" > all_objects.txt
+      "${OUTPUT_GCS_DIR}/" > all_objects.txt 2> gcloud_ls_stderr.txt
+    GCLOUD_LS_EXIT_CODE=$?
+    set -o errexit
+
+    if [[ ${GCLOUD_LS_EXIT_CODE} -ne 0 ]]; then
+      if grep -q 'One or more URLs matched no objects' gcloud_ls_stderr.txt; then
+        echo "No objects found under ${OUTPUT_GCS_DIR}/, proceeding with an empty file list."
+        : > all_objects.txt
+      else
+        echo "gcloud storage ls failed unexpectedly:" >&2
+        cat gcloud_ls_stderr.txt >&2
+        exit "${GCLOUD_LS_EXIT_CODE}"
+      fi
+    fi
 
     grep '\.parquet$' all_objects.txt > all_files.txt || touch all_files.txt
 

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -1259,7 +1259,7 @@ task DiscoverParquetFiles {
     # List all objects, filter for Parquet files
     echo "Listing files in ${OUTPUT_GCS_DIR}..."
     gcloud storage ls --recursive ~{"--billing-project " + billing_project_id} \
-      "${OUTPUT_GCS_DIR}/" > all_objects.txt || true
+      "${OUTPUT_GCS_DIR}/" > all_objects.txt
 
     grep '\.parquet$' all_objects.txt > all_files.txt || touch all_files.txt
 
@@ -1281,6 +1281,7 @@ task DiscoverParquetFiles {
     memory: "4 GB"
     disks: "local-disk 50 HDD"
     preemptible: 3
+    maxRetries: 3
     cpu: 2
   }
 

--- a/scripts/variantstore/wdl/GvsImportGenomes.wdl
+++ b/scripts/variantstore/wdl/GvsImportGenomes.wdl
@@ -1257,8 +1257,24 @@ task DiscoverParquetFiles {
     OUTPUT_GCS_DIR=$(echo ~{output_gcs_dir} | sed 's/\/$//')
 
     # List all objects, filter for Parquet files.
-    # "One or more URLs matched no objects" is a valid outcome (the directory is legitimately empty),
-    # not a listing failure, so only that specific error is tolerated; anything else fails fast.
+    #
+    # We deliberately tolerate exactly one gcloud failure mode -- stderr containing "One or more
+    # URLs matched no objects" -- and treat it as a legitimately empty directory (proceed with an
+    # empty file list). Every other non-zero exit fails the task. This couples GVS idempotency to
+    # gcloud's error wording; we go into it with open eyes:
+    #   - It is fail-safe. If a future cloud-sdk reworded this message, the empty-directory case
+    #     would stop matching and fall through to the `else`, failing the task loudly (retried, then
+    #     a visible workflow failure) rather than silently loading nothing.
+    #   - gcloud is version-pinned in the Variants image, so the wording can only change at a
+    #     deliberate cloud-sdk bump -- a reviewed, integration-tested event -- not under a running
+    #     pipeline.
+    #   - The match is kept specific (not broadened) so a genuine listing error is never mis-read
+    #     as "empty" -- that would be the one silent, dangerous direction.
+    # A canary asserts this contract against real gcloud + GCS. build_docker.sh runs it inside every
+    # freshly built Variants image (so a cloud-sdk bump that reworded this is caught at rebuild time);
+    # it can also be run standalone:
+    #   scripts/variantstore/scripts/test/gcs_listing_canary/run_gcs_listing_canary.sh
+    # If you change the grep pattern below, change the SENTINEL in that script too.
     echo "Listing files in ${OUTPUT_GCS_DIR}..."
     set +o errexit
     gcloud storage ls --recursive ~{"--billing-project " + billing_project_id} \


### PR DESCRIPTION
[VS-1990](https://broadworkbench.atlassian.net/browse/VS-1990) The **|| t**rue on the gcloud storage ls in `DiscoverParquetFiles` swallowed a `retryable` listing failure and let a short/empty file list proceed to BigQuery load as if it were complete. Drop the **||** true so `errexit` kills the task, and add `maxRetries` so a transient failure is retried automatically instead of requiring a manual workflow restart.

Based on input from @koncheto-broad - a GCS prefix(folder), with no Parquet files is valid output - `gcloud storage ls exits non-zero with "One or more URLs matched no objects`". That specific message is scanned for in stderr and the logic proceeds with an empty list. All other errors get re-raised with the transient errors(e.g. 429)  covered by the task's maxRetries.

[VS-1990]: https://broadworkbench.atlassian.net/browse/VS-1990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ