### PR TITLE
Supersede permanently-failed Parquet load jobs instead of re-fetching [VS-1988]

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -349,6 +349,7 @@ workflows:
          branches:
              - master
              - ah_var_store
+             - ng_vs_1988_failed_load_job
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -349,7 +349,6 @@ workflows:
          branches:
              - master
              - ah_var_store
-             - ng_vs_1988_failed_load_job
          tags:
              - /.*/
    - name: GvsIngestTieout

--- a/scripts/variantstore/scripts/load_parquet_to_bq.py
+++ b/scripts/variantstore/scripts/load_parquet_to_bq.py
@@ -2,6 +2,9 @@
 """
 Load Parquet files from GCS to BigQuery with fault tolerance and idempotency.
 Uses deterministic job IDs to handle preemptions; no local state file is needed.
+A job that fails permanently is superseded by a fresh generation of its job ID so
+that a task retry is not stuck re-fetching the same dead job (see
+_submit_resumable_load_job).
 """
 
 import argparse
@@ -106,14 +109,13 @@ def load_table_from_parquet_files(
 
         job_id = None  # ensure it is always defined for the except handler
         try:
-            job_id = _make_job_id(project_id, dataset_name, table_name, batch)
-            
-            # Submit job (handles already-existing jobs via Conflict exception)
-            print(f"  Submitting job {job_id}")
-            load_job = _submit_load_job_with_retry(
-                client, batch, table_id, job_config, job_id, location
+            # Submit the job, resuming an in-flight or already-succeeded job on a
+            # deterministic job-ID collision and superseding a permanently-failed one.
+            load_job, job_id = _submit_resumable_load_job(
+                client, project_id, dataset_name, table_name, batch,
+                table_id, job_config, location,
             )
-            
+
             # Wait for completion with retry logic
             load_job = _wait_for_job_with_retry(load_job)
             
@@ -163,12 +165,21 @@ def load_table_from_parquet_files(
 
 
 
-def _make_job_id(project_id, dataset_name, table_name, batch):
-    """Create deterministic job ID from project, dataset, table name and batch contents."""
+def _make_job_id(project_id, dataset_name, table_name, batch, generation=0):
+    """Create deterministic job ID from project, dataset, table name and batch contents.
+
+    The optional generation lets a permanently-failed job be superseded by a fresh
+    job ID on a later task attempt (see _submit_resumable_load_job).  Generation 0
+    (the default) is unsuffixed so IDs minted before this parameter existed still
+    resolve identically; generation N>=1 appends an "_rN" suffix.
+    """
     digest = hashlib.sha1(
         "\n".join([project_id, dataset_name] + sorted(batch)).encode("utf-8")
     ).hexdigest()[:16]
-    return f"load_{table_name}_{digest}"
+    job_id = f"load_{table_name}_{digest}"
+    if generation:
+        job_id = f"{job_id}_r{generation}"
+    return job_id
 
 
 
@@ -208,6 +219,64 @@ def _log_batch_result(files, table_name, job_id, error=None):
         sample_id = _extract_sample_id_from_file_path(file_path, table_name)
         sample_id_str = sample_id if sample_id is not None else ""
         print(f"{sample_id_str}\t{file_path}")
+
+
+def _is_permanently_failed_job(load_job):
+    """
+    True if load_job is an existing job that finished in DONE state with an
+    error_result.
+
+    A BigQuery load job is atomic: one that terminates with an error_result loaded
+    zero rows, so it is safe to supersede with a fresh job ID rather than re-fetching
+    it forever.  A freshly submitted job is PENDING/RUNNING with no error_result and
+    is therefore never considered permanently failed here.
+    """
+    return load_job.state == "DONE" and load_job.error_result is not None
+
+
+def _submit_resumable_load_job(
+    client, project_id, dataset_name, table_name, batch,
+    table_id, job_config, location, max_generations=100,
+):
+    """
+    Submit a load job for a batch, resuming on a deterministic job-ID collision and
+    superseding a permanently-failed job with a fresh generation of the ID.
+
+    A BigQuery job ID cannot be reused, so once a job reaches DONE with an
+    error_result (a malformed Parquet file, a schema mismatch) its ID is burned:
+    re-submitting the same ID only re-fetches the dead job, whose result() re-raises
+    the original error.  Because the base ID is a pure function of the batch
+    contents, no task retry could otherwise make the batch succeed.  Walking a
+    generation suffix mints a genuinely new ID on the next attempt while still
+    resuming a job that is merely PENDING/RUNNING or already succeeded -- which must
+    never be duplicated, since the load is WRITE_APPEND.
+
+    Returns:
+        (load_job, job_id) for the generation that is in flight, already succeeded,
+        or freshly submitted.
+
+    Raises:
+        Exception: if the job submission fails for a non-Conflict reason, or if every
+        generation up to max_generations is an existing permanently-failed job.
+    """
+    for generation in range(max_generations):
+        job_id = _make_job_id(project_id, dataset_name, table_name, batch, generation)
+        print(f"  Submitting job {job_id}")
+        load_job = _submit_load_job_with_retry(
+            client, batch, table_id, job_config, job_id, location
+        )
+        if _is_permanently_failed_job(load_job):
+            print(
+                f"  Job {job_id} already exists and failed permanently "
+                f"({load_job.error_result}); superseding it with a fresh job ID"
+            )
+            continue
+        return load_job, job_id
+
+    raise Exception(
+        f"Exhausted {max_generations} job-ID generations for table {table_name}; "
+        f"every generation is an existing permanently-failed job"
+    )
 
 
 def _submit_load_job_with_retry(client, batch, table_id, job_config, job_id, location, max_retries=3):

--- a/scripts/variantstore/scripts/load_parquet_to_bq.py
+++ b/scripts/variantstore/scripts/load_parquet_to_bq.py
@@ -240,7 +240,8 @@ def _submit_resumable_load_job(
 ):
     """
     Submit a load job for a batch, resuming on a deterministic job-ID collision and
-    superseding a permanently-failed job with a fresh generation of the ID.
+    superseding a pre-existing permanently-failed job (one we collide with) with a
+    fresh generation of the ID.
 
     A BigQuery job ID cannot be reused, so once a job reaches DONE with an
     error_result (a malformed Parquet file, a schema mismatch) its ID is burned:
@@ -262,10 +263,17 @@ def _submit_resumable_load_job(
     for generation in range(max_generations):
         job_id = _make_job_id(project_id, dataset_name, table_name, batch, generation)
         print(f"  Submitting job {job_id}")
-        load_job = _submit_load_job_with_retry(
+        load_job, resumed_existing = _submit_load_job_with_retry(
             client, batch, table_id, job_config, job_id, location
         )
-        if _is_permanently_failed_job(load_job):
+        # Only supersede a job we *collided with*: a pre-existing job that reached DONE
+        # with an error_result loaded zero rows and its ID is burned.  A job we just
+        # submitted is returned as-is even if it fast-failed (e.g. a schema rejection
+        # already terminal in the insert response), so the caller records the batch
+        # failure and a later task attempt supersedes it.  Superseding a fresh failure
+        # here would burn every generation in a single attempt, since each new
+        # generation fast-fails identically -- leaving all later retries exhausted.
+        if resumed_existing and _is_permanently_failed_job(load_job):
             print(
                 f"  Job {job_id} already exists and failed permanently "
                 f"({load_job.error_result}); superseding it with a fresh job ID"
@@ -291,17 +299,22 @@ def _submit_load_job_with_retry(client, batch, table_id, job_config, job_id, loc
         job_id: Deterministic job ID
         location: BigQuery location
         max_retries: Maximum number of retry attempts (default: 3)
-    
+
     Returns:
-        LoadJob object
-    
+        (load_job, resumed_existing).  resumed_existing is True only when the job ID
+        already existed and the job was fetched via get_job() (a Conflict); it is
+        False for a job we freshly submitted.  Callers use this to distinguish a
+        pre-existing job -- which may be safely superseded if it failed permanently --
+        from one we just created, which must be returned as-is even if it is already
+        terminal (see _submit_resumable_load_job).
+
     Raises:
         Exception: If all retries are exhausted or a non-retryable error occurs
     """
     from google.api_core import exceptions
 
     retry_delays = [30, 60, 120]  # Exponential backoff: 30s, 60s, 120s
-    
+
     for attempt in range(max_retries + 1):
         try:
             load_job = client.load_table_from_uri(
@@ -311,8 +324,8 @@ def _submit_load_job_with_retry(client, batch, table_id, job_config, job_id, loc
                 job_id=job_id,
                 location=location,
             )
-            return load_job
-            
+            return load_job, False
+
         except (exceptions.TooManyRequests, 
                 exceptions.ServiceUnavailable,
                 exceptions.InternalServerError) as e:
@@ -327,10 +340,11 @@ def _submit_load_job_with_retry(client, batch, table_id, job_config, job_id, loc
                 raise
         
         except exceptions.Conflict as e:
-            # Job ID already exists and is running - this is actually OK
-            # We can fetch it instead of treating it as an error
+            # Job ID already exists - this is actually OK.  Fetch the existing job
+            # rather than treating it as an error, and flag it as pre-existing so the
+            # caller may supersede it if it turns out to have failed permanently.
             print(f"  Job {job_id} already exists, fetching existing job")
-            return client.get_job(job_id=job_id, location=location)
+            return client.get_job(job_id=job_id, location=location), True
         
         except Exception as e:
             # Non-retryable error, fail immediately

--- a/scripts/variantstore/scripts/load_parquet_to_bq.py
+++ b/scripts/variantstore/scripts/load_parquet_to_bq.py
@@ -228,7 +228,7 @@ def _is_permanently_failed_job(load_job):
 
     A BigQuery load job is atomic: one that terminates with an error_result loaded
     zero rows, so it is safe to supersede with a fresh job ID rather than re-fetching
-    This predicate only classifies terminal job state; the caller must separately
+    it. This predicate only classifies terminal job state; the caller must separately
     verify that the job was fetched after a Conflict before superseding it.
     """
     return load_job.state == "DONE" and load_job.error_result is not None

--- a/scripts/variantstore/scripts/load_parquet_to_bq.py
+++ b/scripts/variantstore/scripts/load_parquet_to_bq.py
@@ -228,8 +228,8 @@ def _is_permanently_failed_job(load_job):
 
     A BigQuery load job is atomic: one that terminates with an error_result loaded
     zero rows, so it is safe to supersede with a fresh job ID rather than re-fetching
-    it forever.  A freshly submitted job is PENDING/RUNNING with no error_result and
-    is therefore never considered permanently failed here.
+    This predicate only classifies terminal job state; the caller must separately
+    verify that the job was fetched after a Conflict before superseding it.
     """
     return load_job.state == "DONE" and load_job.error_result is not None
 

--- a/scripts/variantstore/scripts/test/test_parquet_loading.py
+++ b/scripts/variantstore/scripts/test/test_parquet_loading.py
@@ -364,16 +364,17 @@ class TestSubmitLoadJobWithRetry(unittest.TestCase):
         self.location = "us-central1"
 
     def test_first_attempt_succeeds(self):
-        """Normal path: job is submitted and returned immediately."""
+        """Normal path: job is submitted and returned immediately, flagged as fresh."""
         mock_job = MagicMock()
         self.client.load_table_from_uri.return_value = mock_job
 
-        result = _submit_load_job_with_retry(
+        load_job, resumed_existing = _submit_load_job_with_retry(
             self.client, self.batch, self.table_id,
             self.job_config, self.job_id, self.location,
         )
 
-        self.assertIs(result, mock_job)
+        self.assertIs(load_job, mock_job)
+        self.assertFalse(resumed_existing)  # freshly submitted, not fetched via Conflict
         self.client.load_table_from_uri.assert_called_once_with(
             self.batch, self.table_id,
             job_config=self.job_config, job_id=self.job_id, location=self.location,
@@ -391,12 +392,13 @@ class TestSubmitLoadJobWithRetry(unittest.TestCase):
         self.client.load_table_from_uri.side_effect = _bq_exceptions.Conflict("Job already exists")
         self.client.get_job.return_value = existing_job
 
-        result = _submit_load_job_with_retry(
+        load_job, resumed_existing = _submit_load_job_with_retry(
             self.client, self.batch, self.table_id,
             self.job_config, self.job_id, self.location,
         )
 
-        self.assertIs(result, existing_job)
+        self.assertIs(load_job, existing_job)
+        self.assertTrue(resumed_existing)  # fetched via Conflict, so eligible for supersede
         self.client.load_table_from_uri.assert_called_once()
         self.client.get_job.assert_called_once_with(job_id=self.job_id, location=self.location)
 
@@ -409,12 +411,13 @@ class TestSubmitLoadJobWithRetry(unittest.TestCase):
             mock_job,
         ]
 
-        result = _submit_load_job_with_retry(
+        load_job, resumed_existing = _submit_load_job_with_retry(
             self.client, self.batch, self.table_id,
             self.job_config, self.job_id, self.location,
         )
 
-        self.assertIs(result, mock_job)
+        self.assertIs(load_job, mock_job)
+        self.assertFalse(resumed_existing)  # a retried fresh submit is still fresh
         self.assertEqual(self.client.load_table_from_uri.call_count, 2)
         mock_sleep.assert_called_once_with(30)  # first backoff delay
 
@@ -515,6 +518,26 @@ class TestSubmitResumableLoadJob(unittest.TestCase):
 
         self.assertIs(load_job, fresh)
         self.assertEqual(job_id, self._job_id_for(0))
+        self.client.get_job.assert_not_called()
+
+    def test_fresh_submit_that_fast_fails_is_returned_not_superseded(self):
+        """
+        A freshly submitted job can come back already DONE with an error_result -- a
+        fast schema rejection surfaced in the jobs.insert response, with no Conflict
+        raised.  Because it is not an *existing* job we collided with, it must be
+        returned to the caller (which records the batch failure) rather than
+        superseded.  Superseding it here would burn every generation in one task
+        attempt, since each fresh generation fast-fails identically, leaving all later
+        retries permanently exhausted.
+        """
+        fast_failed = self._job(state="DONE", error_result={"reason": "invalid", "message": "bad schema"})
+        self.client.load_table_from_uri.return_value = fast_failed
+
+        load_job, job_id = self._submit()
+
+        self.assertIs(load_job, fast_failed)
+        self.assertEqual(job_id, self._job_id_for(0))          # only generation 0 consumed
+        self.assertEqual(self.client.load_table_from_uri.call_count, 1)
         self.client.get_job.assert_not_called()
 
     def test_conflict_resumes_running_job(self):
@@ -761,6 +784,36 @@ class TestLoadTableFromParquetFiles(unittest.TestCase):
         # Generation 0 was fetched once (the dead job); generation 1 was submitted fresh.
         self.mock_client.get_job.assert_called_once()
         self.assertEqual(self.mock_client.load_table_from_uri.call_count, 2)
+
+    def test_fresh_submit_that_fast_fails_records_single_failed_batch(self):
+        """
+        End-to-end guard for the fresh-failure case: load_table_from_uri returns a job
+        already DONE with an error_result (a fast schema rejection, no Conflict), whose
+        result() raises.  The batch is recorded as one failure and the run moves on --
+        exactly one generation is consumed.  A regression that superseded the fresh
+        failure would instead re-submit under every generation, burning all 100 IDs in
+        this single task attempt and exhausting every later retry.
+        """
+        files = ["gs://bucket/vet/001/vet_001_42_file.parquet"]
+        fofn = self._make_fofn(files)
+
+        fast_failed = MagicMock()
+        fast_failed.state = "DONE"
+        fast_failed.error_result = {"reason": "invalid", "message": "schema mismatch"}
+        fast_failed.result.side_effect = _bq_exceptions.BadRequest("schema mismatch")
+        self.mock_client.load_table_from_uri.return_value = fast_failed
+
+        stats = load_table_from_parquet_files(
+            project_id="proj", dataset_name="ds", table_name="vet_001",
+            files_fofn=fofn, schema_path=None,
+        )
+
+        self.assertEqual(stats["completion_status"], "PARTIAL")
+        self.assertEqual(stats["batches_failed"], 1)
+        self.assertEqual(stats["rows_loaded"], 0)
+        # Exactly one generation consumed -- the fresh failure was not superseded.
+        self.assertEqual(self.mock_client.load_table_from_uri.call_count, 1)
+        self.mock_client.get_job.assert_not_called()
 
     def test_batch_with_job_errors_is_partial_failure(self):
         """A job that completes but carries errors is counted as a failed batch."""

--- a/scripts/variantstore/scripts/test/test_parquet_loading.py
+++ b/scripts/variantstore/scripts/test/test_parquet_loading.py
@@ -30,7 +30,9 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from parse_and_group_files import parse_table_and_sample_id_from_file_path, get_already_loaded_tables_and_sample_ids, _validate_table_prefixes
 from load_parquet_to_bq import (
     _make_job_id,
+    _is_permanently_failed_job,
     _submit_load_job_with_retry,
+    _submit_resumable_load_job,
     _wait_for_job_with_retry,
     load_table_from_parquet_files,
 )
@@ -159,6 +161,38 @@ class TestMakeJobId(unittest.TestCase):
 
         # Job IDs should be the same because files are sorted inside _make_job_id
         self.assertEqual(job_id_1, job_id_2)
+
+    def test_generation_zero_is_unsuffixed(self):
+        """Generation 0 (the default) must equal the historical unsuffixed ID."""
+        batch = ["gs://bucket/file1.parquet"]
+
+        default_id = _make_job_id("my-project", "my_dataset", "vet_042", batch)
+        gen0_id = _make_job_id("my-project", "my_dataset", "vet_042", batch, generation=0)
+
+        self.assertEqual(default_id, gen0_id)
+        # No "_r" generation suffix appended for generation 0.
+        self.assertFalse(default_id.endswith("_r0"))
+
+    def test_generation_suffix_appended_for_nonzero(self):
+        """Generation N>=1 appends an _rN suffix to the base ID."""
+        batch = ["gs://bucket/file1.parquet"]
+
+        base_id = _make_job_id("my-project", "my_dataset", "vet_042", batch)
+        gen1_id = _make_job_id("my-project", "my_dataset", "vet_042", batch, generation=1)
+        gen2_id = _make_job_id("my-project", "my_dataset", "vet_042", batch, generation=2)
+
+        self.assertEqual(gen1_id, f"{base_id}_r1")
+        self.assertEqual(gen2_id, f"{base_id}_r2")
+
+    def test_generations_are_distinct(self):
+        """Different generations of the same batch produce different job IDs."""
+        batch = ["gs://bucket/file1.parquet"]
+
+        ids = {
+            _make_job_id("my-project", "my_dataset", "vet_042", batch, generation=g)
+            for g in range(4)
+        }
+        self.assertEqual(len(ids), 4)
 
 
 class TestPathNormalization(unittest.TestCase):
@@ -413,6 +447,150 @@ class TestSubmitLoadJobWithRetry(unittest.TestCase):
 
 
 @unittest.skipUnless(_GOOGLE_AVAILABLE, "google-cloud-bigquery not installed")
+class TestIsPermanentlyFailedJob(unittest.TestCase):
+    """Tests for the _is_permanently_failed_job predicate."""
+
+    @staticmethod
+    def _job(state, error_result):
+        job = MagicMock()
+        job.state = state
+        job.error_result = error_result
+        return job
+
+    def test_done_with_error_result_is_permanent(self):
+        """A terminal job carrying an error_result loaded nothing and is superseded."""
+        self.assertTrue(
+            _is_permanently_failed_job(self._job("DONE", {"reason": "invalid", "message": "bad parquet"}))
+        )
+
+    def test_done_without_error_result_is_not_permanent(self):
+        """A successfully completed job must be resumed, never superseded."""
+        self.assertFalse(_is_permanently_failed_job(self._job("DONE", None)))
+
+    def test_running_is_not_permanent(self):
+        """An in-flight job must be resumed, never superseded."""
+        self.assertFalse(_is_permanently_failed_job(self._job("RUNNING", None)))
+
+    def test_running_with_error_result_is_not_permanent(self):
+        """Only DONE jobs are superseded; a non-terminal job is always resumed."""
+        self.assertFalse(_is_permanently_failed_job(self._job("RUNNING", {"reason": "backendError"})))
+
+
+@unittest.skipUnless(_GOOGLE_AVAILABLE, "google-cloud-bigquery not installed")
+class TestSubmitResumableLoadJob(unittest.TestCase):
+    """Tests for _submit_resumable_load_job's generation-walk resume/supersede logic."""
+
+    def setUp(self):
+        self.client = MagicMock()
+        self.project_id = "proj"
+        self.dataset_name = "ds"
+        self.table_name = "vet_001"
+        self.batch = ["gs://bucket/vet/001/vet_001_42_file.parquet"]
+        self.table_id = "proj.ds.vet_001"
+        self.job_config = MagicMock()
+        self.location = "us-central1"
+
+    def _job(self, state="RUNNING", error_result=None):
+        job = MagicMock()
+        job.state = state
+        job.error_result = error_result
+        return job
+
+    def _job_id_for(self, generation):
+        return _make_job_id(self.project_id, self.dataset_name, self.table_name, self.batch, generation)
+
+    def _submit(self, max_generations=100):
+        return _submit_resumable_load_job(
+            self.client, self.project_id, self.dataset_name, self.table_name,
+            self.batch, self.table_id, self.job_config, self.location,
+            max_generations=max_generations,
+        )
+
+    def test_fresh_submit_uses_generation_zero(self):
+        """With no collision the batch loads under the unsuffixed generation-0 ID."""
+        fresh = self._job(state="RUNNING")
+        self.client.load_table_from_uri.return_value = fresh
+
+        load_job, job_id = self._submit()
+
+        self.assertIs(load_job, fresh)
+        self.assertEqual(job_id, self._job_id_for(0))
+        self.client.get_job.assert_not_called()
+
+    def test_conflict_resumes_running_job(self):
+        """A collision with a still-running job resumes it rather than superseding."""
+        running = self._job(state="RUNNING")
+        self.client.load_table_from_uri.side_effect = _bq_exceptions.Conflict("exists")
+        self.client.get_job.return_value = running
+
+        load_job, job_id = self._submit()
+
+        self.assertIs(load_job, running)
+        self.assertEqual(job_id, self._job_id_for(0))
+        self.client.get_job.assert_called_once_with(job_id=self._job_id_for(0), location=self.location)
+
+    def test_conflict_resumes_succeeded_job(self):
+        """A collision with a DONE job that has no error_result resumes it."""
+        succeeded = self._job(state="DONE", error_result=None)
+        self.client.load_table_from_uri.side_effect = _bq_exceptions.Conflict("exists")
+        self.client.get_job.return_value = succeeded
+
+        load_job, job_id = self._submit()
+
+        self.assertIs(load_job, succeeded)
+        self.assertEqual(job_id, self._job_id_for(0))
+
+    def test_permanently_failed_job_is_superseded_by_fresh_generation(self):
+        """
+        The core VS-1988 fix: generation 0 already exists as a DONE job with an
+        error_result, so it is superseded by a freshly submitted generation-1 job
+        instead of re-fetching the dead job forever.
+        """
+        failed = self._job(state="DONE", error_result={"reason": "invalid", "message": "bad parquet"})
+        fresh = self._job(state="RUNNING")
+        self.client.load_table_from_uri.side_effect = [_bq_exceptions.Conflict("exists"), fresh]
+        self.client.get_job.return_value = failed
+
+        load_job, job_id = self._submit()
+
+        self.assertIs(load_job, fresh)
+        self.assertEqual(job_id, self._job_id_for(1))
+        self.assertTrue(job_id.endswith("_r1"))
+        # The fresh submit used the generation-1 ID, not the burned generation-0 ID.
+        self.assertEqual(self.client.load_table_from_uri.call_args_list[1][1]["job_id"], self._job_id_for(1))
+        self.client.get_job.assert_called_once()
+
+    def test_two_failed_generations_are_walked(self):
+        """Two consecutive permanently-failed generations are skipped before a fresh one."""
+        failed0 = self._job(state="DONE", error_result={"reason": "invalid"})
+        failed1 = self._job(state="DONE", error_result={"reason": "invalid"})
+        fresh = self._job(state="RUNNING")
+        self.client.load_table_from_uri.side_effect = [
+            _bq_exceptions.Conflict("exists"),
+            _bq_exceptions.Conflict("exists"),
+            fresh,
+        ]
+        self.client.get_job.side_effect = [failed0, failed1]
+
+        load_job, job_id = self._submit()
+
+        self.assertIs(load_job, fresh)
+        self.assertEqual(job_id, self._job_id_for(2))
+        self.assertEqual(self.client.load_table_from_uri.call_count, 3)
+        self.assertEqual(self.client.get_job.call_count, 2)
+
+    def test_all_generations_permanently_failed_raises(self):
+        """If every generation up to the cap is a dead job, the batch cannot proceed."""
+        self.client.load_table_from_uri.side_effect = _bq_exceptions.Conflict("exists")
+        self.client.get_job.return_value = self._job(state="DONE", error_result={"reason": "invalid"})
+
+        with self.assertRaises(Exception):
+            self._submit(max_generations=3)
+
+        self.assertEqual(self.client.load_table_from_uri.call_count, 3)
+
+
+@unittest.skipUnless(_GOOGLE_AVAILABLE, "google-cloud-bigquery not installed")
 class TestWaitForJobWithRetry(unittest.TestCase):
     """Tests for _wait_for_job_with_retry."""
 
@@ -546,6 +724,43 @@ class TestLoadTableFromParquetFiles(unittest.TestCase):
         self.assertEqual(stats["completion_status"], "SUCCESS")
         self.assertEqual(stats["rows_loaded"], 50)
         self.assertEqual(stats["batches_failed"], 0)
+
+    def test_supersedes_permanently_failed_job_on_retry(self):
+        """
+        End-to-end VS-1988 fix: a prior task attempt left a DONE job with an
+        error_result under the deterministic (generation-0) job ID.  This attempt
+        must supersede it with a fresh generation-1 job that succeeds, rather than
+        re-fetching the dead job and failing the batch again.
+        """
+        files = ["gs://bucket/vet/001/vet_001_42_file.parquet"]
+        fofn = self._make_fofn(files)
+
+        failed_job = MagicMock()
+        failed_job.state = "DONE"
+        failed_job.error_result = {"reason": "invalid", "message": "schema mismatch"}
+
+        fresh_job = self._make_mock_job(rows=77, job_id="load_vet_001_gen1")
+        fresh_job.state = "RUNNING"
+        fresh_job.error_result = None
+
+        # Generation 0 collides (Conflict -> fetch the dead job); generation 1 is fresh.
+        self.mock_client.load_table_from_uri.side_effect = [
+            _bq_exceptions.Conflict("already exists"),
+            fresh_job,
+        ]
+        self.mock_client.get_job.return_value = failed_job
+
+        stats = load_table_from_parquet_files(
+            project_id="proj", dataset_name="ds", table_name="vet_001",
+            files_fofn=fofn, schema_path=None,
+        )
+
+        self.assertEqual(stats["completion_status"], "SUCCESS")
+        self.assertEqual(stats["rows_loaded"], 77)
+        self.assertEqual(stats["batches_failed"], 0)
+        # Generation 0 was fetched once (the dead job); generation 1 was submitted fresh.
+        self.mock_client.get_job.assert_called_once()
+        self.assertEqual(self.mock_client.load_table_from_uri.call_count, 2)
 
     def test_batch_with_job_errors_is_partial_failure(self):
         """A job that completes but carries errors is counted as a failed batch."""

--- a/scripts/variantstore/scripts/test/test_parquet_loading.py
+++ b/scripts/variantstore/scripts/test/test_parquet_loading.py
@@ -612,6 +612,23 @@ class TestSubmitResumableLoadJob(unittest.TestCase):
 
         self.assertEqual(self.client.load_table_from_uri.call_count, 3)
 
+    def test_non_conflict_error_propagates_without_advancing_generation(self):
+        """
+        A non-Conflict, non-retryable submit error (bad permissions, a missing table,
+        ...) is a genuine failure, not a burned job ID.  It must propagate straight out
+        of the generation walk -- never be swallowed or retried under a fresh
+        generation -- so the caller records the batch as failed.  Only a *collided*
+        permanently-failed job advances a generation.
+        """
+        self.client.load_table_from_uri.side_effect = ValueError("bad table")
+
+        with self.assertRaises(ValueError):
+            self._submit()
+
+        # Exactly one attempt: the loop did not advance to another generation.
+        self.assertEqual(self.client.load_table_from_uri.call_count, 1)
+        self.client.get_job.assert_not_called()
+
 
 @unittest.skipUnless(_GOOGLE_AVAILABLE, "google-cloud-bigquery not installed")
 class TestWaitForJobWithRetry(unittest.TestCase):

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -146,7 +146,7 @@ task GetToolVersions {
     # Must stay in lockstep with `cloud_sdk_docker_decl` above -- 565.0.0 is the last tag whose `-slim`
     # sibling is Debian 12 / Python 3.11. See the note there before bumping.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-02-alpine-94f330a9eb2e"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-04-alpine-56d98f52a857"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -146,7 +146,7 @@ task GetToolVersions {
     # Must stay in lockstep with `cloud_sdk_docker_decl` above -- 565.0.0 is the last tag whose `-slim`
     # sibling is Debian 12 / Python 3.11. See the note there before bumping.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-02-alpine-fdf40647cbfd"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-02-alpine-94f330a9eb2e"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"

--- a/scripts/variantstore/wdl/GvsUtils.wdl
+++ b/scripts/variantstore/wdl/GvsUtils.wdl
@@ -146,7 +146,7 @@ task GetToolVersions {
     # Must stay in lockstep with `cloud_sdk_docker_decl` above -- 565.0.0 is the last tag whose `-slim`
     # sibling is Debian 12 / Python 3.11. See the note there before bumping.
     String cloud_sdk_slim_docker = "gcr.io/google.com/cloudsdktool/cloud-sdk:565.0.0-slim"
-    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-04-alpine-56d98f52a857"
+    String variants_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/variants:2026-09-09-alpine-56d98f52a857"
     String variants_nirvana_docker = "us.gcr.io/broad-dsde-methods/variantstore:nirvana_2022_10_19"
     String gatk_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-lite-087565f1a432"
     String gatk_heavy_docker = "us-central1-docker.pkg.dev/broad-dsde-methods/gvs/gatk:2026-08-19-gatkbase-32785e9276be"


### PR DESCRIPTION
`load_parquet_to_bq.py` derives a deterministic BigQuery job ID from the batch contents so that a preempted or retried `LoadParquetFilesToBQ` task resumes the in-flight job rather than duplicating a WRITE_APPEND load. But a BigQuery job ID cannot be reused once it reaches DONE, so a job that fails permanently (malformed Parquet, schema mismatch) burns its ID: every subsequent task attempt re-derives the same ID, hits `Conflict`, fetches the same dead job, and `result()` re-raises the original error. Because the ID is a pure function of the batch, no `maxRetries`/`preemptible` retry can ever make that batch succeed — the only escape was changing the batch composition.

This adds a generation suffix to the job ID that advances only when we observe an *existing* job that is DONE with an `error_result`. Since a BigQuery load job is atomic, such a job loaded zero rows and is safe to supersede with a fresh ID. A job that is merely running or already succeeded is still resumed, never duplicated — preserving the idempotency the deterministic ID was built for. Generation 0 stays unsuffixed, so IDs minted before this change resolve identically.

I chose this over salting the ID with an externally-supplied attempt counter: that would also change the ID on a preemption restart, duplicating a still-running job and reintroducing the exact problem deterministic IDs prevent.

## Changes

- `_make_job_id(..., generation=0)` — generation 0 unsuffixed (backward-compatible); generation N≥1 appends `_rN`.
- `_is_permanently_failed_job(load_job)` — `state == "DONE" and error_result is not None`.
- `_submit_resumable_load_job(...)` — walks generations, superseding permanently-failed jobs and resuming everything else, capped at `max_generations=100`.

## Testing

`test_parquet_loading.py` now passes 62 tests (15 new): generation-suffix behavior, the `_is_permanently_failed_job` predicate, the generation-walk (fresh submit, resume running/succeeded, supersede one and two failed generations, exhaustion raises), and an end-to-end supersede-on-retry case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)